### PR TITLE
Fixes bar that could appear at the top of the notes list

### DIFF
--- a/Simplenote/NoteListViewController.m
+++ b/Simplenote/NoteListViewController.m
@@ -85,6 +85,7 @@ NSString * const kPreviewLinesPref = @"kPreviewLinesPref";
     awake = YES;
 
     self.tableView.selectionHighlightStyle = NSTableViewSelectionHighlightStyleRegular;
+    self.tableView.backgroundColor = [NSColor clearColor];
 }
 
 - (void)viewWillAppear
@@ -492,17 +493,6 @@ NSString * const kPreviewLinesPref = @"kPreviewLinesPref";
 #pragma mark - Theme
 
 - (void)applyStyle
-{
-    [self applyStatusStyle];
-    [self applyTableStyle];
-}
-
-- (void)applyTableStyle
-{
-    [self.tableView setBackgroundColor:[NSColor clearColor]];
-}
-
-- (void)applyStatusStyle
 {
     VSTheme *theme = [[VSThemeManager sharedManager] theme];
     statusField.textColor = [theme colorForKey:@"emptyListViewFontColor"];


### PR DESCRIPTION
Fixes the bar that could appear at the top of the notes list view, using dark AppKit magic...

**To Test**
When you launch the app and switch themes, you shouldn't see anything like this:

![pasted_image_at_2017_12_07_12_35_pm_360-1](https://user-images.githubusercontent.com/789137/33740822-dde9a5cc-db56-11e7-858b-d894265ef1b2.png)
