### PR TITLE
Fix tag renaming update in editor

### DIFF
--- a/Simplenote/NoteEditorViewController.m
+++ b/Simplenote/NoteEditorViewController.m
@@ -135,7 +135,7 @@ static NSInteger const SPVersionSliderMaxVersions       = 10;
 	NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
     [nc addObserver:self selector:@selector(trashDidLoad:) name:kDidBeginViewingTrash object:nil];
     [nc addObserver:self selector:@selector(tagsDidLoad:) name:kTagsDidLoad object:nil];
-    [nc addObserver:self selector:@selector(tagDeleted:) name:kTagDeleted object:nil];
+    [nc addObserver:self selector:@selector(tagUpdated:) name:kTagUpdated object:nil];
     [nc addObserver:self selector:@selector(simperiumWillSave:) name:SimperiumWillSaveNotification object:nil];
 }
 
@@ -281,7 +281,7 @@ static NSInteger const SPVersionSliderMaxVersions       = 10;
     [self.bottomBar setEnabled:YES];
 }
 
-- (void)tagDeleted:(NSNotification *)notification
+- (void)tagUpdated:(NSNotification *)notification
 {
     [self updateTagField];
 }

--- a/Simplenote/TagListViewController.h
+++ b/Simplenote/TagListViewController.h
@@ -25,7 +25,7 @@
 @property (strong) NSArray *tagArray;
 
 extern NSString * const kTagsDidLoad;
-extern NSString * const kTagDeleted;
+extern NSString * const kTagUpdated;
 extern NSString * const kDidBeginViewingTrash;
 extern NSString * const kWillFinishViewingTrash;
 extern NSString * const kDidEmptyTrash;

--- a/Simplenote/TagListViewController.m
+++ b/Simplenote/TagListViewController.m
@@ -30,7 +30,7 @@
 
 
 NSString * const kTagsDidLoad = @"SPTagsDidLoad";
-NSString * const kTagDeleted = @"SPTagDeleted";
+NSString * const kTagUpdated = @"SPTagUpdated";
 NSString * const kDidBeginViewingTrash = @"SPDidBeginViewingTrash";
 NSString * const kWillFinishViewingTrash = @"SPWillFinishViewingTrash";
 NSString * const kDidEmptyTrash = @"SPDidEmptyTrash";
@@ -268,6 +268,9 @@ NSString * const kDidEmptyTrash = @"SPDidEmptyTrash";
     
     renamedTag.name = newTagName;
     [self.simperium save];
+    
+    NSDictionary *userInfo = @{@"tagName": newTagName};
+    [[NSNotificationCenter defaultCenter] postNotificationName:kTagUpdated object:self userInfo:userInfo];
 }
 
 - (void)deleteTag:(Tag *)tag
@@ -304,7 +307,7 @@ NSString * const kDidEmptyTrash = @"SPDidEmptyTrash";
 	}
 	
     NSDictionary *userInfo = @{@"tagName": tagName};
-    [[NSNotificationCenter defaultCenter] postNotificationName:kTagDeleted object:self userInfo:userInfo];
+    [[NSNotificationCenter defaultCenter] postNotificationName:kTagUpdated object:self userInfo:userInfo];
 }
 
 


### PR DESCRIPTION
Notify the editor that it should update the tags once a tag rename operation occurs. We already had a tag delete notification that did something similar, so I renamed it to `SPTagUpdated` and fired the notification after a tag is renamed.

**To Test**
* Open up a note that has a tag.
* Rename the tag in the tags list.
* You should see the tag name updated in the note editor.

Fixes #154