### PR TITLE
Add missing delegate connection for search field

### DIFF
--- a/Simplenote/en.lproj/MainMenu.xib
+++ b/Simplenote/en.lproj/MainMenu.xib
@@ -127,7 +127,7 @@
                                 </searchFieldCell>
                                 <connections>
                                     <action selector="filterNotes:" target="874" id="dQa-U1-MUq"/>
-                                    <outlet property="delegate" destination="914" id="c9e-3v-2l6"/>
+                                    <outlet property="delegate" destination="874" id="c6x-8I-Ool"/>
                                 </connections>
                             </searchField>
                         </subviews>


### PR DESCRIPTION
I broke a delegate connection from the toolbar's search field to the note list view controller.

**To Test**
* Search the notes list for content other than what the current note has in it.
* The note editor should update to show the content of the top note.

Fixes #149 