### PR TITLE
Add Focus Ring to Search Field

### DIFF
--- a/Simplenote/en.lproj/MainMenu.xib
+++ b/Simplenote/en.lproj/MainMenu.xib
@@ -117,10 +117,10 @@
                         <rect key="frame" x="0.0" y="0.0" width="190" height="22"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <searchField wantsLayer="YES" focusRingType="none" verticalHuggingPriority="750" tag="1" allowsCharacterPickerTouchBarItem="YES" id="915">
+                            <searchField wantsLayer="YES" verticalHuggingPriority="750" tag="1" allowsCharacterPickerTouchBarItem="YES" id="915">
                                 <rect key="frame" x="0.0" y="0.0" width="190" height="22"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
-                                <searchFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" borderStyle="bezel" focusRingType="none" placeholderString="Search" usesSingleLineMode="YES" bezelStyle="round" id="916">
+                                <searchFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" borderStyle="bezel" placeholderString="Search" usesSingleLineMode="YES" bezelStyle="round" id="916">
                                     <font key="font" metaFont="system"/>
                                     <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>


### PR DESCRIPTION
Per @drw158 request, I'm adding back the focus ring to the search field:

<img width="260" alt="screen shot 2017-12-12 at 8 56 15 am" src="https://user-images.githubusercontent.com/789137/33897952-c0a9f534-df1b-11e7-94be-85d088284090.png">
<img width="258" alt="screen shot 2017-12-12 at 8 56 42 am" src="https://user-images.githubusercontent.com/789137/33897954-c0bcf968-df1b-11e7-8a99-159349454dcf.png">
