### PR TITLE
Preserve tag/list selection when opening the tags list

### DIFF
--- a/Simplenote/SPTagCellView.m
+++ b/Simplenote/SPTagCellView.m
@@ -149,13 +149,8 @@ static CGFloat SPTagCellPopUpButtonAlpha    = 0.5f;
 
 - (void)setSelected:(BOOL)selected
 {
-    BOOL changed = _highlighted != selected;
-
     _highlighted = selected;
-
-    if (changed) {
-        [self updateTextAndImageColors];
-    }    
+    [self updateTextAndImageColors];
 }
 
 - (void)applyStyle

--- a/Simplenote/TagListViewController.m
+++ b/Simplenote/TagListViewController.m
@@ -705,8 +705,7 @@ NSString * const kDidEmptyTrash = @"SPDidEmptyTrash";
 {
     [tableView setBackgroundColor:[[[VSThemeManager sharedManager] theme] colorForKey:@"tableViewBackgroundColor"]];
     [tagBox setFillColor:[[[VSThemeManager sharedManager] theme] colorForKey:@"tableViewBackgroundColor"]];
-    [tableView setNeedsDisplay:YES];
-    [tableView reloadData];
+    [self reloadDataAndPreserveSelection];
 }
 
 @end


### PR DESCRIPTION
There's a bug where the list would reset if you opened the tag drawer:

![screencast-2017-12-11-13-39-10](https://user-images.githubusercontent.com/789137/33964626-e416d8be-e00d-11e7-8cd2-c685026d88a7.gif)

I fixed it by using `reloadDataAndPreserveSelection`. This caused another bug where the tag cell wouldn't remain highlighted... so I removed a check that wouldn't redraw it unless it had changed status. So we lose a bit of efficiency there but retain a working UI :)

**To Test**
* Click on a note down the list a ways, and open and close the tag drawer. The selection should remain the same.
* Now select a tag and close/open the tag drawer. The selection should preserve as well.