### PR TITLE
Restore editor scroll position for notes

### DIFF
--- a/Simplenote/NoteEditorViewController.h
+++ b/Simplenote/NoteEditorViewController.h
@@ -63,6 +63,7 @@ extern NSString * const SPWillAddNewNoteNotificationName;
 }
 
 @property (nonatomic, assign) IBOutlet SPTextView           *noteEditor;
+@property (nonatomic, assign) IBOutlet NSScrollView         *scrollView;
 @property (nonatomic, assign) IBOutlet NoteEditorBottomBar  *bottomBar;
 @property (nonatomic, strong) IBOutlet NSViewController     *shareViewController;
 @property (nonatomic, strong) IBOutlet NSViewController     *publishViewController;

--- a/Simplenote/en.lproj/MainMenu.xib
+++ b/Simplenote/en.lproj/MainMenu.xib
@@ -1060,6 +1060,7 @@
                 <outlet property="publishLabel" destination="1058" id="1322"/>
                 <outlet property="publishViewController" destination="1040" id="5kS-We-Atz"/>
                 <outlet property="restoreVersionButton" destination="1088" id="1312"/>
+                <outlet property="scrollView" destination="933" id="eqf-0S-fBY"/>
                 <outlet property="shareButton" destination="qmA-vO-wPh" id="Q66-fK-ISA"/>
                 <outlet property="shareViewController" destination="1643" id="Ahf-1p-0Qr"/>
                 <outlet property="statusView" destination="1440" id="1769"/>


### PR DESCRIPTION
@m noticed that whenever you had a long note in the editor, then switched to another note, the editor would keep the same scroll position as the previous note.

I'm attempting here to store the scroll position for a note when a new one is loaded. If we don't have a scroll position stored, it will default to scroll to the top. I'm storing the positions in a small `NSMutableDictionary` that is stored in memory, so it won't persist if you quit the app.

**To Test**
* Browse your notes, and scroll down in longer notes.
* When you return to a note you scrolled previously, it should restore the last scrolled position.
* Selecting a note that you haven't loaded before should go to the top of the editor, even if the note is long.

