### PR TITLE
Fix tag list restoration

### DIFF
--- a/Simplenote/SPSplitView.m
+++ b/Simplenote/SPSplitView.m
@@ -68,13 +68,13 @@ const CGFloat SPSplitViewDefaultWidth = 135.0;
 - (void)startListeningToNotifications
 {
     [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(handleAppWillTerminateNote:)
-                                                 name:NSApplicationWillTerminateNotification
+                                             selector:@selector(handleWindowWillClose:)
+                                                 name:NSWindowWillCloseNotification
                                                object:nil];
 }
 
 
-- (void)handleAppWillTerminateNote:(NSNotification *)note
+- (void)handleWindowWillClose:(NSNotification *)note
 {
     [self saveStateWithName:self.simplenoteAutosaveName];
 }
@@ -131,9 +131,12 @@ const CGFloat SPSplitViewDefaultWidth = 135.0;
         }
 
         /// NOTE:
-        /// The TagList's width is fixed, and should not be restored!
+        /// The TagList's width is fixed, and should not be restored! (Unless it is zero)
         ///
-        CGFloat targetWidth = (i == SPSplitViewSectionTags) ? SPSplitViewDefaultWidth : [params[SPSplitViewWidthKey] floatValue];
+        CGFloat targetWidth = [params[SPSplitViewWidthKey] floatValue];
+        if (i == SPSplitViewSectionTags && targetWidth > 0) {
+            targetWidth = SPSplitViewDefaultWidth;
+        }
         NSRect frame        = subview.frame;
         frame.size.width    = targetWidth;
         subview.frame       = frame;


### PR DESCRIPTION
We recently changed the app to use a fixed width when restoring the tags list, but it caused #163 to happen because it always shows the tags list no matter what. 

I've changed it so that it will restore the saved width, but only if it is `0`.

I also noticed that the state was only being saved using `NSApplicationWillTerminateNotification`, but we should be using `NSWindowWillCloseNotification` now that we allow the app to remain open even after closing the app window.

**To Test**
* Launch the app, toggle tag list state. Close or quit the app.
* Open the app again, the tag list state should be in the same state as you left it.

Fixes #163