### PR TITLE
Adding alert when signing out of the app with unsynced notes.

### DIFF
--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -167,6 +167,8 @@
 		B5C92ECA1B03D7DB00A4FFD0 /* NSString+Simplenote.m in Sources */ = {isa = PBXBuildFile; fileRef = B5C92EC81B03D7DB00A4FFD0 /* NSString+Simplenote.m */; };
 		B5CC81671AF2DAE1001D2A69 /* VSThemeManager.m in Sources */ = {isa = PBXBuildFile; fileRef = B5CC81661AF2DAE1001D2A69 /* VSThemeManager.m */; };
 		B5CC81681AF2DAE1001D2A69 /* VSThemeManager.m in Sources */ = {isa = PBXBuildFile; fileRef = B5CC81661AF2DAE1001D2A69 /* VSThemeManager.m */; };
+		B5D3FCCC201F906E00A813B7 /* StatusChecker.m in Sources */ = {isa = PBXBuildFile; fileRef = B5D3FCCA201F906E00A813B7 /* StatusChecker.m */; };
+		B5D3FCCD201F906E00A813B7 /* StatusChecker.m in Sources */ = {isa = PBXBuildFile; fileRef = B5D3FCCA201F906E00A813B7 /* StatusChecker.m */; };
 		B5E96B661BDE732500D707F5 /* LoginWindowController.m in Sources */ = {isa = PBXBuildFile; fileRef = B5E96B651BDE732500D707F5 /* LoginWindowController.m */; };
 		B5E96B671BDE732500D707F5 /* LoginWindowController.m in Sources */ = {isa = PBXBuildFile; fileRef = B5E96B651BDE732500D707F5 /* LoginWindowController.m */; };
 		B5EC0C241D0EEF5700818458 /* NSString+Escaping.m in Sources */ = {isa = PBXBuildFile; fileRef = 378E1F741CFCB5A7007486B5 /* NSString+Escaping.m */; };
@@ -383,6 +385,8 @@
 		B5C92EC81B03D7DB00A4FFD0 /* NSString+Simplenote.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSString+Simplenote.m"; sourceTree = "<group>"; };
 		B5CC81651AF2DAE1001D2A69 /* VSThemeManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = VSThemeManager.h; path = DB5/VSThemeManager.h; sourceTree = "<group>"; };
 		B5CC81661AF2DAE1001D2A69 /* VSThemeManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = VSThemeManager.m; path = DB5/VSThemeManager.m; sourceTree = "<group>"; };
+		B5D3FCCA201F906E00A813B7 /* StatusChecker.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = StatusChecker.m; sourceTree = "<group>"; };
+		B5D3FCCB201F906E00A813B7 /* StatusChecker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StatusChecker.h; sourceTree = "<group>"; };
 		B5E96B641BDE732500D707F5 /* LoginWindowController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LoginWindowController.h; sourceTree = "<group>"; };
 		B5E96B651BDE732500D707F5 /* LoginWindowController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LoginWindowController.m; sourceTree = "<group>"; };
 		B5FA82991B977A1F00082296 /* SPTextLinkifier.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPTextLinkifier.h; sourceTree = "<group>"; };
@@ -497,6 +501,8 @@
 				26F72A9F14032D2A00A7935E /* SimplenoteAppDelegate.m */,
 				B543BEA319DDEC1D0051D30C /* SPIntegrityHelper.h */,
 				B543BEA219DDEC1D0051D30C /* SPIntegrityHelper.m */,
+				B5D3FCCB201F906E00A813B7 /* StatusChecker.h */,
+				B5D3FCCA201F906E00A813B7 /* StatusChecker.m */,
 				B5FA82991B977A1F00082296 /* SPTextLinkifier.h */,
 				B5FA829A1B977A1F00082296 /* SPTextLinkifier.m */,
 				46CF73051782C6B200FC2B5C /* TagListViewController.h */,
@@ -1038,6 +1044,7 @@
 			files = (
 				378AA7051ACB05B100CA87DC /* VSTheme.m in Sources */,
 				378AA7071ACB05B100CA87DC /* VSThemeLoader.m in Sources */,
+				B5D3FCCC201F906E00A813B7 /* StatusChecker.m in Sources */,
 				26F72A9914032D2A00A7935E /* main.m in Sources */,
 				B5FA82A41B977E8300082296 /* NSView+Simplenote.m in Sources */,
 				26F72AA014032D2A00A7935E /* SimplenoteAppDelegate.m in Sources */,
@@ -1111,6 +1118,7 @@
 			files = (
 				466FFEA817CC10A800399652 /* main.m in Sources */,
 				466FFEA917CC10A800399652 /* SimplenoteAppDelegate.m in Sources */,
+				B5D3FCCD201F906E00A813B7 /* StatusChecker.m in Sources */,
 				466FFEAA17CC10A800399652 /* Note.m in Sources */,
 				B5FA82A51B977E8300082296 /* NSView+Simplenote.m in Sources */,
 				466FFEAB17CC10A800399652 /* Tag.m in Sources */,

--- a/Simplenote/SimplenoteAppDelegate.m
+++ b/Simplenote/SimplenoteAppDelegate.m
@@ -579,14 +579,14 @@
 
     NSAlert *alert = [[NSAlert alloc] init];
     [alert addButtonWithTitle:NSLocalizedString(@"Delete Notes", @"Delete notes and sign out of the app")];
-    [alert addButtonWithTitle:NSLocalizedString(@"Visit Web App", @"Visit app.simplenote.com in the browser")];
     [alert addButtonWithTitle:NSLocalizedString(@"Cancel", @"Cancel the action")];
+    [alert addButtonWithTitle:NSLocalizedString(@"Visit Web App", @"Visit app.simplenote.com in the browser")];
     [alert setMessageText:NSLocalizedString(@"Unsynced Notes Detected", @"Alert title displayed in when an account has unsynced notes")];
-    [alert setInformativeText:NSLocalizedString(@"Signing out will delete any unsynced notes. You can verify your synced notes by signing in to the Web App.", @"Alert message displayed when an account has unsynced notes")];
+    [alert setInformativeText:NSLocalizedString(@"Signing out will delete any unsynced notes. Check your connection and verify your synced notes by signing in to the Web App.", @"Alert message displayed when an account has unsynced notes")];
     [alert setAlertStyle:NSAlertStyleCritical];
 
     [alert beginSheetModalForWindow:[self window] completionHandler:^(NSInteger result) {
-        if (result == NSAlertSecondButtonReturn) {
+        if (result == NSAlertThirdButtonReturn) {
             NSURL *linkUrl = [NSURL URLWithString:@"https://app.simplenote.com"];
             [[NSWorkspace sharedWorkspace] openURL:linkUrl];
         } else if (result == NSAlertFirstButtonReturn) {

--- a/Simplenote/SimplenoteAppDelegate.m
+++ b/Simplenote/SimplenoteAppDelegate.m
@@ -578,7 +578,7 @@
     }
 
     NSAlert *alert = [[NSAlert alloc] init];
-    [alert addButtonWithTitle:NSLocalizedString(@"Sign Out", @"Sign out of the app")];
+    [alert addButtonWithTitle:NSLocalizedString(@"Delete Notes", @"Delete notes and sign out of the app")];
     [alert addButtonWithTitle:NSLocalizedString(@"Visit Web App", @"Visit app.simplenote.com in the browser")];
     [alert addButtonWithTitle:NSLocalizedString(@"Cancel", @"Cancel the action")];
     [alert setMessageText:NSLocalizedString(@"Unsynced Notes Detected", @"Alert title displayed in when an account has unsynced notes")];

--- a/Simplenote/StatusChecker.h
+++ b/Simplenote/StatusChecker.h
@@ -1,0 +1,15 @@
+#import <Cocoa/Cocoa.h>
+
+
+
+@class Simperium;
+
+#pragma mark ================================================================================
+#pragma mark StatusChecker
+#pragma mark ================================================================================
+
+@interface StatusChecker : NSObject
+
++ (BOOL)hasUnsentChanges:(Simperium *)simperium;
+
+@end

--- a/Simplenote/StatusChecker.m
+++ b/Simplenote/StatusChecker.m
@@ -1,0 +1,53 @@
+#import "StatusChecker.h"
+#import "Note.h"
+@import Simperium_OSX;
+
+
+
+#pragma mark ================================================================================
+#pragma mark Workaround: Exposing Private SPBucket methods
+#pragma mark ================================================================================
+
+@interface SPBucket ()
+- (BOOL)hasLocalChangesForKey:(NSString *)key;
+@end
+
+
+#pragma mark ================================================================================
+#pragma mark Constants
+#pragma mark ================================================================================
+
+static NSString *kEntityName = @"Note";
+
+
+#pragma mark ================================================================================
+#pragma mark StatusChecker
+#pragma mark ================================================================================
+
+@implementation StatusChecker
+
++ (BOOL)hasUnsentChanges:(Simperium *)simperium
+{    
+    if (simperium.user.authenticated == false) {
+        return false;
+    }
+
+    SPBucket *bucket = [simperium bucketForName:kEntityName];
+    NSArray *allNotes = [bucket allObjects];
+    NSDate *startDate = [NSDate date];
+
+    NSLog(@"<> Status Checker: Found %ld Entities [%f seconds elapsed]", (unsigned long)allNotes.count, startDate.timeIntervalSinceNow);
+    
+    // Compare the Ghost Content string, against the Entity Content
+    for (Note *note in allNotes) {
+        if ([bucket hasLocalChangesForKey:note.simperiumKey]) {
+            NSLog(@"<> Status Checker: FOUND entities with local changes [%f seconds elapsed]", startDate.timeIntervalSinceNow);
+            return true;
+        }
+    }
+
+    NSLog(@"<> Status Checker: No entities with local changes [%f seconds elapsed]", startDate.timeIntervalSinceNow);
+    return false;
+}
+
+@end


### PR DESCRIPTION
Some users are losing notes when they sign out because for one reason or another they have unsynced notes. This is a quick solution to that which searches for unsynced notes upon signout and warns the user if so. An option is presented to view the web app to reconcile their unsynced notes:

<img width="483" alt="screen shot 2018-01-25 at 11 59 52 am" src="https://user-images.githubusercontent.com/789137/35409537-5c584fd0-01c7-11e8-8a0b-99589ccd0f6f.png">

**To Test**
* Take the app offline, and create a note.
* Click Simplenote menu and then `Sign Out`. You should see the alert dialog.
* Verify all of the buttons work as expected.
* Also verify that you don't see the prompt if all of your notes have synced.

Refs: https://github.com/Automattic/Simplenote-United/issues/7