### PR TITLE
Fix a few markdown bugs

### DIFF
--- a/Simplenote/NoteEditorViewController.m
+++ b/Simplenote/NoteEditorViewController.m
@@ -244,7 +244,7 @@ static NSInteger const SPVersionSliderMaxVersions       = 10;
         self.noteEditor.string = @"";
     }
     
-    [previewButton setHidden:!self.note.markdown];
+    [previewButton setHidden:!self.note.markdown || self.viewingTrash];
     [self.storage applyStyleWithMarkdownEnabled:self.note.markdown];
     
     if ([self.noteScrollPositions objectForKey:selectedNote.simperiumKey] != nil) {
@@ -316,6 +316,7 @@ static NSInteger const SPVersionSliderMaxVersions       = 10;
 - (void)trashDidLoad:(NSNotification *)notification
 {
     self.viewingTrash = YES;
+    [previewButton setHidden:YES];
     [self.bottomBar setEnabled:NO];
 }
 
@@ -706,6 +707,11 @@ static NSInteger const SPVersionSliderMaxVersions       = 10;
         selectedNote.markdown = isEnabled;
     }
     
+    // Switch back to the editor if markdown is disabled
+    if (!isEnabled && ![self.markdownView isHidden]) {
+        [self toggleMarkdownView:nil];
+    }
+    
     [self save];
     
     // Update editor to apply markdown styles
@@ -1030,6 +1036,9 @@ static NSInteger const SPVersionSliderMaxVersions       = 10;
 {
     if (self.note != nil) {
         [self.storage applyStyleWithMarkdownEnabled:self.note.markdown];
+        if (!self.markdownView.hidden) {
+            [self loadMarkdownContent];
+        }
     }
     [self.noteEditor setInsertionPointColor:[self.theme colorForKey:@"textColor"]];
     [self.noteEditor setTextColor:[self.theme colorForKey:@"textColor"]];

--- a/Simplenote/SPMarkdownParser.m
+++ b/Simplenote/SPMarkdownParser.m
@@ -16,7 +16,7 @@
 + (NSString *)renderHTMLFromMarkdownString:(NSString *)markdown
 {
     hoedown_renderer *renderer = hoedown_html_renderer_new(HOEDOWN_HTML_SKIP_HTML, 0);
-    hoedown_document *document = hoedown_document_new(renderer, HOEDOWN_EXT_AUTOLINK | HOEDOWN_EXT_FENCED_CODE | HOEDOWN_EXT_FOOTNOTES, 16);
+    hoedown_document *document = hoedown_document_new(renderer, HOEDOWN_EXT_AUTOLINK | HOEDOWN_EXT_FENCED_CODE | HOEDOWN_EXT_FOOTNOTES | HOEDOWN_EXT_TABLES, 16);
     hoedown_buffer *html = hoedown_buffer_new(16);
     
     NSData *markdownData = [markdown dataUsingEncoding:NSUTF8StringEncoding];

--- a/Simplenote/SPToolbarView.h
+++ b/Simplenote/SPToolbarView.h
@@ -18,7 +18,6 @@
     IBOutlet NSButton *trashButton;
     IBOutlet NSButton *restoreButton;
     IBOutlet NSButton *shareButton;
-    IBOutlet NSButton *previewButton;
     IBOutlet NSTableView *tableView;
     IBOutlet NSArrayController *arrayController;
     IBOutlet NSTextView *noteEditor;

--- a/Simplenote/SPToolbarView.h
+++ b/Simplenote/SPToolbarView.h
@@ -18,6 +18,7 @@
     IBOutlet NSButton *trashButton;
     IBOutlet NSButton *restoreButton;
     IBOutlet NSButton *shareButton;
+    IBOutlet NSButton *previewButton;
     IBOutlet NSTableView *tableView;
     IBOutlet NSArrayController *arrayController;
     IBOutlet NSTextView *noteEditor;

--- a/Simplenote/SPToolbarView.m
+++ b/Simplenote/SPToolbarView.m
@@ -81,6 +81,7 @@
     [self.actionButton setEnabled:enabled];
     [shareButton setEnabled:enabled];
     [trashButton setEnabled:enabled];
+    [restoreButton setEnabled:enabled];
     [historyButton setEnabled:enabled];
     [previewButton setEnabled:enabled];
 }

--- a/Simplenote/SPToolbarView.m
+++ b/Simplenote/SPToolbarView.m
@@ -82,6 +82,7 @@
     [shareButton setEnabled:enabled];
     [trashButton setEnabled:enabled];
     [historyButton setEnabled:enabled];
+    [previewButton setEnabled:enabled];
 }
 
 - (void)noNoteLoaded:(id)sender {

--- a/Simplenote/SPToolbarView.m
+++ b/Simplenote/SPToolbarView.m
@@ -97,7 +97,6 @@
     [shareButton setHidden:trash];
     [addButton setEnabled:!trash];
     [historyButton setHidden:trash];
-    [previewButton setHidden:trash];
     [trashButton setHidden:trash];
     [restoreButton setHidden:!trash];
     [noteEditor setEditable:!trash];

--- a/Simplenote/en.lproj/MainMenu.xib
+++ b/Simplenote/en.lproj/MainMenu.xib
@@ -215,7 +215,6 @@
                 <outlet property="arrayController" destination="573" id="1148"/>
                 <outlet property="historyButton" destination="7hm-UJ-0zw" id="1wy-uD-TOl"/>
                 <outlet property="noteEditor" destination="934" id="1154"/>
-                <outlet property="previewButton" destination="OMI-hx-wfj" id="XYV-Pc-8mE"/>
                 <outlet property="restoreButton" destination="fA9-bG-luR" id="WSi-qs-xAS"/>
                 <outlet property="searchBox" destination="1698" id="wme-tN-dmD"/>
                 <outlet property="searchField" destination="915" id="L6k-Ak-N34"/>
@@ -855,17 +854,17 @@
                                         <rect key="frame" x="0.0" y="0.0" width="270" height="618"/>
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                         <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="AdS-Q8-czF">
-                                            <rect key="frame" x="0.0" y="0.0" width="270" height="618"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="255" height="618"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
                                                 <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="firstColumnOnly" selectionHighlightStyle="sourceList" emptySelection="NO" autosaveColumns="NO" typeSelect="NO" rowHeight="64" rowSizeStyle="automatic" viewBased="YES" floatsGroupRows="NO" id="561" customClass="SPTableView">
-                                                    <rect key="frame" x="0.0" y="0.0" width="270" height="606"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="255" height="606"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <size key="intercellSpacing" width="0.0" height="8"/>
                                                     <color key="backgroundColor" red="1" green="0.0" blue="0.0" alpha="0.0" colorSpace="calibratedRGB"/>
                                                     <color key="gridColor" white="0.94999999999999996" alpha="1" colorSpace="deviceWhite"/>
                                                     <tableColumns>
-                                                        <tableColumn identifier="" width="270" maxWidth="10000000" id="565">
+                                                        <tableColumn identifier="" width="255" maxWidth="10000000" id="565">
                                                             <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left">
                                                                 <font key="font" metaFont="smallSystem"/>
                                                                 <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
@@ -880,11 +879,11 @@
                                                             <tableColumnResizingMask key="resizingMask" resizeWithTable="YES"/>
                                                             <prototypeCellViews>
                                                                 <tableCellView identifier="CustomCell" id="607" customClass="SPNoteCellView">
-                                                                    <rect key="frame" x="0.0" y="4" width="270" height="64"/>
+                                                                    <rect key="frame" x="0.0" y="4" width="255" height="64"/>
                                                                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMaxX="YES" flexibleMinY="YES" heightSizable="YES" flexibleMaxY="YES"/>
                                                                     <subviews>
                                                                         <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" allowsCharacterPickerTouchBarItem="YES" id="1103">
-                                                                            <rect key="frame" x="18" y="0.0" width="244" height="59"/>
+                                                                            <rect key="frame" x="18" y="0.0" width="229" height="59"/>
                                                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES" heightSizable="YES"/>
                                                                             <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="This is some text in a note that is long enough to allow us to preview what it will look like inside the app." placeholderString="" allowsEditingTextAttributes="YES" id="1104">
                                                                                 <font key="font" size="12" name="Helvetica"/>
@@ -920,7 +919,7 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                         </scroller>
                                         <scroller key="verticalScroller" verticalHuggingPriority="750" horizontal="NO" id="564" customClass="MMScroller">
-                                            <rect key="frame" x="254" y="0.0" width="16" height="618"/>
+                                            <rect key="frame" x="255" y="0.0" width="15" height="618"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                         </scroller>
                                         <connections>
@@ -950,14 +949,14 @@
                                         <rect key="frame" x="0.0" y="43" width="493" height="575"/>
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                         <clipView key="contentView" copiesOnScroll="NO" id="LKV-y0-209">
-                                            <rect key="frame" x="0.0" y="0.0" width="493" height="575"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="478" height="575"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
                                                 <textView drawsBackground="NO" importsGraphics="NO" richText="NO" horizontallyResizable="YES" verticallyResizable="YES" findStyle="panel" incrementalSearchingEnabled="YES" continuousSpellChecking="YES" allowsUndo="YES" allowsNonContiguousLayout="YES" linkDetection="YES" dataDetection="YES" spellingCorrection="YES" smartInsertDelete="YES" id="934" customClass="SPTextView">
-                                                    <rect key="frame" x="0.0" y="0.0" width="493" height="575"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="478" height="575"/>
                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                     <color key="backgroundColor" red="1" green="0.0" blue="0.0" alpha="0.0" colorSpace="calibratedRGB"/>
-                                                    <size key="minSize" width="493" height="575"/>
+                                                    <size key="minSize" width="478" height="575"/>
                                                     <size key="maxSize" width="10000000" height="10000000"/>
                                                     <color key="insertionPointColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
                                                     <connections>
@@ -972,7 +971,7 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                         </scroller>
                                         <scroller key="verticalScroller" verticalHuggingPriority="750" horizontal="NO" id="936" customClass="MMScroller">
-                                            <rect key="frame" x="477" y="0.0" width="16" height="575"/>
+                                            <rect key="frame" x="478" y="0.0" width="15" height="575"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                         </scroller>
                                     </scrollView>

--- a/Simplenote/en.lproj/MainMenu.xib
+++ b/Simplenote/en.lproj/MainMenu.xib
@@ -215,6 +215,7 @@
                 <outlet property="arrayController" destination="573" id="1148"/>
                 <outlet property="historyButton" destination="7hm-UJ-0zw" id="1wy-uD-TOl"/>
                 <outlet property="noteEditor" destination="934" id="1154"/>
+                <outlet property="previewButton" destination="OMI-hx-wfj" id="XYV-Pc-8mE"/>
                 <outlet property="restoreButton" destination="fA9-bG-luR" id="WSi-qs-xAS"/>
                 <outlet property="searchBox" destination="1698" id="wme-tN-dmD"/>
                 <outlet property="searchField" destination="915" id="L6k-Ak-N34"/>

--- a/Simplenote/en.lproj/MainMenu.xib
+++ b/Simplenote/en.lproj/MainMenu.xib
@@ -211,6 +211,7 @@
                 </button>
             </subviews>
             <connections>
+                <outlet property="actionButton" destination="1601" id="gdu-Es-X6I"/>
                 <outlet property="addButton" destination="987" id="1424"/>
                 <outlet property="arrayController" destination="573" id="1148"/>
                 <outlet property="historyButton" destination="7hm-UJ-0zw" id="1wy-uD-TOl"/>


### PR DESCRIPTION
I noticed a few markdown bugs 😄 

This PR should fix the following scenarios:

* If you switch themes while viewing a markdown preview, the preview should reload with the new stylesheet
* If you add a new tag to a note that doesn't have markdown enabled, the preview icon _should not_ appear.
* Viewing the trash should hide the markdown preview, and leaving the trash should show it again as long as the first selected note has markdown enabled.
* If you disable markdown for a note while viewing the preview, it should switch back to the editor.