### PR TITLE
Disable the history button while viewing the markdown preview.

### DIFF
--- a/Simplenote/NoteEditorViewController.m
+++ b/Simplenote/NoteEditorViewController.m
@@ -1103,6 +1103,7 @@ static NSInteger const SPVersionSliderMaxVersions       = 10;
     [self.markdownView setHidden:!markdownVisible];
     
     [previewButton setImage:[NSImage imageNamed:markdownVisible ? @"icon_preview_stop" : @"icon_preview"]];
+    [historyButton setEnabled:!markdownVisible];
     
     if (markdownVisible) {
         [self loadMarkdownContent];


### PR DESCRIPTION
When you're viewing the markdown preview, clicking on the history button does nothing. So I figured it'd be good to disable it visually while viewing the preview:

![disable-history](https://user-images.githubusercontent.com/789137/36223261-b1542c96-1178-11e8-81f4-e3cf8a0e6bf1.gif)
