### PR TITLE
Fix for Printing Crash

### DIFF
--- a/External/Notepad/Storage.swift
+++ b/External/Notepad/Storage.swift
@@ -52,19 +52,13 @@
     }
 
     required public init?(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+        super.init(coder: aDecoder)
     }
     
-    required public init(itemProviderData data: Data, typeIdentifier: String) throws {
-        fatalError("init(itemProviderData:typeIdentifier:) has not been implemented")
-    }
-    
-    #if os(macOS)
     required public init?(pasteboardPropertyList propertyList: Any, ofType type: NSPasteboard.PasteboardType) {
-        fatalError("init(pasteboardPropertyList:ofType:) has not been implemented")
+        super.init(pasteboardPropertyList: propertyList, ofType: type)
     }
-    #endif
-
+    
     /// Finds attributes within a given range on a String.
     ///
     /// - parameter location: How far into the String to look.

--- a/Simplenote/NoteEditorViewController.m
+++ b/Simplenote/NoteEditorViewController.m
@@ -799,8 +799,8 @@ static NSInteger const SPVersionSliderMaxVersions       = 10;
 - (IBAction)printAction:(id)sender
 {
     // Create a copy of the editor view to be used as the print source
-    NSData *archivedView = [NSKeyedArchiver archivedDataWithRootObject:self.noteEditor];
-    NSTextView *printView = [NSKeyedUnarchiver unarchiveObjectWithData:archivedView];
+    NSTextView *printView = [[NSTextView alloc] init];
+    [printView.textStorage appendAttributedString:self.noteEditor.attributedString];
     [printView setTextColor:[NSColor blackColor]];
 
     // Configure wrapping and alignment

--- a/Simplenote/Simplenote-Info-Hockey.plist
+++ b/Simplenote/Simplenote-Info-Hockey.plist
@@ -21,11 +21,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.3</string>
+	<string>1.3.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1300</string>
+	<string>1310</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.productivity</string>
 	<key>LSMinimumSystemVersion</key>

--- a/Simplenote/Simplenote-Info.plist
+++ b/Simplenote/Simplenote-Info.plist
@@ -21,11 +21,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.3</string>
+	<string>1.3.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1300</string>
+	<string>1310</string>
 	<key>Fabric</key>
 	<dict>
 		<key>APIKey</key>


### PR DESCRIPTION
Printing broke in 1.3 because of a fatal being thrown in the new text storage mechanism used for the live markdown editor.

I've added some default `super` calls in the storage class, as well as updated the print operation to create a new `NSTextView` to be used for printing instead of copying the old one.

**To Test**
Open a note, press command+P or Note->Print.
The print dialog should open with the note content displayed properly.