### PR TITLE
Disable the editor delegate while processing links.

### DIFF
--- a/Simplenote/NoteEditorViewController.m
+++ b/Simplenote/NoteEditorViewController.m
@@ -293,8 +293,11 @@ static NSInteger const SPVersionSliderMaxVersions       = 10;
 - (void)checkTextInDocument
 {
     dispatch_async(dispatch_get_main_queue(), ^() {
+        // Disable editor delegate while processing links to prevent the editor from modifying the note
+        [self.noteEditor setDelegate:nil];
         [self.noteEditor checkTextInDocument:nil];
         [self.noteEditor setNeedsDisplay:YES];
+        [self.noteEditor setDelegate:self];
     });
 }
 

--- a/Simplenote/NoteEditorViewController.m
+++ b/Simplenote/NoteEditorViewController.m
@@ -293,7 +293,8 @@ static NSInteger const SPVersionSliderMaxVersions       = 10;
 - (void)checkTextInDocument
 {
     dispatch_async(dispatch_get_main_queue(), ^() {
-        // Disable editor delegate while processing links to prevent the editor from modifying the note
+        // Temporarily remove the editor delegate because `checkTextInDocument`
+        // fires `textDidChange` which will erroneously modify the note
         [self.noteEditor setDelegate:nil];
         [self.noteEditor checkTextInDocument:nil];
         [self.noteEditor setNeedsDisplay:YES];

--- a/Simplenote/NoteEditorViewController.m
+++ b/Simplenote/NoteEditorViewController.m
@@ -294,7 +294,8 @@ static NSInteger const SPVersionSliderMaxVersions       = 10;
 {
     dispatch_async(dispatch_get_main_queue(), ^() {
         // Temporarily remove the editor delegate because `checkTextInDocument`
-        // fires `textDidChange` which will erroneously modify the note
+        // fires `textDidChange` which will erroneously modify the note's modification
+        // date and unintentionally change the sort order of the note in the list as a result
         [self.noteEditor setDelegate:nil];
         [self.noteEditor checkTextInDocument:nil];
         [self.noteEditor setNeedsDisplay:YES];

--- a/Simplenote/Simplenote-Info-Hockey.plist
+++ b/Simplenote/Simplenote-Info-Hockey.plist
@@ -21,11 +21,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.3.1</string>
+	<string>1.3.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1310</string>
+	<string>1320</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.productivity</string>
 	<key>LSMinimumSystemVersion</key>

--- a/Simplenote/Simplenote-Info.plist
+++ b/Simplenote/Simplenote-Info.plist
@@ -21,11 +21,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.3.1</string>
+	<string>1.3.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1310</string>
+	<string>1320</string>
 	<key>Fabric</key>
 	<dict>
 		<key>APIKey</key>


### PR DESCRIPTION
#190 was caused by the new way we process links in the editor using `checkTextInDocument`. It turns out that this causes the `textDidChange` notification to fire for the text view, so the app was modifying the note and saving it which caused the bug.

I have disabled the text view delegate while `checkTextInDocument` is processing. It adds it back after finishing. I think this is OK? If not we can also use a boolean or something to not do any of the `textDidChange` processing while it is running.

**To Test**
Open the app, and the web app for the same account in a browser. Clicking on notes that have URLs in them should not modify them at all and move them anywhere in the notes list.