### PR TITLE
Fixing colors for tables when using the dark theme.

### DIFF
--- a/Simplenote/CSS/markdown-dark.css
+++ b/Simplenote/CSS/markdown-dark.css
@@ -160,11 +160,11 @@ html {
 }
 
 .note-detail-markdown table tr:nth-child(2n) {
-    background-color: #f6f7f8;
+    background-color: #383d41;
 }
 
 .note-detail-markdown table th, .note-detail-markdown table td {
-    border: 1px solid #c0c4c8;
+    border: 1px solid #575e65;
     padding: 6px 13px;
 }
 


### PR DESCRIPTION
The `markdown-dark.css` had some of the values from the `markdown-light.css` in it. I corrected them to the proper colors:

<img width="488" alt="screen shot 2018-03-27 at 2 18 10 pm" src="https://user-images.githubusercontent.com/789137/37995641-0704931c-31ca-11e8-8931-8192ac19fe2e.png">

Fixes #189 