### PR TITLE
Prevent adding a tag when another tag has the same name

### DIFF
--- a/Simplenote/TagListViewController.m
+++ b/Simplenote/TagListViewController.m
@@ -232,6 +232,11 @@ NSString * const kDidEmptyTrash = @"SPDidEmptyTrash";
         return nil;
     }
     
+    // Don't add the tag if there is an existing tag with the same name
+    if ([self tagWithName:tagName]) {
+        return nil;
+    }
+    
     SimplenoteAppDelegate *appDelegate = [SimplenoteAppDelegate sharedDelegate];
     SPBucket *tagBucket = [appDelegate.simperium bucketForName:@"Tag"];
     NSString *tagKey = [[tagName lowercaseString] sp_urlEncodeString];


### PR DESCRIPTION
Fixes #150 by adding a sanity check that we aren't adding a new tag that has the same name as an existing one.

![rename-tags](https://user-images.githubusercontent.com/789137/38649099-8a348a5e-3da9-11e8-87cf-01c1bf1c6c2b.gif)

**To Test**
* Rename a tag with a note open that contains the tag.
* Click in the tag editor field, no duplicate tags should show in the tags list.
