### PR TITLE
Do wp.com sign-in via a separate app window

### DIFF
--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		376EE3E9202A558E00E3812E /* simplenote.iconset in Resources */ = {isa = PBXBuildFile; fileRef = 469512C817CC38790014A2BF /* simplenote.iconset */; };
 		376EE3EB202B748E00E3812E /* SPAboutTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 376EE3EA202B748E00E3812E /* SPAboutTextField.swift */; };
 		376EE3EC202B748E00E3812E /* SPAboutTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 376EE3EA202B748E00E3812E /* SPAboutTextField.swift */; };
+		3777F9E820D19BE100580AF6 /* WPAuthWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3765B88020CB2F31001A3269 /* WPAuthWindowController.swift */; };
 		378345021D38624100D45D46 /* config.plist in Resources */ = {isa = PBXBuildFile; fileRef = 378345001D38624100D45D46 /* config.plist */; };
 		378AA6F81ACB04FD00CA87DC /* Simplenote-DB5.plist in Resources */ = {isa = PBXBuildFile; fileRef = 378AA6F71ACB04FD00CA87DC /* Simplenote-DB5.plist */; };
 		378AA7051ACB05B100CA87DC /* VSTheme.m in Sources */ = {isa = PBXBuildFile; fileRef = 378AA6FF1ACB05B100CA87DC /* VSTheme.m */; };
@@ -1308,6 +1309,7 @@
 				466FFED417CC10A800399652 /* SPTableView.m in Sources */,
 				466FFED517CC10A800399652 /* SPSplitView.m in Sources */,
 				B5A4EF301AEE76B8007AB0AB /* SPPopUpButtonCell.m in Sources */,
+				3777F9E820D19BE100580AF6 /* WPAuthWindowController.swift in Sources */,
 				466FFED617CC10A800399652 /* NSString+Styling.m in Sources */,
 				466FFED717CC10A800399652 /* SPTextView.m in Sources */,
 				3712FC831FE1ACAA008544AC /* Storage.swift in Sources */,

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		376EE3EB202B748E00E3812E /* SPAboutTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 376EE3EA202B748E00E3812E /* SPAboutTextField.swift */; };
 		376EE3EC202B748E00E3812E /* SPAboutTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 376EE3EA202B748E00E3812E /* SPAboutTextField.swift */; };
 		3777F9E820D19BE100580AF6 /* WPAuthWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3765B88020CB2F31001A3269 /* WPAuthWindowController.swift */; };
+		3777F9E920D19D5200580AF6 /* WPAuthWindowController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 3765B88120CB2F31001A3269 /* WPAuthWindowController.xib */; };
 		378345021D38624100D45D46 /* config.plist in Resources */ = {isa = PBXBuildFile; fileRef = 378345001D38624100D45D46 /* config.plist */; };
 		378AA6F81ACB04FD00CA87DC /* Simplenote-DB5.plist in Resources */ = {isa = PBXBuildFile; fileRef = 378AA6F71ACB04FD00CA87DC /* Simplenote-DB5.plist */; };
 		378AA7051ACB05B100CA87DC /* VSTheme.m in Sources */ = {isa = PBXBuildFile; fileRef = 378AA6FF1ACB05B100CA87DC /* VSTheme.m */; };
@@ -971,6 +972,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3777F9E920D19D5200580AF6 /* WPAuthWindowController.xib in Resources */,
 				B5B410BF1B17F28500CFCF8D /* Simplenote-DB5.plist in Resources */,
 				466FFEE617CC10A800399652 /* InfoPlist.strings in Resources */,
 				466FFEE717CC10A800399652 /* Credits.rtf in Resources */,

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -39,6 +39,8 @@
 		373B50E020179DFE000568A6 /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 373B50DC20179DFE000568A6 /* Extensions.swift */; };
 		375581C220292AA800529D79 /* About.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 375581C120292AA800529D79 /* About.storyboard */; };
 		375581C320292AA800529D79 /* About.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 375581C120292AA800529D79 /* About.storyboard */; };
+		3765B88220CB2F31001A3269 /* WPAuthWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3765B88020CB2F31001A3269 /* WPAuthWindowController.swift */; };
+		3765B88320CB2F31001A3269 /* WPAuthWindowController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 3765B88120CB2F31001A3269 /* WPAuthWindowController.xib */; };
 		376EE3E9202A558E00E3812E /* simplenote.iconset in Resources */ = {isa = PBXBuildFile; fileRef = 469512C817CC38790014A2BF /* simplenote.iconset */; };
 		376EE3EB202B748E00E3812E /* SPAboutTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 376EE3EA202B748E00E3812E /* SPAboutTextField.swift */; };
 		376EE3EC202B748E00E3812E /* SPAboutTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 376EE3EA202B748E00E3812E /* SPAboutTextField.swift */; };
@@ -299,6 +301,8 @@
 		373B50DC20179DFE000568A6 /* Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
 		375581C120292AA800529D79 /* About.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = About.storyboard; sourceTree = "<group>"; };
 		37647D71202A500E00B78C74 /* Simplenote-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Simplenote-Bridging-Header.h"; sourceTree = "<group>"; };
+		3765B88020CB2F31001A3269 /* WPAuthWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WPAuthWindowController.swift; sourceTree = "<group>"; };
+		3765B88120CB2F31001A3269 /* WPAuthWindowController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = WPAuthWindowController.xib; sourceTree = "<group>"; };
 		376EE3EA202B748E00E3812E /* SPAboutTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPAboutTextField.swift; sourceTree = "<group>"; };
 		378345001D38624100D45D46 /* config.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = config.plist; sourceTree = "<group>"; };
 		378AA6F71ACB04FD00CA87DC /* Simplenote-DB5.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "Simplenote-DB5.plist"; sourceTree = "<group>"; };
@@ -580,6 +584,8 @@
 				B5E96B641BDE732500D707F5 /* LoginWindowController.h */,
 				B5E96B651BDE732500D707F5 /* LoginWindowController.m */,
 				26F72AA114032D2A00A7935E /* MainMenu.xib */,
+				3765B88020CB2F31001A3269 /* WPAuthWindowController.swift */,
+				3765B88120CB2F31001A3269 /* WPAuthWindowController.xib */,
 			);
 			path = Simplenote;
 			sourceTree = "<group>";
@@ -954,6 +960,7 @@
 				B58A7B931D66643000B9DD13 /* config.plist in Resources */,
 				46F6540617F3F6E80074422C /* simplenotebeta.iconset in Resources */,
 				46F0E66717A3300B005BB4D1 /* Localizable.strings in Resources */,
+				3765B88320CB2F31001A3269 /* WPAuthWindowController.xib in Resources */,
 				375581C220292AA800529D79 /* About.storyboard in Resources */,
 				37AE49C71FFEBB0B00FCB165 /* markdown-default.css in Resources */,
 			);
@@ -1212,6 +1219,7 @@
 				46558BB61793AF4B009CD695 /* NSImage+Colorize.m in Sources */,
 				46558C0117947E77009CD695 /* NoteEditorBottomBar.m in Sources */,
 				46DD162F17A1E9C10093678C /* SPTagTextField.m in Sources */,
+				3765B88220CB2F31001A3269 /* WPAuthWindowController.swift in Sources */,
 				46F0E66317A32269005BB4D1 /* SPTableView.m in Sources */,
 				46F4EAB217B1A5F800697EAD /* SPSplitView.m in Sources */,
 				B5A4EF2F1AEE76B8007AB0AB /* SPPopUpButtonCell.m in Sources */,

--- a/Simplenote/LoginWindowController.h
+++ b/Simplenote/LoginWindowController.h
@@ -18,8 +18,6 @@
  *              extra functionality, Simplenote-Y.
  */
 
-@interface LoginWindowController : SPAuthenticationWindowController <NSWindowDelegate> {
-    WPAuthWindowController *wpAuthWindowController;
-}
-
+@interface LoginWindowController : SPAuthenticationWindowController <NSWindowDelegate>
+    @property (nonatomic, strong) WPAuthWindowController *wpAuthWindowController;
 @end

--- a/Simplenote/LoginWindowController.h
+++ b/Simplenote/LoginWindowController.h
@@ -7,6 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "Simplenote-Swift.h"
 @import Simperium_OSX;
 
 
@@ -17,6 +18,8 @@
  *              extra functionality, Simplenote-Y.
  */
 
-@interface LoginWindowController : SPAuthenticationWindowController
+@interface LoginWindowController : SPAuthenticationWindowController <NSWindowDelegate> {
+    WPAuthWindowController *wpAuthWindowController;
+}
 
 @end

--- a/Simplenote/LoginWindowController.m
+++ b/Simplenote/LoginWindowController.m
@@ -9,7 +9,6 @@
 #import "LoginWindowController.h"
 #import "SPConstants.h"
 #import "SPTracker.h"
-#import "Simplenote-Swift.h"
 
 static CGFloat const SPLoginAdditionalHeight        = 40.0f;
 static CGFloat const SPLoginWPButtonWidth           = 270.0f;

--- a/Simplenote/LoginWindowController.m
+++ b/Simplenote/LoginWindowController.m
@@ -66,8 +66,8 @@ static NSString *SPAuthSessionKey                   = @"SPAuthSessionKey";
 
 - (IBAction)wpccSignInAction:(id)sender
 {
-    if (wpAuthWindowController != nil) {
-        [wpAuthWindowController.window makeKeyAndOrderFront:nil];
+    if (self.wpAuthWindowController != nil) {
+        [self.wpAuthWindowController.window makeKeyAndOrderFront:nil];
         return;
     }
     
@@ -80,18 +80,18 @@ static NSString *SPAuthSessionKey                   = @"SPAuthSessionKey";
     
     NSString *requestUrl = [NSString stringWithFormat:SPWPSignInAuthURL, config[@"WPCCClientID"], config[@"WPCCRedirectURL"], sessionState];
     NSString *encodedUrl = [requestUrl stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]];
-    wpAuthWindowController = [[WPAuthWindowController alloc] initWithWindowNibName:@"WPAuthWindowController"];
-    [wpAuthWindowController showWindow:self];
+    self.wpAuthWindowController = [[WPAuthWindowController alloc] initWithWindowNibName:@"WPAuthWindowController"];
+    [self.wpAuthWindowController showWindow:self];
     
-    [wpAuthWindowController loadUrlWithUrl:[NSURL URLWithString:encodedUrl]];
+    [self.wpAuthWindowController loadUrlWithUrl:[NSURL URLWithString:encodedUrl]];
     
     [SPTracker trackWPCCButtonPressed];
 }
 
 - (IBAction)signInErrorAction:(NSNotification *)notification
 {
-    if (wpAuthWindowController != nil) {
-        [wpAuthWindowController close];
+    if (self.wpAuthWindowController != nil) {
+        [self.wpAuthWindowController close];
     }
     
     NSString *errorMessage = NSLocalizedString(@"An error was encountered while signing in.", @"Sign in error message");
@@ -126,8 +126,8 @@ static NSString *SPAuthSessionKey                   = @"SPAuthSessionKey";
 }
 
 - (void)windowWillClose:(NSNotification *)notification {
-    if (wpAuthWindowController != nil) {
-        [wpAuthWindowController close];
+    if (self.wpAuthWindowController != nil) {
+        [self.wpAuthWindowController close];
     }
 }
 

--- a/Simplenote/Simplenote-Info-Hockey.plist
+++ b/Simplenote/Simplenote-Info-Hockey.plist
@@ -21,24 +21,24 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.3.3</string>
+	<string>1.3.4</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
-	<key>CFBundleVersion</key>
-	<string>1330</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
 			<key>CFBundleTypeRole</key>
 			<string>Editor</string>
-			<key>URL Identifier</key>
-			<string>Simplenote URL</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
 				<string>simplenote</string>
 			</array>
+			<key>URL Identifier</key>
+			<string>Simplenote URL</string>
 		</dict>
 	</array>
+	<key>CFBundleVersion</key>
+	<string>1340</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.productivity</string>
 	<key>LSMinimumSystemVersion</key>

--- a/Simplenote/Simplenote-Info.plist
+++ b/Simplenote/Simplenote-Info.plist
@@ -21,24 +21,24 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.3.3</string>
+	<string>1.3.4</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
-	<key>CFBundleVersion</key>
-	<string>1330</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
 			<key>CFBundleTypeRole</key>
 			<string>Editor</string>
-			<key>URL Identifier</key>
-			<string>Simplenote URL</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
 				<string>simplenote</string>
 			</array>
+			<key>URL Identifier</key>
+			<string>Simplenote URL</string>
 		</dict>
 	</array>
+	<key>CFBundleVersion</key>
+	<string>1340</string>
 	<key>Fabric</key>
 	<dict>
 		<key>APIKey</key>

--- a/Simplenote/WPAuthWindowController.swift
+++ b/Simplenote/WPAuthWindowController.swift
@@ -11,6 +11,6 @@ class WPAuthWindowController: NSWindowController {
     @IBOutlet var webView: WebView!
     
     @objc public func loadUrl(url: URL) {
-        webView.mainFrame.load(URLRequest.init(url: url));
+        webView.mainFrame.load(URLRequest(url: url))
     }
 }

--- a/Simplenote/WPAuthWindowController.swift
+++ b/Simplenote/WPAuthWindowController.swift
@@ -1,0 +1,16 @@
+//
+//  WPAuthViewController.swift
+//  Simplenote
+//
+
+import Cocoa
+import WebKit
+
+class WPAuthWindowController: NSWindowController {
+    
+    @IBOutlet var webView: WebView!
+    
+    @objc public func loadUrl(url: URL) {
+        webView.mainFrame.load(URLRequest.init(url: url));
+    }
+}

--- a/Simplenote/WPAuthWindowController.xib
+++ b/Simplenote/WPAuthWindowController.xib
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14113" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+    <dependencies>
+        <deployment identifier="macosx"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14113"/>
+        <plugIn identifier="com.apple.WebKitIBPlugin" version="14113"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <customObject id="-2" userLabel="File's Owner" customClass="WPAuthWindowController" customModule="Simplenote" customModuleProvider="target">
+            <connections>
+                <outlet property="webView" destination="vYB-g8-SQi" id="WD7-WB-twK"/>
+                <outlet property="window" destination="F0z-JX-Cv5" id="Cpx-dQ-SbR"/>
+            </connections>
+        </customObject>
+        <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
+        <customObject id="-3" userLabel="Application" customClass="NSObject"/>
+        <window title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" oneShot="NO" releasedWhenClosed="NO" animationBehavior="default" titleVisibility="hidden" id="F0z-JX-Cv5">
+            <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
+            <rect key="contentRect" x="196" y="240" width="480" height="671"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1920" height="1058"/>
+            <view key="contentView" wantsLayer="YES" id="se5-gp-TjO">
+                <rect key="frame" x="0.0" y="0.0" width="480" height="671"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <webView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="vYB-g8-SQi">
+                        <rect key="frame" x="0.0" y="27" width="480" height="644"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                        <webPreferences key="preferences" defaultFontSize="12" defaultFixedFontSize="12">
+                            <nil key="identifier"/>
+                        </webPreferences>
+                    </webView>
+                    <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="5TA-UQ-c92">
+                        <rect key="frame" x="9" y="3" width="22" height="21"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <buttonCell key="cell" type="smallSquare" bezelStyle="smallSquare" image="NSGoBackTemplate" imagePosition="overlaps" alignment="center" lineBreakMode="truncatingTail" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="dk0-Ce-JaF">
+                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                            <font key="font" metaFont="system"/>
+                        </buttonCell>
+                        <connections>
+                            <action selector="goBack:" target="vYB-g8-SQi" id="9T7-ma-tfZ"/>
+                        </connections>
+                    </button>
+                    <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ScL-ed-SVM">
+                        <rect key="frame" x="30" y="3" width="22" height="21"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <buttonCell key="cell" type="smallSquare" bezelStyle="smallSquare" image="NSGoForwardTemplate" imagePosition="overlaps" alignment="center" lineBreakMode="truncatingTail" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="Un8-kS-lOg">
+                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                            <font key="font" metaFont="system"/>
+                        </buttonCell>
+                        <connections>
+                            <action selector="goForward:" target="vYB-g8-SQi" id="Jrw-bh-qfZ"/>
+                        </connections>
+                    </button>
+                </subviews>
+            </view>
+            <connections>
+                <outlet property="delegate" destination="-2" id="0bl-1N-AYu"/>
+            </connections>
+            <point key="canvasLocation" x="131" y="322.5"/>
+        </window>
+    </objects>
+    <resources>
+        <image name="NSGoBackTemplate" width="9" height="12"/>
+        <image name="NSGoForwardTemplate" width="9" height="12"/>
+    </resources>
+</document>

--- a/Simplenote/WPAuthWindowController.xib
+++ b/Simplenote/WPAuthWindowController.xib
@@ -25,14 +25,14 @@
                 <subviews>
                     <webView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="vYB-g8-SQi">
                         <rect key="frame" x="0.0" y="27" width="480" height="644"/>
-                        <autoresizingMask key="autoresizingMask"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <webPreferences key="preferences" defaultFontSize="12" defaultFixedFontSize="12">
                             <nil key="identifier"/>
                         </webPreferences>
                     </webView>
                     <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="5TA-UQ-c92">
                         <rect key="frame" x="9" y="3" width="22" height="21"/>
-                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <buttonCell key="cell" type="smallSquare" bezelStyle="smallSquare" image="NSGoBackTemplate" imagePosition="overlaps" alignment="center" lineBreakMode="truncatingTail" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="dk0-Ce-JaF">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="system"/>
@@ -43,7 +43,7 @@
                     </button>
                     <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ScL-ed-SVM">
                         <rect key="frame" x="30" y="3" width="22" height="21"/>
-                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <buttonCell key="cell" type="smallSquare" bezelStyle="smallSquare" image="NSGoForwardTemplate" imagePosition="overlaps" alignment="center" lineBreakMode="truncatingTail" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="Un8-kS-lOg">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="system"/>

--- a/Simplenote/WPAuthWindowController.xib
+++ b/Simplenote/WPAuthWindowController.xib
@@ -33,7 +33,7 @@
                     <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="5TA-UQ-c92">
                         <rect key="frame" x="9" y="3" width="22" height="21"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                        <buttonCell key="cell" type="smallSquare" bezelStyle="smallSquare" image="NSGoBackTemplate" imagePosition="overlaps" alignment="center" lineBreakMode="truncatingTail" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="dk0-Ce-JaF">
+                        <buttonCell key="cell" type="smallSquare" bezelStyle="smallSquare" image="NSGoLeftTemplate" imagePosition="overlaps" alignment="center" lineBreakMode="truncatingTail" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="dk0-Ce-JaF">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="system"/>
                         </buttonCell>
@@ -44,7 +44,7 @@
                     <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ScL-ed-SVM">
                         <rect key="frame" x="30" y="3" width="22" height="21"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                        <buttonCell key="cell" type="smallSquare" bezelStyle="smallSquare" image="NSGoForwardTemplate" imagePosition="overlaps" alignment="center" lineBreakMode="truncatingTail" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="Un8-kS-lOg">
+                        <buttonCell key="cell" type="smallSquare" bezelStyle="smallSquare" image="NSGoRightTemplate" imagePosition="overlaps" alignment="center" lineBreakMode="truncatingTail" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="Un8-kS-lOg">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="system"/>
                         </buttonCell>
@@ -61,7 +61,7 @@
         </window>
     </objects>
     <resources>
-        <image name="NSGoBackTemplate" width="9" height="12"/>
-        <image name="NSGoForwardTemplate" width="9" height="12"/>
+        <image name="NSGoLeftTemplate" width="9" height="12"/>
+        <image name="NSGoRightTemplate" width="9" height="12"/>
     </resources>
 </document>


### PR DESCRIPTION
Previously, wp.com sign in did the authorization via the external web browser, which many users during testing found confusing when the authorization page would stay in the browser tab without closing.

This PR moves that flow to a new`WPAuthWindowController` that has a web view and some simple forward/back buttons. It also is nice because you don't need to authorize the app to open the `simplenote://` protocol.

Screenshot:
<img width="477" alt="screen shot 2018-06-11 at 9 58 43 am" src="https://user-images.githubusercontent.com/789137/41246191-23bd99a6-6d5f-11e8-8f87-402393e46c41.png">


**To Test**
* Sign in using the wp.com sign in flow. Approving or Denying should work as expected.
* Try opening multiple auth windows, it should only allow one instance.
* Completing the sign in or when an error is shown should close the auth window.

