### PR TITLE
Changed NSButton construction to be compatible with macOS < 10.12

### DIFF
--- a/Simplenote/LoginWindowController.m
+++ b/Simplenote/LoginWindowController.m
@@ -39,7 +39,10 @@ static NSString *SPAuthSessionKey                   = @"SPAuthSessionKey";
         [view setFrame:frame];
     }
     
-    NSButton *wpccButton = [NSButton buttonWithTitle:NSLocalizedString(@"Sign in with WordPress.com", @"button title for wp.com sign in button") target:self action:@selector(wpccSignInAction:)];
+    NSButton *wpccButton = [[NSButton alloc] init];
+    [wpccButton setTitle:NSLocalizedString(@"Sign in with WordPress.com", @"button title for wp.com sign in button")];
+    [wpccButton setTarget:self];
+    [wpccButton setAction:@selector(wpccSignInAction:)];
     [wpccButton setImage:[NSImage imageNamed:@"icon_wp"]];
     [wpccButton setImagePosition:NSImageLeft];
     [wpccButton setBordered:NO];


### PR DESCRIPTION
#219 was caused by usage of a convenience constructor for `NSButton` that is [only available as of macOS 10.12](https://developer.apple.com/documentation/appkit/nsbutton/1644256-buttonwithtitle?language=objc).

_This is why we can't have nice things!_ It's weird that Xcode doesn't warn about usage of the constructor...

I've tested this on a El Capitan VM, and the login window now appears and works as expected:

<img width="1021" alt="screen shot 2018-07-12 at 2 26 47 pm" src="https://user-images.githubusercontent.com/789137/42660619-a1220ec4-85e0-11e8-91c2-1831ef528694.png">
