### PR TITLE
Add Focus Mode Setting

### DIFF
--- a/Simplenote/SPSplitView.m
+++ b/Simplenote/SPSplitView.m
@@ -53,7 +53,7 @@ const CGFloat SPSplitViewDefaultWidth = 120.0;
 - (void)drawDividerInRect:(NSRect)rect
 {
     // Slight hack to make left divider the background color when tags view is collapsed
-    if (rect.origin.x == 0) {
+    if (rect.origin.x <= 1) {
         [[[[VSThemeManager sharedManager] theme] colorForKey:@"tableViewBackgroundColor"] set];
         NSRectFill(rect);
     } else {

--- a/Simplenote/SPToolbarView.h
+++ b/Simplenote/SPToolbarView.h
@@ -35,6 +35,6 @@
 - (void)setFullscreen:(BOOL)fullscreen;
 - (void)setSplitPositionLeft:(CGFloat)left right:(CGFloat)right;
 - (void)applyStyle;
-- (void)setButtonsAlpha:(CGFloat)alpha;
+- (void)configureForFocusMode:(BOOL)enabled;
 
 @end

--- a/Simplenote/SPToolbarView.h
+++ b/Simplenote/SPToolbarView.h
@@ -35,5 +35,6 @@
 - (void)setFullscreen:(BOOL)fullscreen;
 - (void)setSplitPositionLeft:(CGFloat)left right:(CGFloat)right;
 - (void)applyStyle;
+- (void)setButtonsAlpha:(CGFloat)alpha;
 
 @end

--- a/Simplenote/SPToolbarView.m
+++ b/Simplenote/SPToolbarView.m
@@ -21,6 +21,9 @@
 #define kSearchCollapsedWidth   120
 #define kSearchExpandedMargin   156
 #define kSearchExpandedWidth    79
+#define kFocusModeOnAlpha       0.5f
+#define kFocusModeOffAlpha      1.0f
+#define kFocusModeDuration      0.8f
 
 @implementation SPToolbarView
 
@@ -88,7 +91,7 @@
 
 - (void)setButtonsAlpha:(CGFloat)alpha {
     [NSAnimationContext runAnimationGroup:^(NSAnimationContext *context) {
-        context.duration = 0.8;
+        context.duration = kFocusModeDuration;
         self.actionButton.animator.alphaValue = alpha;
         addButton.animator.alphaValue = alpha;
         sidebarButton.animator.alphaValue = alpha;
@@ -105,7 +108,7 @@
 - (void)configureForFocusMode:(BOOL)enabled {
     [searchField setEnabled:!enabled];
     
-    [self setButtonsAlpha:enabled? 0.5 : 1.0];
+    [self setButtonsAlpha:enabled? kFocusModeOnAlpha : kFocusModeOffAlpha];
 }
 
 - (void)noNoteLoaded:(id)sender {

--- a/Simplenote/SPToolbarView.m
+++ b/Simplenote/SPToolbarView.m
@@ -89,16 +89,23 @@
 - (void)setButtonsAlpha:(CGFloat)alpha {
     [NSAnimationContext runAnimationGroup:^(NSAnimationContext *context) {
         context.duration = 0.8;
+        self.actionButton.animator.alphaValue = alpha;
         addButton.animator.alphaValue = alpha;
         sidebarButton.animator.alphaValue = alpha;
-        self.actionButton.animator.alphaValue = alpha;
         shareButton.animator.alphaValue = alpha;
         trashButton.animator.alphaValue = alpha;
         restoreButton.animator.alphaValue = alpha;
         historyButton.animator.alphaValue = alpha;
         previewButton.animator.alphaValue = alpha;
+        searchField.animator.alphaValue = alpha;
     }
     completionHandler:nil];
+}
+
+- (void)configureForFocusMode:(BOOL)enabled {
+    [searchField setEnabled:!enabled];
+    
+    [self setButtonsAlpha:enabled? 0.5 : 1.0];
 }
 
 - (void)noNoteLoaded:(id)sender {

--- a/Simplenote/SPToolbarView.m
+++ b/Simplenote/SPToolbarView.m
@@ -86,6 +86,21 @@
     [previewButton setEnabled:enabled];
 }
 
+- (void)setButtonsAlpha:(CGFloat)alpha {
+    [NSAnimationContext runAnimationGroup:^(NSAnimationContext *context) {
+        context.duration = 0.8;
+        addButton.animator.alphaValue = alpha;
+        sidebarButton.animator.alphaValue = alpha;
+        self.actionButton.animator.alphaValue = alpha;
+        shareButton.animator.alphaValue = alpha;
+        trashButton.animator.alphaValue = alpha;
+        restoreButton.animator.alphaValue = alpha;
+        historyButton.animator.alphaValue = alpha;
+        previewButton.animator.alphaValue = alpha;
+    }
+    completionHandler:nil];
+}
+
 - (void)noNoteLoaded:(id)sender {
     [self enableButtons:NO];
 }

--- a/Simplenote/SimplenoteAppDelegate.h
+++ b/Simplenote/SimplenoteAppDelegate.h
@@ -20,6 +20,7 @@
 
 @interface SimplenoteAppDelegate : NSObject <NSApplicationDelegate, NSSplitViewDelegate, NSWindowDelegate> {
     IBOutlet NSMenu *themeMenu;
+    IBOutlet NSMenuItem *focusModeMenuItem;
     IBOutlet SPBackgroundView *backgroundView;
 }
 

--- a/Simplenote/SimplenoteAppDelegate.m
+++ b/Simplenote/SimplenoteAppDelegate.m
@@ -456,7 +456,7 @@
 - (BOOL)splitView:(NSSplitView *)splitView shouldHideDividerAtIndex:(NSInteger)dividerIndex
 {
     // Tag List: Don't draw separators
-    return (dividerIndex == SPSplitViewSectionTags);
+    return (self.noteListViewController.view.isHidden || dividerIndex == SPSplitViewSectionTags);
 }
 
 - (NSRect)splitView:(NSSplitView *)splitView effectiveRect:(NSRect)proposedEffectiveRect forDrawnRect:(NSRect)drawnRect ofDividerAtIndex:(NSInteger)dividerIndex
@@ -706,6 +706,15 @@
     
     [self.splitView setPosition:collapsed ? 0 : tagListSplitPosition ofDividerAtIndex:0];
     [self.splitView setPosition:collapsed ? editorSplitPosition - tagListSplitPosition : editorSplitPosition + tagListSplitPosition ofDividerAtIndex:1];
+    [self.splitView adjustSubviews];
+}
+
+- (IBAction)focusModeAction:(id)sender {
+    [self.noteListViewController.view setHidden:![self.noteListViewController.view isHidden]];
+    
+    CGFloat alphaValue = [self.noteListViewController.view isHidden] ? 0.5f : 1.0f;
+    [self.toolbar setButtonsAlpha:alphaValue];
+    
     [self.splitView adjustSubviews];
 }
 

--- a/Simplenote/en.lproj/MainMenu.xib
+++ b/Simplenote/en.lproj/MainMenu.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14109" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14113" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14109"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14113"/>
         <capability name="box content view" minToolsVersion="7.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -37,6 +37,7 @@
             <connections>
                 <outlet property="delegate" destination="1461" id="1520"/>
             </connections>
+            <point key="canvasLocation" x="-58" y="411"/>
         </menu>
         <menu id="1504" userLabel="Note List Menu">
             <items>
@@ -612,6 +613,11 @@
                             <menuItem title="Toggle Sidebar" keyEquivalent="t" id="tkU-Gb-qGx">
                                 <connections>
                                     <action selector="toggleSidebarAction:" target="494" id="eqc-Uf-NHj"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Focus Mode" keyEquivalent="F" id="nrD-mL-W7Q">
+                                <connections>
+                                    <action selector="focusModeAction:" target="494" id="3q6-ha-uEK"/>
                                 </connections>
                             </menuItem>
                             <menuItem title="Enter Full Screen" keyEquivalent="f" id="1324">
@@ -1283,7 +1289,7 @@
     <resources>
         <image name="button_new" width="22" height="22"/>
         <image name="icon_all_notes" width="22" height="22"/>
-        <image name="icon_preview" width="22" height="22"/>
+        <image name="icon_preview" width="44" height="44"/>
         <image name="icon_tags" width="22" height="22"/>
         <image name="icon_trash" width="22" height="22"/>
         <image name="icon_trash_highlighted" width="22" height="22"/>

--- a/Simplenote/en.lproj/MainMenu.xib
+++ b/Simplenote/en.lproj/MainMenu.xib
@@ -959,7 +959,7 @@
                                             <rect key="frame" x="0.0" y="0.0" width="478" height="575"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
-                                                <textView drawsBackground="NO" importsGraphics="NO" richText="NO" horizontallyResizable="YES" verticallyResizable="YES" findStyle="panel" incrementalSearchingEnabled="YES" continuousSpellChecking="YES" allowsUndo="YES" allowsNonContiguousLayout="YES" linkDetection="YES" dataDetection="YES" spellingCorrection="YES" smartInsertDelete="YES" id="934" customClass="SPTextView">
+                                                <textView drawsBackground="NO" importsGraphics="NO" richText="NO" verticallyResizable="YES" findStyle="panel" incrementalSearchingEnabled="YES" continuousSpellChecking="YES" allowsUndo="YES" allowsNonContiguousLayout="YES" linkDetection="YES" dataDetection="YES" spellingCorrection="YES" smartInsertDelete="YES" id="934" customClass="SPTextView">
                                                     <rect key="frame" x="0.0" y="0.0" width="478" height="575"/>
                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                     <color key="backgroundColor" red="1" green="0.0" blue="0.0" alpha="0.0" colorSpace="calibratedRGB"/>
@@ -1056,6 +1056,7 @@
             <connections>
                 <outlet property="backgroundView" destination="372" id="C2S-D2-Vn5"/>
                 <outlet property="emptyTrashItem" destination="1256" id="1776"/>
+                <outlet property="focusModeMenuItem" destination="nrD-mL-W7Q" id="9KY-QY-jI5"/>
                 <outlet property="mainWindowItem" destination="vor-dd-sYt" id="jUG-qn-XNJ"/>
                 <outlet property="noteEditorViewController" destination="1107" id="1674"/>
                 <outlet property="noteListToolbarButton" destination="1680" id="1703"/>


### PR DESCRIPTION
Continuing the good work started by @jtoy in #182!

This adds a new `Focus Mode` that hides both the tags and notes list to make the editor full width. It also fades the UI buttons in the toolbar when entering focus mode. You can toggle focus mode in the view menu, or by pressing `cmd+shift+f`.

<img width="894" alt="screen shot 2018-07-25 at 2 53 52 pm" src="https://user-images.githubusercontent.com/789137/43229826-f3e06360-901a-11e8-8c1f-5abaaeca3a1f.png">

**To Test**
* Enable focus mode, and test that the editor works as expected. The search bar should be disabled.
* Try toggling the tags toolbar, it should show the notes list.
* The app should remember if the tags list was opened when you started focus mode and restore its state when focus mode ends.
