### PR TITLE
Add a maximum note editor width and setting

### DIFF
--- a/Simplenote/NoteEditorViewController.h
+++ b/Simplenote/NoteEditorViewController.h
@@ -61,6 +61,7 @@ extern NSString * const SPWillAddNewNoteNotificationName;
     IBOutlet NSMenuItem *deleteItem;
     IBOutlet NSMenuItem *printItem;
     IBOutlet NSMenuItem *collaborateItem;
+    IBOutlet NSMenuItem *editorWidthItem;
 }
 
 @property (nonatomic, assign) IBOutlet SPTextView           *noteEditor;
@@ -91,5 +92,6 @@ extern NSString * const SPWillAddNewNoteNotificationName;
 - (IBAction)showSharePopover:(id)sender;
 - (IBAction)showVersionPopover:(id)sender;
 - (IBAction)toggleMarkdownView:(id)sender;
+- (IBAction)toggleEditorWidth:(id)sender;
 
 @end

--- a/Simplenote/NoteEditorViewController.h
+++ b/Simplenote/NoteEditorViewController.h
@@ -52,6 +52,7 @@ extern NSString * const SPWillAddNewNoteNotificationName;
     IBOutlet NSButton *shareButton;
     IBOutlet NSView *statusView;
     IBOutlet NSTextField *noNoteText;
+    IBOutlet NSMenu *lineLengthMenu;
     IBOutlet NSMenuItem *wordCountItem;
     IBOutlet NSMenuItem *characterCountItem;
     IBOutlet NSMenuItem *modifiedItem;
@@ -61,7 +62,6 @@ extern NSString * const SPWillAddNewNoteNotificationName;
     IBOutlet NSMenuItem *deleteItem;
     IBOutlet NSMenuItem *printItem;
     IBOutlet NSMenuItem *collaborateItem;
-    IBOutlet NSMenuItem *editorWidthItem;
 }
 
 @property (nonatomic, assign) IBOutlet SPTextView           *noteEditor;

--- a/Simplenote/NoteEditorViewController.m
+++ b/Simplenote/NoteEditorViewController.m
@@ -101,11 +101,7 @@ static NSInteger const SPVersionSliderMaxVersions       = 10;
 
 - (void)awakeFromNib
 {
-    CGFloat insetX = 20;
-    CGFloat insetY = 20;
-    
-    [self.noteEditor setTextContainerInset: NSMakeSize(insetX, insetY)];
-    [self.noteEditor setFrameSize:NSMakeSize(self.noteEditor.frame.size.width-insetX/2, self.noteEditor.frame.size.height-insetY/2)];
+    [self.noteEditor setFrameSize:NSMakeSize(self.noteEditor.frame.size.width-kMinEditorPadding/2, self.noteEditor.frame.size.height-kMinEditorPadding/2)];
     self.storage = [Storage newInstance];
     [self.noteEditor.layoutManager replaceTextStorage:self.storage];
     

--- a/Simplenote/NoteEditorViewController.m
+++ b/Simplenote/NoteEditorViewController.m
@@ -118,8 +118,8 @@ static NSInteger const SPVersionSliderMaxVersions       = 10;
 		[self.noteEditor setValue:preferences[key] forKey:key];
 	}
     
-    BOOL fullWidthEnabled = [[NSUserDefaults standardUserDefaults] boolForKey:kEditorWidthPreferencesKey];
-    [editorWidthItem setState:fullWidthEnabled ? NSControlStateValueOn : NSControlStateValueOff];
+    int lineLengthPosition = [[NSUserDefaults standardUserDefaults] boolForKey:kEditorWidthPreferencesKey] ? 1 : 0;
+    [self updateLineLengthMenuForPosition:lineLengthPosition];
     
     tagTokenField = [self.bottomBar addTagField];
     tagTokenField.delegate = self;
@@ -1115,11 +1115,26 @@ static NSInteger const SPVersionSliderMaxVersions       = 10;
 }
 
 - (IBAction)toggleEditorWidth:(id)sender {
-    [editorWidthItem setState:editorWidthItem.state == NSControlStateValueOn ? NSControlStateValueOff : NSControlStateValueOn];
-    BOOL fullWidthEnabled = editorWidthItem.state == NSControlStateValueOn;
+    NSMenuItem *item = (NSMenuItem *)sender;
+    if (item.state == NSOnState) {
+        return;
+    }
     
-    [[NSUserDefaults standardUserDefaults] setBool:fullWidthEnabled forKey:kEditorWidthPreferencesKey];
+    [self updateLineLengthMenuForPosition:item.tag];
     [self.noteEditor setNeedsDisplay:YES];
+}
+
+- (void)updateLineLengthMenuForPosition:(NSInteger)position
+{
+    for (NSMenuItem *menuItem in lineLengthMenu.itemArray) {
+        if (menuItem.tag == position) {
+            [menuItem setState:NSOnState];
+        } else {
+            [menuItem setState:NSOffState];
+        }
+    }
+    
+    [[NSUserDefaults standardUserDefaults] setBool:position == 1 forKey:kEditorWidthPreferencesKey];
 }
 
 - (void)loadMarkdownContent {

--- a/Simplenote/NoteEditorViewController.m
+++ b/Simplenote/NoteEditorViewController.m
@@ -118,6 +118,9 @@ static NSInteger const SPVersionSliderMaxVersions       = 10;
 		[self.noteEditor setValue:preferences[key] forKey:key];
 	}
     
+    BOOL fullWidthEnabled = [[NSUserDefaults standardUserDefaults] boolForKey:kEditorWidthPreferencesKey];
+    [editorWidthItem setState:fullWidthEnabled ? NSControlStateValueOn : NSControlStateValueOff];
+    
     tagTokenField = [self.bottomBar addTagField];
     tagTokenField.delegate = self;
     self.noteScrollPositions = [[NSMutableDictionary alloc] init];
@@ -1110,6 +1113,15 @@ static NSInteger const SPVersionSliderMaxVersions       = 10;
         [self loadMarkdownContent];
     }
 }
+
+- (IBAction)toggleEditorWidth:(id)sender {
+    [editorWidthItem setState:editorWidthItem.state == NSControlStateValueOn ? NSControlStateValueOff : NSControlStateValueOn];
+    BOOL fullWidthEnabled = editorWidthItem.state == NSControlStateValueOn;
+    
+    [[NSUserDefaults standardUserDefaults] setBool:fullWidthEnabled forKey:kEditorWidthPreferencesKey];
+    [self.noteEditor setNeedsDisplay:YES];
+}
+
 - (void)loadMarkdownContent {
     NSString *html = [SPMarkdownParser renderHTMLFromMarkdownString:self.note.content];
     [self.markdownView loadHTMLString:html baseURL:[[NSBundle mainBundle] bundleURL]];

--- a/Simplenote/SPMarkdownParser.m
+++ b/Simplenote/SPMarkdownParser.m
@@ -10,6 +10,7 @@
 #import <hoedown/html.h>
 #import "VSTheme+Simplenote.h"
 #import "VSThemeManager.h"
+#import "SPTextView.h"
 
 @implementation SPMarkdownParser
 
@@ -40,6 +41,12 @@
             "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">"
             "<link href=\"https://fonts.googleapis.com/css?family=Noto+Serif\" rel=\"stylesheet\">"
             "<style media=\"screen\" type=\"text/css\">\n";
+    
+    // Limit the editor width if the full width setting is not enabled
+    if (![[NSUserDefaults standardUserDefaults] boolForKey:kEditorWidthPreferencesKey]) {
+        headerStart = [headerStart stringByAppendingString:@".note-detail-markdown { max-width:750px;margin:0 auto; }"];
+    }
+    
     NSString *headerEnd = @"</style></head><body><div class=\"note-detail-markdown\"><div id=\"static_content\">";
     
     VSTheme *theme = [[VSThemeManager sharedManager] theme];

--- a/Simplenote/SPTextView.h
+++ b/Simplenote/SPTextView.h
@@ -8,6 +8,8 @@
 
 #import <Cocoa/Cocoa.h>
 
+#define kMinEditorPadding 20
+
 @protocol SPTextViewDelegate <NSTextViewDelegate>
 - (void)didClickTextView:(id)sender;
 @end

--- a/Simplenote/SPTextView.h
+++ b/Simplenote/SPTextView.h
@@ -9,6 +9,7 @@
 #import <Cocoa/Cocoa.h>
 
 #define kMinEditorPadding 20
+#define kEditorWidthPreferencesKey @"kEditorWidthPreferencesKey"
 
 @protocol SPTextViewDelegate <NSTextViewDelegate>
 - (void)didClickTextView:(id)sender;

--- a/Simplenote/SPTextView.m
+++ b/Simplenote/SPTextView.m
@@ -8,6 +8,8 @@
 
 #import "SPTextView.h"
 
+#define kMaxEditorWidth 750 // Note: This matches the Electron apps max editor width
+
 @implementation SPTextView
 
 // Workaround NSTextView not allowing clicks
@@ -23,6 +25,20 @@
 - (id<SPTextViewDelegate>)textViewDelegate
 {
     return [self.delegate conformsToProtocol:@protocol(SPTextViewDelegate)] ? (id<SPTextViewDelegate>)self.delegate : nil;
+}
+
+- (void)drawRect:(NSRect)dirtyRect {
+    [super drawRect:dirtyRect];
+    
+    CGFloat viewWidth = self.frame.size.width;
+    CGFloat insetX = viewWidth > kMaxEditorWidth ? [self getAdjustedInsetX:viewWidth] : kMinEditorPadding;
+    [self setTextContainerInset: NSMakeSize(insetX, kMinEditorPadding)];
+}
+
+- (CGFloat)getAdjustedInsetX: (CGFloat)viewWidth {
+    CGFloat adjustedInset = (viewWidth - kMaxEditorWidth) / 2;
+    
+    return adjustedInset + kMinEditorPadding;
 }
 
 @end

--- a/Simplenote/SPTextView.m
+++ b/Simplenote/SPTextView.m
@@ -40,9 +40,9 @@
 }
 
 - (CGFloat)getAdjustedInsetX: (CGFloat)viewWidth {
-    NSInteger adjustedInset = (viewWidth - kMaxEditorWidth) / 2;
+    CGFloat adjustedInset = (viewWidth - kMaxEditorWidth) / 2;
     
-    return adjustedInset + kMinEditorPadding;
+    return lroundf(adjustedInset) + kMinEditorPadding;
 }
 
 @end

--- a/Simplenote/SPTextView.m
+++ b/Simplenote/SPTextView.m
@@ -40,7 +40,7 @@
 }
 
 - (CGFloat)getAdjustedInsetX: (CGFloat)viewWidth {
-    CGFloat adjustedInset = (viewWidth - kMaxEditorWidth) / 2;
+    NSInteger adjustedInset = (viewWidth - kMaxEditorWidth) / 2;
     
     return adjustedInset + kMinEditorPadding;
 }

--- a/Simplenote/SPTextView.m
+++ b/Simplenote/SPTextView.m
@@ -31,8 +31,12 @@
     [super drawRect:dirtyRect];
     
     CGFloat viewWidth = self.frame.size.width;
-    CGFloat insetX = viewWidth > kMaxEditorWidth ? [self getAdjustedInsetX:viewWidth] : kMinEditorPadding;
+    CGFloat insetX = [self shouldCalculateInset:viewWidth] ? [self getAdjustedInsetX:viewWidth] : kMinEditorPadding;
     [self setTextContainerInset: NSMakeSize(insetX, kMinEditorPadding)];
+}
+
+- (BOOL)shouldCalculateInset: (CGFloat)viewWidth {
+    return viewWidth > kMaxEditorWidth && ![[NSUserDefaults standardUserDefaults] boolForKey:kEditorWidthPreferencesKey];
 }
 
 - (CGFloat)getAdjustedInsetX: (CGFloat)viewWidth {

--- a/Simplenote/en.lproj/MainMenu.xib
+++ b/Simplenote/en.lproj/MainMenu.xib
@@ -530,6 +530,25 @@
                 <menuItem title="View" id="295">
                     <menu key="submenu" title="View" id="296">
                         <items>
+                            <menuItem title="Note Display" id="tl2-gz-YEA">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="Note Display" systemMenu="font" id="fB2-X8-xNp">
+                                    <items>
+                                        <menuItem title="Comfy" id="Qaj-k2-NOz">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="previewLinesAction:" target="874" id="d4I-8r-5Lj"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Condensed" tag="1" id="tQC-gw-hdq">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="previewLinesAction:" target="874" id="X0J-e4-qfh"/>
+                                            </connections>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
                             <menuItem title="Note Editor" id="oYc-2J-WVc">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <menu key="submenu" id="o2X-H9-mTR">
@@ -556,13 +575,26 @@
                                                 </items>
                                             </menu>
                                         </menuItem>
-                                        <menuItem isSeparatorItem="YES" id="byP-HD-jjJ"/>
-                                        <menuItem title="Full Width" id="bBW-To-3v3">
+                                        <menuItem title="Line Length" id="P9P-ed-21W">
                                             <modifierMask key="keyEquivalentModifierMask"/>
-                                            <connections>
-                                                <action selector="toggleEditorWidth:" target="1107" id="6Mk-ep-n1J"/>
-                                            </connections>
+                                            <menu key="submenu" title="Line Length" id="JgX-db-Pi6">
+                                                <items>
+                                                    <menuItem title="Narrow" id="lMi-2X-rR9">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleEditorWidth:" target="1107" id="1D7-pl-Fcz"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Full" tag="1" id="bBW-To-3v3">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleEditorWidth:" target="1107" id="Wf5-Ne-3W8"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                </items>
+                                            </menu>
                                         </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="byP-HD-jjJ"/>
                                     </items>
                                 </menu>
                             </menuItem>
@@ -604,36 +636,18 @@
                                     </items>
                                 </menu>
                             </menuItem>
-                            <menuItem title="Note Display" id="tl2-gz-YEA">
-                                <modifierMask key="keyEquivalentModifierMask"/>
-                                <menu key="submenu" title="Note Display" systemMenu="font" id="fB2-X8-xNp">
-                                    <items>
-                                        <menuItem title="Comfy" id="Qaj-k2-NOz">
-                                            <modifierMask key="keyEquivalentModifierMask"/>
-                                            <connections>
-                                                <action selector="previewLinesAction:" target="874" id="d4I-8r-5Lj"/>
-                                            </connections>
-                                        </menuItem>
-                                        <menuItem title="Condensed" tag="1" id="tQC-gw-hdq">
-                                            <modifierMask key="keyEquivalentModifierMask"/>
-                                            <connections>
-                                                <action selector="previewLinesAction:" target="874" id="X0J-e4-qfh"/>
-                                            </connections>
-                                        </menuItem>
-                                    </items>
-                                </menu>
-                            </menuItem>
                             <menuItem isSeparatorItem="YES" id="6I8-iX-Ptg"/>
-                            <menuItem title="Toggle Sidebar" keyEquivalent="t" id="tkU-Gb-qGx">
-                                <connections>
-                                    <action selector="toggleSidebarAction:" target="494" id="eqc-Uf-NHj"/>
-                                </connections>
-                            </menuItem>
                             <menuItem title="Focus Mode" keyEquivalent="F" id="nrD-mL-W7Q">
                                 <connections>
                                     <action selector="focusModeAction:" target="494" id="3q6-ha-uEK"/>
                                 </connections>
                             </menuItem>
+                            <menuItem title="Toggle Sidebar" keyEquivalent="t" id="tkU-Gb-qGx">
+                                <connections>
+                                    <action selector="toggleSidebarAction:" target="494" id="eqc-Uf-NHj"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="cCS-jM-ycR"/>
                             <menuItem title="Enter Full Screen" keyEquivalent="f" id="1324">
                                 <modifierMask key="keyEquivalentModifierMask" control="YES" command="YES"/>
                                 <connections>
@@ -1091,8 +1105,10 @@
                 <outlet property="characterCountItem" destination="1606" id="1626"/>
                 <outlet property="collaborateItem" destination="1616" id="1770"/>
                 <outlet property="deleteItem" destination="1655" id="1660"/>
-                <outlet property="editorWidthItem" destination="bBW-To-3v3" id="w4S-Rh-4Sg"/>
+                <outlet property="editorWidthFullItem" destination="bBW-To-3v3" id="GmP-lr-AUQ"/>
+                <outlet property="editorWidthNarrowItem" destination="lMi-2X-rR9" id="8k8-KI-fR7"/>
                 <outlet property="historyButton" destination="7hm-UJ-0zw" id="i3Y-k0-nZS"/>
+                <outlet property="lineLengthMenu" destination="JgX-db-Pi6" id="eVA-hS-cdT"/>
                 <outlet property="markdownItem" destination="HN9-TP-CJw" id="JGo-Bq-qMr"/>
                 <outlet property="modifiedItem" destination="1613" id="1628"/>
                 <outlet property="newItem" destination="1654" id="1658"/>

--- a/Simplenote/en.lproj/MainMenu.xib
+++ b/Simplenote/en.lproj/MainMenu.xib
@@ -530,25 +530,6 @@
                 <menuItem title="View" id="295">
                     <menu key="submenu" title="View" id="296">
                         <items>
-                            <menuItem title="Note Display" id="tl2-gz-YEA">
-                                <modifierMask key="keyEquivalentModifierMask"/>
-                                <menu key="submenu" title="Note Display" systemMenu="font" id="fB2-X8-xNp">
-                                    <items>
-                                        <menuItem title="Comfy" id="Qaj-k2-NOz">
-                                            <modifierMask key="keyEquivalentModifierMask"/>
-                                            <connections>
-                                                <action selector="previewLinesAction:" target="874" id="d4I-8r-5Lj"/>
-                                            </connections>
-                                        </menuItem>
-                                        <menuItem title="Condensed" tag="1" id="tQC-gw-hdq">
-                                            <modifierMask key="keyEquivalentModifierMask"/>
-                                            <connections>
-                                                <action selector="previewLinesAction:" target="874" id="X0J-e4-qfh"/>
-                                            </connections>
-                                        </menuItem>
-                                    </items>
-                                </menu>
-                            </menuItem>
                             <menuItem title="Note Editor" id="oYc-2J-WVc">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <menu key="submenu" id="o2X-H9-mTR">
@@ -598,21 +579,47 @@
                                     </items>
                                 </menu>
                             </menuItem>
-                            <menuItem title="Sort Order" id="QGk-SS-2Jf">
+                            <menuItem title="Notes List" id="lqT-82-IW9">
                                 <modifierMask key="keyEquivalentModifierMask"/>
-                                <menu key="submenu" title="Sort Order" systemMenu="font" id="YpJ-fs-p4p">
+                                <menu key="submenu" title="Notes List" id="L8Y-u8-nu8">
                                     <items>
-                                        <menuItem title="Date Updated" id="fep-x2-0FA">
+                                        <menuItem title="Note Display" id="tl2-gz-YEA">
                                             <modifierMask key="keyEquivalentModifierMask"/>
-                                            <connections>
-                                                <action selector="sortPrefAction:" target="874" id="KsM-qb-OZu"/>
-                                            </connections>
+                                            <menu key="submenu" title="Note Display" systemMenu="font" id="fB2-X8-xNp">
+                                                <items>
+                                                    <menuItem title="Comfy" id="Qaj-k2-NOz">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="previewLinesAction:" target="874" id="d4I-8r-5Lj"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Condensed" tag="1" id="tQC-gw-hdq">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="previewLinesAction:" target="874" id="X0J-e4-qfh"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                </items>
+                                            </menu>
                                         </menuItem>
-                                        <menuItem title="Alphabetical" tag="1" id="i8p-Xx-VpF">
+                                        <menuItem title="Sort Order" id="QGk-SS-2Jf">
                                             <modifierMask key="keyEquivalentModifierMask"/>
-                                            <connections>
-                                                <action selector="sortPrefAction:" target="874" id="wYh-RZ-Guv"/>
-                                            </connections>
+                                            <menu key="submenu" title="Sort Order" systemMenu="font" id="YpJ-fs-p4p">
+                                                <items>
+                                                    <menuItem title="Date Updated" id="fep-x2-0FA">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="sortPrefAction:" target="874" id="KsM-qb-OZu"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Alphabetical" tag="1" id="i8p-Xx-VpF">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="sortPrefAction:" target="874" id="wYh-RZ-Guv"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                </items>
+                                            </menu>
                                         </menuItem>
                                     </items>
                                 </menu>

--- a/Simplenote/en.lproj/MainMenu.xib
+++ b/Simplenote/en.lproj/MainMenu.xib
@@ -530,23 +530,37 @@
                 <menuItem title="View" id="295">
                     <menu key="submenu" title="View" id="296">
                         <items>
-                            <menuItem title="Font Size" id="FPg-7U-5Cl">
+                            <menuItem title="Note Editor" id="oYc-2J-WVc">
                                 <modifierMask key="keyEquivalentModifierMask"/>
-                                <menu key="submenu" title="Font Size" systemMenu="font" id="SxH-2F-lin">
+                                <menu key="submenu" id="o2X-H9-mTR">
                                     <items>
-                                        <menuItem title="Bigger" keyEquivalent="+" id="NAj-hV-Pza">
-                                            <connections>
-                                                <action selector="adjustFontSizeAction:" target="1107" id="JOY-pV-iLX"/>
-                                            </connections>
+                                        <menuItem title="Font Size" id="FPg-7U-5Cl">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Font Size" systemMenu="font" id="SxH-2F-lin">
+                                                <items>
+                                                    <menuItem title="Bigger" keyEquivalent="+" id="NAj-hV-Pza">
+                                                        <connections>
+                                                            <action selector="adjustFontSizeAction:" target="1107" id="JOY-pV-iLX"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Smaller" tag="1" keyEquivalent="-" id="w30-fb-a2C">
+                                                        <connections>
+                                                            <action selector="adjustFontSizeAction:" target="1107" id="6sp-XJ-jIQ"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Reset" tag="2" keyEquivalent="0" id="oS8-Vc-yog">
+                                                        <connections>
+                                                            <action selector="adjustFontSizeAction:" target="1107" id="bbs-YW-9tp"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                </items>
+                                            </menu>
                                         </menuItem>
-                                        <menuItem title="Smaller" tag="1" keyEquivalent="-" id="w30-fb-a2C">
+                                        <menuItem isSeparatorItem="YES" id="byP-HD-jjJ"/>
+                                        <menuItem title="Full Width" id="bBW-To-3v3">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
                                             <connections>
-                                                <action selector="adjustFontSizeAction:" target="1107" id="6sp-XJ-jIQ"/>
-                                            </connections>
-                                        </menuItem>
-                                        <menuItem title="Reset" tag="2" keyEquivalent="0" id="oS8-Vc-yog">
-                                            <connections>
-                                                <action selector="adjustFontSizeAction:" target="1107" id="bbs-YW-9tp"/>
+                                                <action selector="toggleEditorWidth:" target="1107" id="6Mk-ep-n1J"/>
                                             </connections>
                                         </menuItem>
                                     </items>
@@ -1077,6 +1091,7 @@
                 <outlet property="characterCountItem" destination="1606" id="1626"/>
                 <outlet property="collaborateItem" destination="1616" id="1770"/>
                 <outlet property="deleteItem" destination="1655" id="1660"/>
+                <outlet property="editorWidthItem" destination="bBW-To-3v3" id="w4S-Rh-4Sg"/>
                 <outlet property="historyButton" destination="7hm-UJ-0zw" id="i3Y-k0-nZS"/>
                 <outlet property="markdownItem" destination="HN9-TP-CJw" id="JGo-Bq-qMr"/>
                 <outlet property="modifiedItem" destination="1613" id="1628"/>


### PR DESCRIPTION
This PR limits the note editor width to 750px to match the Electron app. Since some users will most likely want the full width editor, I've added an option to the menu so that it can be enabled again.

Before:
<img width="1291" alt="screen shot 2018-08-20 at 12 20 36 pm" src="https://user-images.githubusercontent.com/789137/44363048-d36d0180-a477-11e8-8328-df0ca27c6fc2.png">

After:
<img width="1291" alt="screen shot 2018-08-20 at 12 20 22 pm" src="https://user-images.githubusercontent.com/789137/44363059-d9fb7900-a477-11e8-8296-748422bd96dd.png">

**To Test**
* Open the app, and make the note editor larger than 750px wide. You should see padding to the left and right of the editor content.
* Select View->Note Editor->Full Width. The note editor should go full width.
* The markdown preview should also show the padding or not depending on the full width setting.
* Ensure the editor looks and works properly in Focus Mode with the full width setting enabled and disabled.