### PR TITLE
Hide some toolbar elements when in focus mode

### DIFF
--- a/Simplenote/SPToolbarView.m
+++ b/Simplenote/SPToolbarView.m
@@ -88,7 +88,9 @@
 }
 
 - (void)configureForFocusMode:(BOOL)enabled {
-    [searchField setEnabled:!enabled];
+    [searchField setHidden:enabled];
+    [addButton setHidden:enabled];
+    [splitter setHidden:enabled];
 }
 
 - (void)noNoteLoaded:(id)sender {


### PR DESCRIPTION
Based on design feedback. The search bar, new button and divider in the toolbar will now hide when in focus mode:

<img width="769" alt="screen shot 2018-08-24 at 10 57 43 am" src="https://user-images.githubusercontent.com/789137/44599981-c9efdc00-a78c-11e8-9f6a-9cb05e995060.png">
