### PR TITLE
Make the selected text readable in dark mode

### DIFF
--- a/Simplenote/NoteEditorViewController.m
+++ b/Simplenote/NoteEditorViewController.m
@@ -993,7 +993,18 @@ static NSInteger const SPVersionSliderMaxVersions       = 10;
 		[theNoteEditor addObserver:self forKeyPath:property options:NSKeyValueObservingOptionNew context:nil];
 	}
 	
+    [self setNoteEditorSelectionColors];
+    
 	_noteEditor = theNoteEditor;
+}
+
+- (void)setNoteEditorSelectionColors
+{
+    [self.noteEditor setSelectedTextAttributes:
+     [NSDictionary dictionaryWithObjectsAndKeys:
+      [self.theme colorForKey:@"selectionBackgroundColor"], NSBackgroundColorAttributeName,
+      [self.theme colorForKey:@"selectionTextColor"], NSForegroundColorAttributeName,
+      nil]];
 }
 
 - (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context
@@ -1046,6 +1057,8 @@ static NSInteger const SPVersionSliderMaxVersions       = 10;
     }
     [self.noteEditor setInsertionPointColor:[self.theme colorForKey:@"textColor"]];
     [self.noteEditor setTextColor:[self.theme colorForKey:@"textColor"]];
+    
+    [self setNoteEditorSelectionColors];
 
     [self.bottomBar applyStyle];
     [self.bottomBar setNeedsDisplay:YES];

--- a/Simplenote/Simplenote-DB5.plist
+++ b/Simplenote/Simplenote-DB5.plist
@@ -332,6 +332,10 @@
 		<string>13</string>
 		<key>shareUrlBackgroundColor</key>
 		<string>555555</string>
+		<key>selectionTextColor</key>
+		<string>ffffff</string>
+		<key>selectionBackgroundColor</key>
+		<string>000000</string>
 	</dict>
 	<key>Dark</key>
 	<dict>
@@ -473,6 +477,10 @@
 		<string>000000</string>
 		<key>shareUrlBackgroundColor</key>
 		<string>DDDDDD</string>
+		<key>selectionTextColor</key>
+		<string>000000</string>
+		<key>selectionBackgroundColor</key>
+		<string>ffffff</string>
 	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
Similar issue is already reported here - https://github.com/Automattic/simplenote-macos/issues/207. Therefore, instead of reporting a duplicate issue, I forked and added a simple solution in this pull request to address the readability problem with the selected text in dark mode.

### Problem

As of now, when using SimpleNote app on macOS in dark mode, the selected text is not readable at all as show in the below screenshot (v1.3.6).

![image](https://user-images.githubusercontent.com/876195/44857118-bfea4380-ac8c-11e8-8b9f-bce867c9e37d.png)

### Solution

Please check the following GIF image.

![ly39m5rykq](https://user-images.githubusercontent.com/876195/44857299-16578200-ac8d-11e8-9c77-2e35188bdeb6.gif)
