### PR TITLE
Fix the welcome note reference to the search box location (it's above the note list).

### DIFF
--- a/Simplenote/en.lproj/Localizable.strings
+++ b/Simplenote/en.lproj/Localizable.strings
@@ -12,7 +12,7 @@ To add a note, click the plus button.
 
 To remove a note, click the options button at the top right and choose Move to Trash.
 
-You can search all your notes by typing in the search field at the bottom of the note list.
+You can search all your notes by typing in the search field above the note list.
 
 Click the arrow button at the bottom left to open the sidebar. You can add tags to a note at the bottom of the note editor, and then use the sidebar to help you stay organized.
 


### PR DESCRIPTION
The welcome note indicates that the search box is below the notes list, but it's actually above the notes list.

![screen shot 2018-09-06 at 18 53 10](https://user-images.githubusercontent.com/5273579/45182434-17525b80-b219-11e8-8fb3-a4064e95b462.png)

This change to `en.lproj/Localizable.strings` should fix this.

(This is my first PR for this project so please let me know if I've done anything wrong).