### PR TITLE
Fixing CSS coloring for markdown preview on Mojave.

### DIFF
--- a/DB5/VSTheme.h
+++ b/DB5/VSTheme.h
@@ -26,6 +26,7 @@ typedef NS_ENUM(NSUInteger, VSTextCaseTransform) {
 @property (nonatomic, weak) VSTheme *parentTheme; /*can inherit*/
 
 - (BOOL)boolForKey:(NSString *)key;
+- (BOOL)isMojaveDarkMode;
 - (NSString *)stringForKey:(NSString *)key;
 - (NSInteger)integerForKey:(NSString *)key;
 - (NSNumber *)numberForKey:(NSString *)key;
@@ -40,7 +41,6 @@ typedef NS_ENUM(NSUInteger, VSTextCaseTransform) {
 - (NSTimeInterval)timeIntervalForKey:(NSString *)key;
 
 - (VSTextCaseTransform)textCaseTransformForKey:(NSString *)key; /*lowercase or uppercase -- returns VSTextCaseTransformNone*/
-
 
 - (void)clearCaches;
 

--- a/DB5/VSTheme.m
+++ b/DB5/VSTheme.m
@@ -172,6 +172,16 @@ static NSColor *colorWithHexString(NSString *hexString);
     return nil;
 }
 
+- (BOOL)isMojaveDarkMode {
+    if (@available(macOS 10.14, *)) {
+        NSString *interfaceStyle = [[NSUserDefaults standardUserDefaults] stringForKey:@"AppleInterfaceStyle"];
+        
+        return interfaceStyle != nil && [interfaceStyle isEqualToString:@"Dark"];
+    } else {
+        return NO;
+    }
+}
+
 - (NSEdgeInsets)edgeInsetsForKey:(NSString *)key {
 
 	CGFloat left = [self floatForKey:[key stringByAppendingString:@"Left"]];

--- a/Simplenote/CSS/markdown-dark.css
+++ b/Simplenote/CSS/markdown-dark.css
@@ -19,8 +19,6 @@ img {
 html {
     margin: 0;
     padding: 0;
-    background: #2d3034;
-    color: #dbdee0;
     text-rendering: optimizeLegibility;
 }
 

--- a/Simplenote/CSS/markdown-default.css
+++ b/Simplenote/CSS/markdown-default.css
@@ -19,8 +19,6 @@ img {
 html {
     margin: 0;
     padding: 0;
-    background: #FFFFFF;
-    color: #2d3034;
     text-rendering: optimizeLegibility;
 }
 

--- a/Simplenote/SPMarkdownParser.m
+++ b/Simplenote/SPMarkdownParser.m
@@ -57,8 +57,8 @@
         bgHexColor = theme.isMojaveDarkMode ? @"1e1e1e" : @"FFFFFF";
         textHexColor = theme.isMojaveDarkMode ? @"FFFFFF" : @"000000";
     } else {
-        bgHexColor = theme.isDark ? @"2d3034" : @"dbdee0";
-        textHexColor = theme.isDark ? @"FFFFFF" : @"2d3034";
+        bgHexColor = theme.isDark ? @"2d3034" : @"FFFFFF";
+        textHexColor = theme.isDark ? @"dbdee0" : @"2d3034";
     }
     
     headerStart = [headerStart stringByAppendingString:[NSString stringWithFormat:colorCSS, bgHexColor, textHexColor]];

--- a/Simplenote/SPMarkdownParser.m
+++ b/Simplenote/SPMarkdownParser.m
@@ -47,11 +47,24 @@
         headerStart = [headerStart stringByAppendingString:@".note-detail-markdown { max-width:750px;margin:0 auto; }"];
     }
     
-    NSString *headerEnd = @"</style></head><body><div class=\"note-detail-markdown\"><div id=\"static_content\">";
-    
     VSTheme *theme = [[VSThemeManager sharedManager] theme];
-    NSString *path = [self cssPathForTheme:theme];
     
+    // set main background and font color
+    NSString *colorCSS = @"html { background-color: #%@; color: #%@ }\n";
+    NSString *bgHexColor;
+    NSString *textHexColor;
+    if (@available(macOS 10.14, *)) {
+        bgHexColor = theme.isMojaveDarkMode ? @"1e1e1e" : @"FFFFFF";
+        textHexColor = theme.isMojaveDarkMode ? @"FFFFFF" : @"000000";
+    } else {
+        bgHexColor = theme.isDark ? @"2d3034" : @"dbdee0";
+        textHexColor = theme.isDark ? @"FFFFFF" : @"2d3034";
+    }
+    
+    headerStart = [headerStart stringByAppendingString:[NSString stringWithFormat:colorCSS, bgHexColor, textHexColor]];
+    
+    NSString *headerEnd = @"</style></head><body><div class=\"note-detail-markdown\"><div id=\"static_content\">";
+    NSString *path = [self cssPathForTheme:theme];
     NSString *css = [NSString stringWithContentsOfURL:[[NSBundle mainBundle] URLForResource:path withExtension:nil]
                                              encoding:NSUTF8StringEncoding error:nil];
     
@@ -60,11 +73,11 @@
 
 + (NSString *)cssPathForTheme:(VSTheme *)theme
 {
-    if (theme.isDark) {
-        return @"markdown-dark.css";
-    } else {
-        return @"markdown-default.css";
+    if (@available(macOS 10.14, *)) {
+        return theme.isMojaveDarkMode ? @"markdown-dark.css" : @"markdown-default.css";
     }
+    
+    return theme.isDark ? @"markdown-dark.css" : @"markdown-default.css";
 }
 
 + (NSString *)htmlFooter


### PR DESCRIPTION
The markdown preview was still pulling in the old styles for the preview, so it looked off. It also wasn't loading the correct stylesheet based on whether the dark theme was enabled in Mojave or not.

Unfortunately I didn't see an easy way to get the hex value from the system provided dynamic `NSColor` objects that Apple has added in Mojave. So I hard coded them 👨‍🎨 

**To Test**
* Preview a markdown note in both light and dark mode on Mojave. It should look good!
<img width="729" alt="screen shot 2018-09-20 at 4 11 38 pm" src="https://user-images.githubusercontent.com/789137/45851547-5d66ef00-bcf0-11e8-97e8-f3e20883784b.png">


_Note: I haven't tested this on older macOS versions yet_