### PR TITLE
Tracks: Opt Out

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -33,6 +33,14 @@ DEPENDENCIES:
   - Simperium-OSX (= 0.8.19)
   - Sparkle (= 1.18.1)
 
+SPEC REPOS:
+  https://github.com/cocoapods/specs.git:
+    - CocoaLumberjack
+    - hoedown
+    - Reachability
+    - Simperium-OSX
+    - Sparkle
+
 EXTERNAL SOURCES:
   Automattic-Tracks-OSX:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
@@ -53,4 +61,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 8f9476118ed71d8ae1bbd11cc4c58d884bfbdfcf
 
-COCOAPODS: 1.3.1
+COCOAPODS: 1.5.3

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -863,7 +863,6 @@
 				B5E372CA1896F010005EE097 /* CopyFiles */,
 				B51D44911945FEFD00496889 /* ShellScript */,
 				516D51EC5AEF5EB2EB2C1DE7 /* [CP] Embed Pods Frameworks */,
-				781EA4180C752C2D48538CA0 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -887,7 +886,6 @@
 				B51D44821945EF7900496889 /* ShellScript */,
 				B58CF20C1A8121F000A9B4D2 /* ShellScript */,
 				D70F19DBCBC35255BE560AC0 /* [CP] Embed Pods Frameworks */,
-				BADACE73845227A304509AD9 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -1012,21 +1010,6 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Automattic-Simplenote/Pods-Automattic-Simplenote-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		781EA4180C752C2D48538CA0 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Automattic-Simplenote/Pods-Automattic-Simplenote-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		8346CBC02BCE6435853FB902 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -1083,21 +1066,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "FABRIC_API_KEY=$(defaults read ${SRCROOT}/Simplenote/config.plist FabricApiKey);\nFABRIC_BUILD_KEY=$(defaults read ${SRCROOT}/Simplenote/config.plist FabricBuildKey);\n\nif [ ${FABRIC_API_KEY} == \"not-required\" ] || [ ${FABRIC_BUILD_KEY} == \"not-required\" ]; then\necho \"Could not find fabric keys. Check your config.plist.\";\nexit 0;\nfi\n\n./External/Fabric.framework/run ${FABRIC_API_KEY} ${FABRIC_BUILD_KEY}\n";
-		};
-		BADACE73845227A304509AD9 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Automattic-Simplenote-AppStore/Pods-Automattic-Simplenote-AppStore-resources.sh\"\n";
-			showEnvVarsInLog = 0;
 		};
 		D70F19DBCBC35255BE560AC0 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -202,6 +202,10 @@
 		B5E96B661BDE732500D707F5 /* LoginWindowController.m in Sources */ = {isa = PBXBuildFile; fileRef = B5E96B651BDE732500D707F5 /* LoginWindowController.m */; };
 		B5E96B671BDE732500D707F5 /* LoginWindowController.m in Sources */ = {isa = PBXBuildFile; fileRef = B5E96B651BDE732500D707F5 /* LoginWindowController.m */; };
 		B5EC0C241D0EEF5700818458 /* NSString+Escaping.m in Sources */ = {isa = PBXBuildFile; fileRef = 378E1F741CFCB5A7007486B5 /* NSString+Escaping.m */; };
+		B5F04FCC215949FE004B1AA0 /* Preferences.m in Sources */ = {isa = PBXBuildFile; fileRef = B5F04FCB215949FD004B1AA0 /* Preferences.m */; };
+		B5F04FCD215949FE004B1AA0 /* Preferences.m in Sources */ = {isa = PBXBuildFile; fileRef = B5F04FCB215949FD004B1AA0 /* Preferences.m */; };
+		B5F04FD021594B6D004B1AA0 /* Simperium+Simplenote.m in Sources */ = {isa = PBXBuildFile; fileRef = B5F04FCE21594B6C004B1AA0 /* Simperium+Simplenote.m */; };
+		B5F04FD121594B6D004B1AA0 /* Simperium+Simplenote.m in Sources */ = {isa = PBXBuildFile; fileRef = B5F04FCE21594B6C004B1AA0 /* Simperium+Simplenote.m */; };
 		B5FA829B1B977A1F00082296 /* SPTextLinkifier.m in Sources */ = {isa = PBXBuildFile; fileRef = B5FA829A1B977A1F00082296 /* SPTextLinkifier.m */; };
 		B5FA829C1B977A1F00082296 /* SPTextLinkifier.m in Sources */ = {isa = PBXBuildFile; fileRef = B5FA829A1B977A1F00082296 /* SPTextLinkifier.m */; };
 		B5FA82A41B977E8300082296 /* NSView+Simplenote.m in Sources */ = {isa = PBXBuildFile; fileRef = B5FA82A31B977E8300082296 /* NSView+Simplenote.m */; };
@@ -438,6 +442,11 @@
 		B5D3FCCB201F906E00A813B7 /* StatusChecker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StatusChecker.h; sourceTree = "<group>"; };
 		B5E96B641BDE732500D707F5 /* LoginWindowController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LoginWindowController.h; sourceTree = "<group>"; };
 		B5E96B651BDE732500D707F5 /* LoginWindowController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LoginWindowController.m; sourceTree = "<group>"; };
+		B5F04FC921594980004B1AA0 /* Simplenote 3.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Simplenote 3.xcdatamodel"; sourceTree = "<group>"; };
+		B5F04FCA215949FD004B1AA0 /* Preferences.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Preferences.h; sourceTree = "<group>"; };
+		B5F04FCB215949FD004B1AA0 /* Preferences.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Preferences.m; sourceTree = "<group>"; };
+		B5F04FCE21594B6C004B1AA0 /* Simperium+Simplenote.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "Simperium+Simplenote.m"; sourceTree = "<group>"; };
+		B5F04FCF21594B6D004B1AA0 /* Simperium+Simplenote.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "Simperium+Simplenote.h"; sourceTree = "<group>"; };
 		B5FA82991B977A1F00082296 /* SPTextLinkifier.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPTextLinkifier.h; sourceTree = "<group>"; };
 		B5FA829A1B977A1F00082296 /* SPTextLinkifier.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPTextLinkifier.m; sourceTree = "<group>"; };
 		B5FA82A21B977E8300082296 /* NSView+Simplenote.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSView+Simplenote.h"; sourceTree = "<group>"; };
@@ -672,6 +681,8 @@
 				2614F1DC1405A0B10031AE94 /* Note.m */,
 				2614F1DD1405A0B10031AE94 /* Tag.h */,
 				2614F1DE1405A0B10031AE94 /* Tag.m */,
+				B5F04FCA215949FD004B1AA0 /* Preferences.h */,
+				B5F04FCB215949FD004B1AA0 /* Preferences.m */,
 			);
 			name = Models;
 			sourceTree = "<group>";
@@ -707,6 +718,8 @@
 				B5C92EBF1B03D5E400A4FFD0 /* NSObject+Simplenote.m */,
 				378E1F731CFCB5A7007486B5 /* NSString+Escaping.h */,
 				378E1F741CFCB5A7007486B5 /* NSString+Escaping.m */,
+				B5F04FCF21594B6D004B1AA0 /* Simperium+Simplenote.h */,
+				B5F04FCE21594B6C004B1AA0 /* Simperium+Simplenote.m */,
 			);
 			name = Categories;
 			sourceTree = "<group>";
@@ -1149,6 +1162,7 @@
 				B5C92EC91B03D7DB00A4FFD0 /* NSString+Simplenote.m in Sources */,
 				71233DD614DB6CD000139E61 /* NoteEditorViewController.m in Sources */,
 				37F742EB202A382400A47D3A /* AboutViewController.swift in Sources */,
+				B5F04FCC215949FE004B1AA0 /* Preferences.m in Sources */,
 				B5C92EC01B03D5E400A4FFD0 /* NSObject+Simplenote.m in Sources */,
 				7154812814E5AB6000CB8964 /* autolink.c in Sources */,
 				7154812914E5AB6000CB8964 /* buffer.c in Sources */,
@@ -1172,6 +1186,7 @@
 				3712FC861FE1ACAA008544AC /* Element.swift in Sources */,
 				4623ABDD1773740700CE0441 /* INAppStoreWindow.m in Sources */,
 				4623ABDE1773740700CE0441 /* INWindowButton.m in Sources */,
+				B5F04FD021594B6D004B1AA0 /* Simperium+Simplenote.m in Sources */,
 				B59848821BCDB95A005EFBBE /* SPTracker.m in Sources */,
 				373B50DF20179DFE000568A6 /* Extensions.swift in Sources */,
 				46EF5198177C4ECC00A139E0 /* SPApplication.m in Sources */,
@@ -1234,6 +1249,7 @@
 				B5C92ECA1B03D7DB00A4FFD0 /* NSString+Simplenote.m in Sources */,
 				466FFEBA17CC10A800399652 /* buffer.c in Sources */,
 				37F742EC202A382400A47D3A /* AboutViewController.swift in Sources */,
+				B5F04FCD215949FE004B1AA0 /* Preferences.m in Sources */,
 				B5C92EC11B03D5E400A4FFD0 /* NSObject+Simplenote.m in Sources */,
 				466FFEBB17CC10A800399652 /* houdini_href_e.c in Sources */,
 				466FFEBC17CC10A800399652 /* houdini_html_e.c in Sources */,
@@ -1257,6 +1273,7 @@
 				3712FC871FE1ACAA008544AC /* Element.swift in Sources */,
 				466FFECC17CC10A800399652 /* INAppStoreWindow.m in Sources */,
 				466FFECD17CC10A800399652 /* INWindowButton.m in Sources */,
+				B5F04FD121594B6D004B1AA0 /* Simperium+Simplenote.m in Sources */,
 				B59848831BCDB95A005EFBBE /* SPTracker.m in Sources */,
 				373B50E020179DFE000568A6 /* Extensions.swift in Sources */,
 				466FFECE17CC10A800399652 /* SPApplication.m in Sources */,
@@ -1648,10 +1665,11 @@
 		2614F1E21405A0C60031AE94 /* Simplenote.xcdatamodeld */ = {
 			isa = XCVersionGroup;
 			children = (
+				B5F04FC921594980004B1AA0 /* Simplenote 3.xcdatamodel */,
 				2614F1E31405A0C60031AE94 /* Simplenote 2.xcdatamodel */,
 				2614F1E41405A0C60031AE94 /* Simplenote.xcdatamodel */,
 			);
-			currentVersion = 2614F1E31405A0C60031AE94 /* Simplenote 2.xcdatamodel */;
+			currentVersion = B5F04FC921594980004B1AA0 /* Simplenote 3.xcdatamodel */;
 			path = Simplenote.xcdatamodeld;
 			sourceTree = "<group>";
 			versionGroupType = wrapper.xcdatamodel;

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -206,6 +206,10 @@
 		B5F04FCD215949FE004B1AA0 /* Preferences.m in Sources */ = {isa = PBXBuildFile; fileRef = B5F04FCB215949FD004B1AA0 /* Preferences.m */; };
 		B5F04FD021594B6D004B1AA0 /* Simperium+Simplenote.m in Sources */ = {isa = PBXBuildFile; fileRef = B5F04FCE21594B6C004B1AA0 /* Simperium+Simplenote.m */; };
 		B5F04FD121594B6D004B1AA0 /* Simperium+Simplenote.m in Sources */ = {isa = PBXBuildFile; fileRef = B5F04FCE21594B6C004B1AA0 /* Simperium+Simplenote.m */; };
+		B5F04FD3215964BC004B1AA0 /* Privacy.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B5F04FD2215964BC004B1AA0 /* Privacy.storyboard */; };
+		B5F04FD4215964BC004B1AA0 /* Privacy.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B5F04FD2215964BC004B1AA0 /* Privacy.storyboard */; };
+		B5F04FD621596551004B1AA0 /* PrivacyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5F04FD521596551004B1AA0 /* PrivacyViewController.swift */; };
+		B5F04FD721596551004B1AA0 /* PrivacyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5F04FD521596551004B1AA0 /* PrivacyViewController.swift */; };
 		B5FA829B1B977A1F00082296 /* SPTextLinkifier.m in Sources */ = {isa = PBXBuildFile; fileRef = B5FA829A1B977A1F00082296 /* SPTextLinkifier.m */; };
 		B5FA829C1B977A1F00082296 /* SPTextLinkifier.m in Sources */ = {isa = PBXBuildFile; fileRef = B5FA829A1B977A1F00082296 /* SPTextLinkifier.m */; };
 		B5FA82A41B977E8300082296 /* NSView+Simplenote.m in Sources */ = {isa = PBXBuildFile; fileRef = B5FA82A31B977E8300082296 /* NSView+Simplenote.m */; };
@@ -447,6 +451,8 @@
 		B5F04FCB215949FD004B1AA0 /* Preferences.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Preferences.m; sourceTree = "<group>"; };
 		B5F04FCE21594B6C004B1AA0 /* Simperium+Simplenote.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "Simperium+Simplenote.m"; sourceTree = "<group>"; };
 		B5F04FCF21594B6D004B1AA0 /* Simperium+Simplenote.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "Simperium+Simplenote.h"; sourceTree = "<group>"; };
+		B5F04FD2215964BC004B1AA0 /* Privacy.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Privacy.storyboard; sourceTree = "<group>"; };
+		B5F04FD521596551004B1AA0 /* PrivacyViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyViewController.swift; sourceTree = "<group>"; };
 		B5FA82991B977A1F00082296 /* SPTextLinkifier.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPTextLinkifier.h; sourceTree = "<group>"; };
 		B5FA829A1B977A1F00082296 /* SPTextLinkifier.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPTextLinkifier.m; sourceTree = "<group>"; };
 		B5FA82A21B977E8300082296 /* NSView+Simplenote.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSView+Simplenote.h"; sourceTree = "<group>"; };
@@ -557,6 +563,7 @@
 				37E10E7A20B356E800864E43 /* Tools */,
 				26F72A9314032D2A00A7935E /* Supporting Files */,
 				37F742EA202A382400A47D3A /* AboutViewController.swift */,
+				B5F04FD521596551004B1AA0 /* PrivacyViewController.swift */,
 				26F72A9E14032D2A00A7935E /* SimplenoteAppDelegate.h */,
 				26F72A9F14032D2A00A7935E /* SimplenoteAppDelegate.m */,
 				B543BEA319DDEC1D0051D30C /* SPIntegrityHelper.h */,
@@ -597,6 +604,7 @@
 			isa = PBXGroup;
 			children = (
 				375581C120292AA800529D79 /* About.storyboard */,
+				B5F04FD2215964BC004B1AA0 /* Privacy.storyboard */,
 				37647D71202A500E00B78C74 /* Simplenote-Bridging-Header.h */,
 				378AA6F71ACB04FD00CA87DC /* Simplenote-DB5.plist */,
 				46A0BEB8175BFD540050E864 /* Simplenote.entitlements */,
@@ -959,6 +967,7 @@
 				26F72AA314032D2A00A7935E /* MainMenu.xib in Resources */,
 				3712FCA21FE1ACAA008544AC /* Info.plist in Resources */,
 				4623ABDC1773740700CE0441 /* .gitignore in Resources */,
+				B5F04FD3215964BC004B1AA0 /* Privacy.storyboard in Resources */,
 				37AE49C91FFEBB0B00FCB165 /* markdown-dark.css in Resources */,
 				4623ABDF1773740700CE0441 /* README.md in Resources */,
 				B5686D0E1AEAE6D7009F9E20 /* Images.xcassets in Resources */,
@@ -977,6 +986,7 @@
 				B5B410BF1B17F28500CFCF8D /* Simplenote-DB5.plist in Resources */,
 				466FFEE617CC10A800399652 /* InfoPlist.strings in Resources */,
 				466FFEE717CC10A800399652 /* Credits.rtf in Resources */,
+				B5F04FD4215964BC004B1AA0 /* Privacy.storyboard in Resources */,
 				466FFEE817CC10A800399652 /* MainMenu.xib in Resources */,
 				B5686D0F1AEAE6D7009F9E20 /* Images.xcassets in Resources */,
 				37AE49CA1FFEBB0B00FCB165 /* markdown-dark.css in Resources */,
@@ -1211,6 +1221,7 @@
 				B5E96B661BDE732500D707F5 /* LoginWindowController.m in Sources */,
 				466FFE9F17CAD71800399652 /* NSString+Bullets.m in Sources */,
 				B59E812F1877C802005ADDCF /* JSONKit+Simplenote.m in Sources */,
+				B5F04FD621596551004B1AA0 /* PrivacyViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1298,6 +1309,7 @@
 				B5E96B671BDE732500D707F5 /* LoginWindowController.m in Sources */,
 				466FFEDB17CC10A800399652 /* NSString+Bullets.m in Sources */,
 				B5BD016B1897552500753208 /* JSONKit+Simplenote.m in Sources */,
+				B5F04FD721596551004B1AA0 /* PrivacyViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Simplenote/Preferences.h
+++ b/Simplenote/Preferences.h
@@ -1,0 +1,8 @@
+@import Simperium_OSX.SPManagedObject;
+
+
+@interface Preferences: SPManagedObject
+
+@property (nullable, nonatomic, copy) NSNumber *analytics_enabled;
+
+@end

--- a/Simplenote/Preferences.m
+++ b/Simplenote/Preferences.m
@@ -1,0 +1,13 @@
+#import <Foundation/Foundation.h>
+#import <CoreData/CoreData.h>
+#import "Preferences.h"
+
+
+@implementation Preferences
+
+@dynamic ghostData;
+@dynamic simperiumKey;
+
+@dynamic analytics_enabled;
+
+@end

--- a/Simplenote/Privacy.storyboard
+++ b/Simplenote/Privacy.storyboard
@@ -3,7 +3,6 @@
     <dependencies>
         <deployment identifier="macosx"/>
         <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14313.18"/>
-        <capability name="System colors introduced in macOS 10.14" minToolsVersion="10.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -49,7 +48,7 @@
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" alignment="center" title="Privacy Policy" id="OVa-ev-GZS">
                                                 <font key="font" metaFont="system" size="24"/>
-                                                <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="textColor" red="0.99999600649999998" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
@@ -83,7 +82,7 @@
                                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                         <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Share Analytics" id="j8x-iT-CCF">
                                                             <font key="font" metaFont="system" size="18"/>
-                                                            <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="textColor" red="0.99999600649999998" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                         </textFieldCell>
                                                     </textField>
@@ -124,7 +123,7 @@
                                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                         <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Help us improve Simplenote by sharing usage data with our analytics tool." id="nFg-wt-adX">
                                                             <font key="font" metaFont="system"/>
-                                                            <color key="textColor" name="unemphasizedSelectedTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="textColor" red="0.99999600649999998" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                         </textFieldCell>
                                                     </textField>

--- a/Simplenote/Privacy.storyboard
+++ b/Simplenote/Privacy.storyboard
@@ -1,0 +1,171 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="14313.18" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+    <dependencies>
+        <deployment identifier="macosx"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14313.18"/>
+        <capability name="System colors introduced in macOS 10.14" minToolsVersion="10.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Window Controller-->
+        <scene sceneID="o5x-cC-aBy">
+            <objects>
+                <windowController storyboardIdentifier="PrivacyWindowController" showSeguePresentationStyle="single" id="WZ7-aT-eIa" sceneMemberID="viewController">
+                    <window key="window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="" animationBehavior="default" titleVisibility="hidden" id="2Om-mE-jCO">
+                        <windowStyleMask key="styleMask" titled="YES" closable="YES"/>
+                        <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
+                        <rect key="contentRect" x="294" y="314" width="480" height="270"/>
+                        <rect key="screenRect" x="0.0" y="0.0" width="1920" height="1058"/>
+                        <connections>
+                            <outlet property="delegate" destination="WZ7-aT-eIa" id="Yto-aQ-Y0c"/>
+                        </connections>
+                    </window>
+                    <connections>
+                        <segue destination="MqH-XQ-fgw" kind="relationship" relationship="window.shadowedContentViewController" id="Co6-pk-71t"/>
+                    </connections>
+                </windowController>
+                <customObject id="b1w-eg-TuA" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="28" y="241"/>
+        </scene>
+        <!--Privacy View Controller-->
+        <scene sceneID="4vT-71-Q2U">
+            <objects>
+                <customObject id="b5m-1i-Rei" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
+                <viewController showSeguePresentationStyle="single" id="MqH-XQ-fgw" customClass="PrivacyViewController" customModule="Simplenote" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" id="jNR-As-MxY">
+                        <rect key="frame" x="0.0" y="0.0" width="451" height="318"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                        <subviews>
+                            <box fixedFrame="YES" boxType="custom" borderType="none" translatesAutoresizingMaskIntoConstraints="NO" id="jR0-c5-hne">
+                                <rect key="frame" x="0.0" y="0.0" width="451" height="318"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                <view key="contentView" ambiguous="YES" id="BDM-Ov-qG6">
+                                    <rect key="frame" x="0.0" y="0.0" width="451" height="318"/>
+                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                    <subviews>
+                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" setsMaxLayoutWidthAtFirstLayout="YES" translatesAutoresizingMaskIntoConstraints="NO" id="8xe-xE-uDv">
+                                            <rect key="frame" x="80" y="243" width="291" height="29"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" alignment="center" title="Privacy Policy" id="OVa-ev-GZS">
+                                                <font key="font" metaFont="system" size="24"/>
+                                                <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <box fixedFrame="YES" boxType="custom" borderType="line" translatesAutoresizingMaskIntoConstraints="NO" id="6Nc-En-R6f">
+                                            <rect key="frame" x="82" y="200" width="287" height="1"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <view key="contentView" ambiguous="YES" id="2Kn-8e-Uf4">
+                                                <rect key="frame" x="1" y="1" width="285" height="0.0"/>
+                                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                            </view>
+                                            <color key="borderColor" red="0.45882352939999999" green="0.68627450980000004" blue="0.8862745098" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        </box>
+                                        <box fixedFrame="YES" boxType="custom" borderType="none" title="Box" translatesAutoresizingMaskIntoConstraints="NO" id="UHw-ou-KCK">
+                                            <rect key="frame" x="82" y="135" width="287" height="66"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <view key="contentView" ambiguous="YES" id="ksN-Qa-WYh">
+                                                <rect key="frame" x="0.0" y="0.0" width="287" height="66"/>
+                                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                <subviews>
+                                                    <box fixedFrame="YES" boxType="custom" borderType="line" translatesAutoresizingMaskIntoConstraints="NO" id="ezJ-xe-XlS">
+                                                        <rect key="frame" x="0.0" y="5" width="287" height="1"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <view key="contentView" ambiguous="YES" id="e2g-Su-oaa">
+                                                            <rect key="frame" x="1" y="1" width="285" height="0.0"/>
+                                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                        </view>
+                                                        <color key="borderColor" red="0.45882352939999999" green="0.68627450980000004" blue="0.8862745098" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    </box>
+                                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" setsMaxLayoutWidthAtFirstLayout="YES" translatesAutoresizingMaskIntoConstraints="NO" id="HND-BA-rDk">
+                                                        <rect key="frame" x="-2" y="22" width="271" height="22"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Share Analytics" id="j8x-iT-CCF">
+                                                            <font key="font" metaFont="system" size="18"/>
+                                                            <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="9ge-iF-MGg">
+                                                        <rect key="frame" x="267" y="24" width="22" height="18"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <buttonCell key="cell" type="check" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="6ei-GL-6va">
+                                                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                            <font key="font" metaFont="system"/>
+                                                        </buttonCell>
+                                                        <color key="contentTintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                        <connections>
+                                                            <action selector="checkboxWasPressedWithSender:" target="MqH-XQ-fgw" id="CBZ-LJ-9ys"/>
+                                                        </connections>
+                                                    </button>
+                                                </subviews>
+                                            </view>
+                                            <color key="borderColor" red="0.93731015920000005" green="0.93701523539999998" blue="0.95686823129999998" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                        </box>
+                                        <box fixedFrame="YES" boxType="custom" borderType="none" title="Box" translatesAutoresizingMaskIntoConstraints="NO" id="z3l-Ll-tYB">
+                                            <rect key="frame" x="82" y="72" width="287" height="66"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <view key="contentView" ambiguous="YES" id="K8E-BJ-rCp">
+                                                <rect key="frame" x="0.0" y="0.0" width="287" height="66"/>
+                                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                <subviews>
+                                                    <box fixedFrame="YES" boxType="custom" borderType="line" translatesAutoresizingMaskIntoConstraints="NO" id="fn5-LT-yPF">
+                                                        <rect key="frame" x="0.0" y="5" width="287" height="1"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <view key="contentView" ambiguous="YES" id="Ibg-f7-cRy">
+                                                            <rect key="frame" x="1" y="1" width="285" height="0.0"/>
+                                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                        </view>
+                                                        <color key="borderColor" red="0.45882352939999999" green="0.68627450980000004" blue="0.8862745098" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    </box>
+                                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" setsMaxLayoutWidthAtFirstLayout="YES" translatesAutoresizingMaskIntoConstraints="NO" id="NvX-jo-5we" customClass="SPAboutTextField" customModule="Simplenote" customModuleProvider="target">
+                                                        <rect key="frame" x="-2" y="19" width="244" height="34"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Help us improve Simplenote by sharing usage data with our analytics tool." id="nFg-wt-adX">
+                                                            <font key="font" metaFont="system"/>
+                                                            <color key="textColor" name="unemphasizedSelectedTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="oLM-IY-yTd">
+                                                        <rect key="frame" x="265" y="27" width="22" height="22"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                        <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="icon_arrow_top_right" id="1JP-im-Ces"/>
+                                                        <color key="contentTintColor" red="0.31988218429999998" green="0.51438856119999998" blue="0.73730570080000002" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                                    </imageView>
+                                                </subviews>
+                                            </view>
+                                        </box>
+                                        <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="hie-vG-TWU">
+                                            <rect key="frame" x="290" y="31" width="79" height="21"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <buttonCell key="cell" type="square" title="Dismiss" bezelStyle="shadowlessSquare" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="0Ab-y0-Nnf">
+                                                <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                                <font key="font" metaFont="system"/>
+                                            </buttonCell>
+                                            <color key="contentTintColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
+                                            <connections>
+                                                <action selector="dismissWasPressedWithSender:" target="MqH-XQ-fgw" id="DZB-yg-WO7"/>
+                                            </connections>
+                                        </button>
+                                    </subviews>
+                                </view>
+                                <color key="fillColor" red="0.35608011484146118" green="0.57671457529067993" blue="0.82750791311264038" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                            </box>
+                        </subviews>
+                    </view>
+                    <connections>
+                        <outlet property="aboutImageView" destination="oLM-IY-yTd" id="9HQ-s6-iek"/>
+                        <outlet property="aboutTextField" destination="NvX-jo-5we" id="nAF-2t-GLM"/>
+                        <outlet property="shareEnabledButton" destination="9ge-iF-MGg" id="Wma-dj-3qr"/>
+                    </connections>
+                </viewController>
+            </objects>
+            <point key="canvasLocation" x="713.5" y="117"/>
+        </scene>
+    </scenes>
+    <resources>
+        <image name="icon_arrow_top_right" width="22" height="22"/>
+    </resources>
+</document>

--- a/Simplenote/Privacy.storyboard
+++ b/Simplenote/Privacy.storyboard
@@ -43,10 +43,10 @@
                                     <rect key="frame" x="0.0" y="0.0" width="451" height="318"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
-                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" setsMaxLayoutWidthAtFirstLayout="YES" translatesAutoresizingMaskIntoConstraints="NO" id="8xe-xE-uDv">
+                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" setsMaxLayoutWidthAtFirstLayout="YES" translatesAutoresizingMaskIntoConstraints="NO" id="8xe-xE-uDv" userLabel="Privacy">
                                             <rect key="frame" x="80" y="243" width="291" height="29"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                            <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" alignment="center" title="Privacy Policy" id="OVa-ev-GZS">
+                                            <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" alignment="center" title="Privacy Settings" id="OVa-ev-GZS">
                                                 <font key="font" metaFont="system" size="24"/>
                                                 <color key="textColor" red="0.99999600649999998" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>

--- a/Simplenote/PrivacyViewController.swift
+++ b/Simplenote/PrivacyViewController.swift
@@ -1,0 +1,140 @@
+//
+//  PrivacyViewController.swift
+//  Simplenote
+//
+
+import Cocoa
+
+
+/// Displays the Privacy Settings
+///
+class PrivacyViewController: NSViewController {
+
+    /// Share Button
+    ///
+    @IBOutlet private var shareEnabledButton: NSButton!
+
+    /// About Legend
+    ///
+    @IBOutlet private var aboutTextField: SPAboutTextField!
+
+    /// About Arrow Image
+    ///
+    @IBOutlet private var aboutImageView: NSImageView!
+
+    /// Indicates if Analytics are Enabled
+    ///
+    private var isAnalyticsEnabled: Bool {
+        guard let simperium = SimplenoteAppDelegate.shared()?.simperium, let preferences = simperium.preferencesObject() else {
+            return true
+        }
+
+        return preferences.analytics_enabled?.boolValue ==  true
+    }
+
+    /// Deinitializer!
+    ///
+    deinit {
+        stopListeningForNotifications()
+    }
+
+
+    // MARK: - Overridden Methods
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        refreshInterface()
+        setupGestureRecognizers()
+        startListeningForNotifications()
+    }
+
+
+    /// Updates the Share Button state
+    ///
+    private func refreshInterface() {
+        shareEnabledButton.state = isAnalyticsEnabled ? .on : .off
+    }
+
+    /// Initializes the About TextField / ImageView Click Recognizers
+    ///
+    private func setupGestureRecognizers() {
+        let textfieldRecognizer = NSClickGestureRecognizer(target: self, action: #selector(learnMoreWasPressed))
+        aboutTextField.addGestureRecognizer(textfieldRecognizer)
+
+        let checkboxRecognizer = NSClickGestureRecognizer(target: self, action: #selector(learnMoreWasPressed))
+        aboutImageView.addGestureRecognizer(checkboxRecognizer)
+    }
+}
+
+
+// MARK: - Actions
+//
+extension PrivacyViewController {
+
+    /// Toggles the Share Analytics setting
+    ///
+    @IBAction func checkboxWasPressed(sender: Any) {
+        guard let simperium = SimplenoteAppDelegate.shared()?.simperium, let preferences = simperium.preferencesObject() else {
+            return
+        }
+
+        let isEnabled = shareEnabledButton.state == .on
+        preferences.analytics_enabled = NSNumber(booleanLiteral: isEnabled)
+        simperium.save()
+    }
+
+    /// Opens the Learn More URL
+    ///
+    @IBAction func learnMoreWasPressed(sender: Any) {
+        NSWorkspace.shared.open(URL(string: SPAutomatticAnalyticLearnMoreURL)!)
+    }
+
+    /// Dismisses the associated Window
+    ///
+    @IBAction func dismissWasPressed(sender: Any) {
+        guard let privacyWindow = view.window, let parentWindow = privacyWindow.sheetParent else {
+            return
+        }
+
+        parentWindow.endSheet(privacyWindow)
+    }
+}
+
+
+// MARK: - Notification Helpers
+//
+extension PrivacyViewController {
+
+    /// Starts listening for Privacy Updates
+    ///
+    private func startListeningForNotifications() {
+        let moc = SimplenoteAppDelegate.shared()?.managedObjectContext
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(privacyWasUpdated),
+                                               name: .NSManagedObjectContextObjectsDidChange,
+                                               object: moc)
+    }
+
+    /// Stops listening for Privacy Updates
+    ///
+    private func stopListeningForNotifications() {
+        let moc = SimplenoteAppDelegate.shared()?.managedObjectContext
+        NotificationCenter.default.removeObserver(self, name: .NSManagedObjectContextObjectsDidChange, object: moc)
+    }
+
+    /// Whenever the Privacy object is updated in the main MOC, we'll refresh the Interface
+    ///
+    @objc func privacyWasUpdated(_ notification: Notification) {
+        let updated             = notification.userInfo?[NSUpdatedObjectsKey]   as? Set<NSManagedObject> ?? Set()
+        let refreshed           = notification.userInfo?[NSRefreshedObjectsKey] as? Set<NSManagedObject> ?? Set()
+        let updatedAndRefreshed = updated.union(refreshed)
+
+        guard updatedAndRefreshed.contains(where: { $0 is Preferences }) else {
+            return
+        }
+
+        DispatchQueue.main.async { [weak self] in
+            self?.refreshInterface()
+        }
+    }
+}

--- a/Simplenote/SPConstants.h
+++ b/Simplenote/SPConstants.h
@@ -16,6 +16,9 @@
 
 extern NSString * const SPWelcomeNoteID;
 
+extern NSString * const SPSimperiumPreferencesObjectKey;
+extern NSString * const SPAutomatticAnalyticLearnMoreURL;
+
 extern NSString * const SPSimplenotePublishURL;
 extern NSString * const SPSimplenoteForgotPasswordURL;
 extern NSString * const SPSimplenoteLogoImageName;

--- a/Simplenote/SPConstants.m
+++ b/Simplenote/SPConstants.m
@@ -16,6 +16,9 @@
 
 NSString * const SPWelcomeNoteID                    = @"welcomeNote-Mac";
 
+NSString * const SPSimperiumPreferencesObjectKey    = @"preferences-key";
+NSString * const SPAutomatticAnalyticLearnMoreURL   = @"https://automattic.com/cookies";
+
 NSString * const SPSimplenotePublishURL             = @"http://simp.ly/publish/";
 NSString * const SPSimplenoteForgotPasswordURL      = @"https://app.simplenote.com/forgot/";
 NSString * const SPSimplenoteLogoImageName          = @"logo";

--- a/Simplenote/SPTracker.m
+++ b/Simplenote/SPTracker.m
@@ -231,9 +231,11 @@
 + (void)trackAutomatticEventWithName:(NSString *)name properties:(NSDictionary *)properties
 {
     if ([self isTrackingDisabled]) {
+        NSLog(@"## Disregarding Event %@", name);
         return;
     }
 
+    NSLog(@"## Sending Event %@", name);
     [[SPAutomatticTracker sharedInstance] trackEventWithName:name properties:properties];
 }
 

--- a/Simplenote/SPTracker.m
+++ b/Simplenote/SPTracker.m
@@ -8,6 +8,8 @@
 
 #import "SPTracker.h"
 #import "SPAutomatticTracker.h"
+#import "SimplenoteAppDelegate.h"
+#import "Simperium+Simplenote.h"
 
 
 @implementation SPTracker
@@ -228,7 +230,22 @@
 
 + (void)trackAutomatticEventWithName:(NSString *)name properties:(NSDictionary *)properties
 {
+    if ([self isTrackingDisabled]) {
+        return;
+    }
+
     [[SPAutomatticTracker sharedInstance] trackEventWithName:name properties:properties];
+}
+
+
+#pragma mark - Automattic Tracks Helpers
+
++ (BOOL)isTrackingDisabled
+{
+    Preferences *preferences = [[[SimplenoteAppDelegate sharedDelegate] simperium] preferencesObject];
+    NSNumber *enabled = [preferences analytics_enabled];
+
+    return [enabled boolValue] == false;
 }
 
 @end

--- a/Simplenote/SPTracker.m
+++ b/Simplenote/SPTracker.m
@@ -231,11 +231,9 @@
 + (void)trackAutomatticEventWithName:(NSString *)name properties:(NSDictionary *)properties
 {
     if ([self isTrackingDisabled]) {
-        NSLog(@"## Disregarding Event %@", name);
         return;
     }
 
-    NSLog(@"## Sending Event %@", name);
     [[SPAutomatticTracker sharedInstance] trackEventWithName:name properties:properties];
 }
 

--- a/Simplenote/Simperium+Simplenote.h
+++ b/Simplenote/Simperium+Simplenote.h
@@ -1,0 +1,10 @@
+#import <Foundation/Foundation.h>
+#import "Preferences.h"
+@import Simperium_OSX;
+
+
+@interface Simperium (Simplenote)
+
+- (Preferences *)preferencesObject;
+
+@end

--- a/Simplenote/Simperium+Simplenote.m
+++ b/Simplenote/Simperium+Simplenote.m
@@ -1,0 +1,19 @@
+#import "Simperium+Simplenote.h"
+#import "Simplenote-Swift.h"
+#import "SPConstants.h"
+
+
+@implementation Simperium (Simplenote)
+
+- (Preferences *)preferencesObject
+{
+    SPBucket *bucket = [self bucketForName:NSStringFromClass([Preferences class])];
+    Preferences *preferences = [bucket objectForKey:SPSimperiumPreferencesObjectKey];
+    if (preferences != nil) {
+        return preferences;
+    }
+
+    return [bucket insertNewObjectForKey:SPSimperiumPreferencesObjectKey];
+}
+
+@end

--- a/Simplenote/Simplenote-Bridging-Header.h
+++ b/Simplenote/Simplenote-Bridging-Header.h
@@ -4,3 +4,6 @@
 //
 
 #import "VSThemeManager.h"
+#import "SimplenoteAppDelegate.h"
+#import "Simperium+Simplenote.h"
+#import "SPConstants.h"

--- a/Simplenote/Simplenote.xcdatamodeld/.xccurrentversion
+++ b/Simplenote/Simplenote.xcdatamodeld/.xccurrentversion
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>_XCCurrentVersionName</key>
-	<string>Simplenote 2.xcdatamodel</string>
+	<string>Simplenote 3.xcdatamodel</string>
 </dict>
 </plist>

--- a/Simplenote/Simplenote.xcdatamodeld/Simplenote 3.xcdatamodel/contents
+++ b/Simplenote/Simplenote.xcdatamodeld/Simplenote 3.xcdatamodel/contents
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="14315.18" systemVersion="18A389" minimumToolsVersion="Xcode 7.3" sourceLanguage="Objective-C" userDefinedModelVersionIdentifier="">
+    <entity name="Note" representedClassName="Note" parentEntity="SPManagedObject" syncable="YES">
+        <attribute name="content" attributeType="String" syncable="YES"/>
+        <attribute name="creationDate" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="deleted" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="lastPosition" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO" syncable="YES">
+            <userInfo>
+                <entry key="spDisableSync" value="True"/>
+            </userInfo>
+        </attribute>
+        <attribute name="markdown" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES">
+            <userInfo>
+                <entry key="spDisableSync" value="1"/>
+            </userInfo>
+        </attribute>
+        <attribute name="modificationDate" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="pinned" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES">
+            <userInfo>
+                <entry key="spDisableSync" value="True"/>
+            </userInfo>
+        </attribute>
+        <attribute name="publishURL" attributeType="String" syncable="YES"/>
+        <attribute name="shareURL" attributeType="String" syncable="YES"/>
+        <attribute name="systemTags" optional="YES" attributeType="String" syncable="YES">
+            <userInfo>
+                <entry key="spOverride" value="jsonlist"/>
+            </userInfo>
+        </attribute>
+        <attribute name="tags" optional="YES" attributeType="String" syncable="YES">
+            <userInfo>
+                <entry key="spOverride" value="jsonlist"/>
+            </userInfo>
+        </attribute>
+    </entity>
+    <entity name="Preferences" representedClassName="Preferences" syncable="YES">
+        <attribute name="analytics_enabled" optional="YES" attributeType="Boolean" defaultValueString="YES" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="ghostData" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="simperiumKey" optional="YES" attributeType="String" syncable="YES"/>
+    </entity>
+    <entity name="SPManagedObject" representedClassName="SPEntity" isAbstract="YES" syncable="YES">
+        <attribute name="ghostData" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="simperiumKey" optional="YES" attributeType="String" syncable="YES"/>
+    </entity>
+    <entity name="Tag" representedClassName="Tag" parentEntity="SPManagedObject" syncable="YES">
+        <attribute name="index" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="share" optional="YES" attributeType="String" syncable="YES">
+            <userInfo>
+                <entry key="spOverride" value="jsonlist"/>
+            </userInfo>
+        </attribute>
+    </entity>
+    <elements>
+        <element name="Note" positionX="9" positionY="12" width="128" height="210"/>
+        <element name="SPManagedObject" positionX="7" positionY="-111" width="128" height="75"/>
+        <element name="Tag" positionX="-189" positionY="27" width="128" height="90"/>
+        <element name="Preferences" positionX="-90" positionY="36" width="128" height="90"/>
+    </elements>
+</model>

--- a/Simplenote/SimplenoteAppDelegate.h
+++ b/Simplenote/SimplenoteAppDelegate.h
@@ -40,6 +40,7 @@
 - (IBAction)changeThemeAction:(id)sender;
 - (IBAction)ensureMainWindowIsVisible:(id)sender;
 - (IBAction)aboutAction:(id)sender;
+- (IBAction)privacyAction:(id)sender;
 
 - (void)selectAllNotesTag;
 - (void)selectNoteWithKey:(NSString *)simperiumKey;

--- a/Simplenote/SimplenoteAppDelegate.m
+++ b/Simplenote/SimplenoteAppDelegate.m
@@ -874,10 +874,15 @@
             return nil;
         }
     }
-    
+
+    NSDictionary *options = @{
+      NSMigratePersistentStoresAutomaticallyOption: @(YES),
+      NSInferMappingModelAutomaticallyOption: @(YES)
+    };
+
     NSURL *url = [applicationFilesDirectory URLByAppendingPathComponent:@"Simplenote.storedata"];
     NSPersistentStoreCoordinator *coordinator = [[NSPersistentStoreCoordinator alloc] initWithManagedObjectModel:mom];
-    if (![coordinator addPersistentStoreWithType:NSXMLStoreType configuration:nil URL:url options:nil error:&error]) {
+    if (![coordinator addPersistentStoreWithType:NSXMLStoreType configuration:nil URL:url options:options error:&error]) {
         [[NSApplication sharedApplication] presentError:error];
         return nil;
     }

--- a/Simplenote/SimplenoteAppDelegate.m
+++ b/Simplenote/SimplenoteAppDelegate.m
@@ -72,6 +72,7 @@
 @property (strong, nonatomic) NSBox                             *inactiveOverlayBox;
 @property (strong, nonatomic) NSBox                             *inactiveOverlayTitleBox;
 @property (strong, nonatomic) NSWindowController                *aboutWindowController;
+@property (strong, nonatomic) NSWindowController                *privacyWindowController;
 
 @end
 
@@ -415,6 +416,22 @@
     NSStoryboard *aboutStoryboard = [NSStoryboard storyboardWithName:@"About" bundle:nil];
     self.aboutWindowController = [aboutStoryboard instantiateControllerWithIdentifier:@"AboutWindowController"];
     [self.aboutWindowController showWindow:self];
+}
+
+- (IBAction)privacyAction:(id)sender
+{
+    [self ensureMainWindowIsVisible:sender];
+
+    if (self.privacyWindowController) {
+        [self.privacyWindowController.window makeKeyAndOrderFront:sender];
+        return;
+    }
+
+    NSStoryboard *aboutStoryboard = [NSStoryboard storyboardWithName:@"Privacy" bundle:nil];
+    self.privacyWindowController = [aboutStoryboard instantiateControllerWithIdentifier:@"PrivacyWindowController"];
+    [self.window beginSheet:_privacyWindowController.window completionHandler:^(NSModalResponse returnCode) {
+        self.privacyWindowController = nil;
+    }];
 }
 
 

--- a/Simplenote/en.lproj/MainMenu.xib
+++ b/Simplenote/en.lproj/MainMenu.xib
@@ -250,7 +250,7 @@
                             <menuItem isSeparatorItem="YES" id="144">
                                 <modifierMask key="keyEquivalentModifierMask" command="YES"/>
                             </menuItem>
-                            <menuItem title="Privacy" id="RZM-N8-VLN">
+                            <menuItem title="Privacy Policy" id="RZM-N8-VLN">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>
                                     <action selector="privacyAction:" target="-1" id="EgA-OE-fPn"/>
@@ -752,7 +752,7 @@
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                         <clipView key="contentView" copiesOnScroll="NO" id="UOf-YZ-mq1">
                                             <rect key="frame" x="0.0" y="0.0" width="136" height="618"/>
-                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                            <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnSelection="YES" multipleSelection="NO" emptySelection="NO" autosaveColumns="NO" rowHeight="30" rowSizeStyle="automatic" viewBased="YES" id="1453" customClass="SPTableView">
                                                     <rect key="frame" x="0.0" y="0.0" width="136" height="618"/>
@@ -839,7 +839,7 @@
                                                                             <rect key="frame" x="0.0" y="15" width="151" height="1"/>
                                                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                                             <view key="contentView" id="8LT-ym-mnf">
-                                                                                <rect key="frame" x="1" y="1" width="149" height="0.0"/>
+                                                                                <rect key="frame" x="1" y="0.5" width="149" height="0.0"/>
                                                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                             </view>
                                                                         </box>
@@ -903,7 +903,7 @@
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                         <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="AdS-Q8-czF">
                                             <rect key="frame" x="0.0" y="0.0" width="270" height="618"/>
-                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                            <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="firstColumnOnly" selectionHighlightStyle="sourceList" emptySelection="NO" autosaveColumns="NO" typeSelect="NO" rowHeight="64" rowSizeStyle="automatic" viewBased="YES" floatsGroupRows="NO" id="561" customClass="SPTableView">
                                                     <rect key="frame" x="0.0" y="0.0" width="270" height="606"/>
@@ -998,14 +998,14 @@
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                         <clipView key="contentView" copiesOnScroll="NO" id="LKV-y0-209">
                                             <rect key="frame" x="0.0" y="0.0" width="493" height="575"/>
-                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                            <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <textView drawsBackground="NO" importsGraphics="NO" richText="NO" verticallyResizable="YES" findStyle="panel" incrementalSearchingEnabled="YES" continuousSpellChecking="YES" allowsUndo="YES" allowsNonContiguousLayout="YES" linkDetection="YES" dataDetection="YES" spellingCorrection="YES" smartInsertDelete="YES" id="934" customClass="SPTextView">
                                                     <rect key="frame" x="0.0" y="0.0" width="478" height="575"/>
                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                     <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
                                                     <color key="backgroundColor" red="1" green="0.0" blue="0.0" alpha="0.0" colorSpace="calibratedRGB"/>
-                                                    <size key="minSize" width="478" height="575"/>
+                                                    <size key="minSize" width="493" height="575"/>
                                                     <size key="maxSize" width="10000000" height="10000000"/>
                                                     <color key="insertionPointColor" name="textColor" catalog="System" colorSpace="catalog"/>
                                                     <connections>

--- a/Simplenote/en.lproj/MainMenu.xib
+++ b/Simplenote/en.lproj/MainMenu.xib
@@ -250,7 +250,7 @@
                             <menuItem isSeparatorItem="YES" id="144">
                                 <modifierMask key="keyEquivalentModifierMask" command="YES"/>
                             </menuItem>
-                            <menuItem title="Privacy Policy" id="RZM-N8-VLN">
+                            <menuItem title="Privacy Settings" id="RZM-N8-VLN">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>
                                     <action selector="privacyAction:" target="-1" id="EgA-OE-fPn"/>

--- a/Simplenote/en.lproj/MainMenu.xib
+++ b/Simplenote/en.lproj/MainMenu.xib
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14113" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14313.18" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14113"/>
-        <capability name="box content view" minToolsVersion="7.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14313.18"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -56,7 +55,7 @@
             <rect key="frame" x="0.0" y="0.0" width="901" height="71"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
             <subviews>
-                <box autoresizesSubviews="NO" misplaced="YES" boxType="custom" borderType="line" borderWidth="0.0" title="Box" titlePosition="noTitle" id="1387">
+                <box autoresizesSubviews="NO" boxType="custom" borderType="line" borderWidth="0.0" title="Box" titlePosition="noTitle" id="1387">
                     <rect key="frame" x="393" y="1" width="1" height="70"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES" heightSizable="YES"/>
                     <view key="contentView" id="uXT-Dz-pKp">
@@ -67,7 +66,7 @@
                     <color key="fillColor" white="0.75" alpha="1" colorSpace="calibratedWhite"/>
                     <font key="titleFont" metaFont="system"/>
                 </box>
-                <popUpButton toolTip="Info" misplaced="YES" id="1601" userLabel="Action">
+                <popUpButton toolTip="Info" id="1601" userLabel="Action">
                     <rect key="frame" x="847" y="10" width="44" height="42"/>
                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                     <popUpButtonCell key="cell" type="square" title="Item 1" bezelStyle="shadowlessSquare" imagePosition="only" alignment="center" lineBreakMode="truncatingTail" imageScaling="proportionallyDown" inset="2" pullsDown="YES" arrowPosition="noArrow" autoenablesItems="NO" id="1602">
@@ -107,11 +106,11 @@
                         </menu>
                     </popUpButtonCell>
                 </popUpButton>
-                <progressIndicator wantsLayer="YES" horizontalHuggingPriority="750" verticalHuggingPriority="750" misplaced="YES" maxValue="100" bezeled="NO" indeterminate="YES" controlSize="small" style="spinning" id="1732">
+                <progressIndicator wantsLayer="YES" horizontalHuggingPriority="750" verticalHuggingPriority="750" maxValue="100" bezeled="NO" indeterminate="YES" controlSize="small" style="spinning" id="1732">
                     <rect key="frame" x="413" y="22" width="16" height="16"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                 </progressIndicator>
-                <button toolTip="Show Sidebar" misplaced="YES" id="1680" userLabel="Sidebar">
+                <button toolTip="Show Sidebar" id="1680" userLabel="Sidebar">
                     <rect key="frame" x="20" y="19" width="22" height="22"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                     <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="icon_tags" imagePosition="overlaps" alignment="center" imageScaling="proportionallyDown" inset="2" id="1681">
@@ -122,7 +121,7 @@
                         <action selector="toggleSidebarAction:" target="494" id="1693"/>
                     </connections>
                 </button>
-                <box autoresizesSubviews="NO" misplaced="YES" boxType="custom" borderType="none" titlePosition="noTitle" id="1698">
+                <box autoresizesSubviews="NO" boxType="custom" borderType="none" titlePosition="noTitle" id="1698">
                     <rect key="frame" x="158" y="19" width="190" height="22"/>
                     <view key="contentView" id="qdW-BD-GMh">
                         <rect key="frame" x="0.0" y="0.0" width="190" height="22"/>
@@ -144,7 +143,7 @@
                         </subviews>
                     </view>
                 </box>
-                <button toolTip="Add Note" misplaced="YES" id="987" userLabel="Add">
+                <button toolTip="Add Note" id="987" userLabel="Add">
                     <rect key="frame" x="351" y="19" width="22" height="22"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                     <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="button_new" imagePosition="overlaps" alignment="center" imageScaling="proportionallyDown" inset="2" id="988">
@@ -155,7 +154,7 @@
                         <action selector="addAction:" target="1107" id="1662"/>
                     </connections>
                 </button>
-                <button toolTip="Trash" verticalHuggingPriority="750" misplaced="YES" id="mXz-OM-6A3">
+                <button toolTip="Trash" verticalHuggingPriority="750" id="mXz-OM-6A3">
                     <rect key="frame" x="818" y="19" width="22" height="22"/>
                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                     <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="icon_trash_highlighted" imagePosition="overlaps" alignment="center" imageScaling="proportionallyDown" inset="2" id="ZqN-rU-FdU">
@@ -166,7 +165,7 @@
                         <action selector="deleteAction:" target="1107" id="OgN-ZB-bHH"/>
                     </connections>
                 </button>
-                <button toolTip="History" verticalHuggingPriority="750" misplaced="YES" id="7hm-UJ-0zw">
+                <button toolTip="History" verticalHuggingPriority="750" id="7hm-UJ-0zw">
                     <rect key="frame" x="735" y="19" width="22" height="22"/>
                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                     <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="toolbar_revisions" imagePosition="overlaps" alignment="center" imageScaling="proportionallyDown" inset="2" id="KJV-0C-wVw">
@@ -177,7 +176,7 @@
                         <action selector="showVersionPopover:" target="1107" id="6bi-5c-YJd"/>
                     </connections>
                 </button>
-                <button toolTip="Restore" verticalHuggingPriority="750" misplaced="YES" id="fA9-bG-luR">
+                <button toolTip="Restore" verticalHuggingPriority="750" id="fA9-bG-luR">
                     <rect key="frame" x="818" y="19" width="22" height="22"/>
                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                     <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="toolbar_trash_restore" imagePosition="overlaps" alignment="center" imageScaling="proportionallyDown" inset="2" id="X3f-rW-nRp">
@@ -188,7 +187,7 @@
                         <action selector="restoreAction:" target="1107" id="Vpw-i1-WtF"/>
                     </connections>
                 </button>
-                <button toolTip="Share" verticalHuggingPriority="750" misplaced="YES" id="qmA-vO-wPh">
+                <button toolTip="Share" verticalHuggingPriority="750" id="qmA-vO-wPh">
                     <rect key="frame" x="777" y="19" width="22" height="22"/>
                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                     <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="toolbar_share" imagePosition="overlaps" alignment="center" imageScaling="proportionallyDown" inset="2" id="L1E-HD-wfM">
@@ -199,7 +198,7 @@
                         <action selector="shareNote:" target="1107" id="W9o-Z7-kgJ"/>
                     </connections>
                 </button>
-                <button toolTip="Preview Markdown" verticalHuggingPriority="750" misplaced="YES" id="OMI-hx-wfj">
+                <button toolTip="Preview Markdown" verticalHuggingPriority="750" id="OMI-hx-wfj">
                     <rect key="frame" x="693" y="19" width="22" height="22"/>
                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                     <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="icon_preview" imagePosition="overlaps" alignment="center" imageScaling="proportionallyDown" inset="2" id="Q9W-kz-F4v">
@@ -251,6 +250,13 @@
                             <menuItem isSeparatorItem="YES" id="144">
                                 <modifierMask key="keyEquivalentModifierMask" command="YES"/>
                             </menuItem>
+                            <menuItem title="Privacy" id="RZM-N8-VLN">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="privacyAction:" target="-1" id="EgA-OE-fPn"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="VsX-bn-hbN"/>
                             <menuItem title="Hide Simplenote" keyEquivalent="h" id="134">
                                 <connections>
                                     <action selector="hide:" target="-1" id="367"/>
@@ -768,11 +774,11 @@
                                                             </textFieldCell>
                                                             <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                                             <prototypeCellViews>
-                                                                <tableCellView identifier="AllNotesCell" misplaced="YES" id="1463" customClass="SPTagCellView">
+                                                                <tableCellView identifier="AllNotesCell" id="1463" customClass="SPTagCellView">
                                                                     <rect key="frame" x="0.0" y="2" width="136" height="30"/>
                                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                     <subviews>
-                                                                        <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" misplaced="YES" allowsCharacterPickerTouchBarItem="YES" id="1464" customClass="SPTagTextField">
+                                                                        <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" allowsCharacterPickerTouchBarItem="YES" id="1464" customClass="SPTagTextField">
                                                                             <rect key="frame" x="47" y="7" width="85" height="22"/>
                                                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                                                                             <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Tag Name" placeholderString="" id="1465">
@@ -781,7 +787,7 @@
                                                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                             </textFieldCell>
                                                                         </textField>
-                                                                        <imageView misplaced="YES" id="1473">
+                                                                        <imageView id="1473">
                                                                             <rect key="frame" x="18" y="7" width="22" height="22"/>
                                                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                                                                             <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="icon_all_notes" id="1474"/>
@@ -792,11 +798,11 @@
                                                                         <outlet property="textField" destination="1464" id="1466"/>
                                                                     </connections>
                                                                 </tableCellView>
-                                                                <tableCellView identifier="TrashCell" misplaced="YES" id="1480" customClass="SPTagCellView">
+                                                                <tableCellView identifier="TrashCell" id="1480" customClass="SPTagCellView">
                                                                     <rect key="frame" x="0.0" y="36" width="136" height="30"/>
                                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                     <subviews>
-                                                                        <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" misplaced="YES" allowsCharacterPickerTouchBarItem="YES" id="1482" customClass="SPTagTextField">
+                                                                        <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" allowsCharacterPickerTouchBarItem="YES" id="1482" customClass="SPTagTextField">
                                                                             <rect key="frame" x="47" y="6" width="85" height="22"/>
                                                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                                                                             <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Tag Name" placeholderString="" id="1483">
@@ -805,7 +811,7 @@
                                                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                             </textFieldCell>
                                                                         </textField>
-                                                                        <imageView misplaced="YES" id="1481">
+                                                                        <imageView id="1481">
                                                                             <rect key="frame" x="18" y="7" width="22" height="22"/>
                                                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                                                                             <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="icon_trash" id="1484"/>
@@ -816,11 +822,11 @@
                                                                         <outlet property="textField" destination="1482" id="1485"/>
                                                                     </connections>
                                                                 </tableCellView>
-                                                                <tableCellView identifier="SeparatorCell" misplaced="YES" id="1494" customClass="SPTagCellView">
+                                                                <tableCellView identifier="SeparatorCell" id="1494" customClass="SPTagCellView">
                                                                     <rect key="frame" x="0.0" y="70" width="136" height="36"/>
                                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                     <subviews>
-                                                                        <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" misplaced="YES" allowsCharacterPickerTouchBarItem="YES" id="1496" customClass="SPTagTextField">
+                                                                        <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" allowsCharacterPickerTouchBarItem="YES" id="1496" customClass="SPTagTextField">
                                                                             <rect key="frame" x="20" y="6" width="109" height="24"/>
                                                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                                                                             <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Tag Name" placeholderString="" id="1497">
@@ -829,7 +835,7 @@
                                                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                             </textFieldCell>
                                                                         </textField>
-                                                                        <box misplaced="YES" boxType="custom" borderType="line" id="vWM-3v-GoR">
+                                                                        <box boxType="custom" borderType="line" id="vWM-3v-GoR">
                                                                             <rect key="frame" x="0.0" y="15" width="151" height="1"/>
                                                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                                             <view key="contentView" id="8LT-ym-mnf">
@@ -843,11 +849,11 @@
                                                                         <outlet property="textField" destination="1496" id="1499"/>
                                                                     </connections>
                                                                 </tableCellView>
-                                                                <tableCellView identifier="TagCell" misplaced="YES" id="1487" customClass="SPTagCellView">
+                                                                <tableCellView identifier="TagCell" id="1487" customClass="SPTagCellView">
                                                                     <rect key="frame" x="0.0" y="110" width="136" height="30"/>
                                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                     <subviews>
-                                                                        <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" misplaced="YES" allowsCharacterPickerTouchBarItem="YES" id="1489" customClass="SPTagTextField">
+                                                                        <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" allowsCharacterPickerTouchBarItem="YES" id="1489" customClass="SPTagTextField">
                                                                             <rect key="frame" x="17" y="3" width="103" height="21"/>
                                                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                                                                             <textFieldCell key="cell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" title="Tag Name" placeholderString="" usesSingleLineMode="YES" id="1490">
@@ -874,11 +880,11 @@
                                                 </tableView>
                                             </subviews>
                                         </clipView>
-                                        <scroller key="horizontalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="YES" id="1454">
+                                        <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="1454">
                                             <rect key="frame" x="-100" y="-100" width="152" height="16"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                         </scroller>
-                                        <scroller key="verticalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="NO" id="1456" customClass="MMScroller">
+                                        <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="1456" customClass="MMScroller">
                                             <rect key="frame" x="-100" y="-100" width="16" height="576"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                         </scroller>
@@ -896,17 +902,17 @@
                                         <rect key="frame" x="0.0" y="0.0" width="270" height="618"/>
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                         <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="AdS-Q8-czF">
-                                            <rect key="frame" x="0.0" y="0.0" width="255" height="618"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="270" height="618"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
                                                 <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="firstColumnOnly" selectionHighlightStyle="sourceList" emptySelection="NO" autosaveColumns="NO" typeSelect="NO" rowHeight="64" rowSizeStyle="automatic" viewBased="YES" floatsGroupRows="NO" id="561" customClass="SPTableView">
-                                                    <rect key="frame" x="0.0" y="0.0" width="255" height="606"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="270" height="606"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <size key="intercellSpacing" width="0.0" height="8"/>
                                                     <color key="backgroundColor" red="1" green="0.0" blue="0.0" alpha="0.0" colorSpace="calibratedRGB"/>
                                                     <color key="gridColor" white="0.94999999999999996" alpha="1" colorSpace="deviceWhite"/>
                                                     <tableColumns>
-                                                        <tableColumn identifier="" width="255" maxWidth="10000000" id="565">
+                                                        <tableColumn width="270" maxWidth="10000000" id="565">
                                                             <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left">
                                                                 <font key="font" metaFont="smallSystem"/>
                                                                 <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
@@ -921,11 +927,11 @@
                                                             <tableColumnResizingMask key="resizingMask" resizeWithTable="YES"/>
                                                             <prototypeCellViews>
                                                                 <tableCellView identifier="CustomCell" id="607" customClass="SPNoteCellView">
-                                                                    <rect key="frame" x="0.0" y="4" width="255" height="64"/>
+                                                                    <rect key="frame" x="0.0" y="4" width="270" height="64"/>
                                                                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMaxX="YES" flexibleMinY="YES" heightSizable="YES" flexibleMaxY="YES"/>
                                                                     <subviews>
                                                                         <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" allowsCharacterPickerTouchBarItem="YES" id="1103">
-                                                                            <rect key="frame" x="18" y="0.0" width="229" height="59"/>
+                                                                            <rect key="frame" x="18" y="0.0" width="244" height="59"/>
                                                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES" heightSizable="YES"/>
                                                                             <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="This is some text in a note that is long enough to allow us to preview what it will look like inside the app." placeholderString="" allowsEditingTextAttributes="YES" id="1104">
                                                                                 <font key="font" size="12" name="Helvetica"/>
@@ -956,12 +962,12 @@
                                         </clipView>
                                         <edgeInsets key="contentInsets" left="0.0" right="0.0" top="12" bottom="0.0"/>
                                         <edgeInsets key="scrollerInsets" left="0.0" right="0.0" top="-12" bottom="0.0"/>
-                                        <scroller key="horizontalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="YES" id="562">
+                                        <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="562">
                                             <rect key="frame" x="-100" y="-100" width="235" height="15"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                         </scroller>
-                                        <scroller key="verticalScroller" verticalHuggingPriority="750" horizontal="NO" id="564" customClass="MMScroller">
-                                            <rect key="frame" x="255" y="0.0" width="15" height="618"/>
+                                        <scroller key="verticalScroller" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="564" customClass="MMScroller">
+                                            <rect key="frame" x="254" y="0.0" width="16" height="618"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                         </scroller>
                                         <connections>
@@ -987,20 +993,21 @@
                                         <rect key="frame" x="0.0" y="0.0" width="493" height="44"/>
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                                     </customView>
-                                    <scrollView misplaced="YES" borderType="none" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" horizontalScrollElasticity="none" id="933" customClass="MMScrollView">
+                                    <scrollView borderType="none" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" horizontalScrollElasticity="none" id="933" customClass="MMScrollView">
                                         <rect key="frame" x="0.0" y="43" width="493" height="575"/>
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                         <clipView key="contentView" copiesOnScroll="NO" id="LKV-y0-209">
-                                            <rect key="frame" x="0.0" y="0.0" width="478" height="575"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="493" height="575"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
                                                 <textView drawsBackground="NO" importsGraphics="NO" richText="NO" verticallyResizable="YES" findStyle="panel" incrementalSearchingEnabled="YES" continuousSpellChecking="YES" allowsUndo="YES" allowsNonContiguousLayout="YES" linkDetection="YES" dataDetection="YES" spellingCorrection="YES" smartInsertDelete="YES" id="934" customClass="SPTextView">
                                                     <rect key="frame" x="0.0" y="0.0" width="478" height="575"/>
                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                    <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
                                                     <color key="backgroundColor" red="1" green="0.0" blue="0.0" alpha="0.0" colorSpace="calibratedRGB"/>
                                                     <size key="minSize" width="478" height="575"/>
                                                     <size key="maxSize" width="10000000" height="10000000"/>
-                                                    <color key="insertionPointColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
+                                                    <color key="insertionPointColor" name="textColor" catalog="System" colorSpace="catalog"/>
                                                     <connections>
                                                         <outlet property="delegate" destination="1107" id="1142"/>
                                                     </connections>
@@ -1008,12 +1015,12 @@
                                             </subviews>
                                             <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                         </clipView>
-                                        <scroller key="horizontalScroller" hidden="YES" verticalHuggingPriority="750" doubleValue="1" horizontal="YES" id="935">
+                                        <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" doubleValue="1" horizontal="YES" id="935">
                                             <rect key="frame" x="-100" y="-100" width="87" height="18"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                         </scroller>
-                                        <scroller key="verticalScroller" verticalHuggingPriority="750" horizontal="NO" id="936" customClass="MMScroller">
-                                            <rect key="frame" x="478" y="0.0" width="15" height="575"/>
+                                        <scroller key="verticalScroller" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="936" customClass="MMScroller">
+                                            <rect key="frame" x="477" y="0.0" width="16" height="575"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                         </scroller>
                                     </scrollView>


### PR DESCRIPTION
### Details:
This PR implements Tracks Opt Out, via Simperium Sync, and a super simple Privacy UI (based on the About UI).

@roundhill i'd be more than happy to twean the Privacy UI, as needed. Screenshots below (Dark / Light mode in Mojave).

Thanks in advance!!!

Closes #238

### Scenario: Sync'ing
1. Launch the latest iOS Version (with the Privacy Settings)
2. Launch Simplenote macOS and open the Privacy Settings
3. Toggle iOS's Privacy settings
4. Verify macOS nearly instantaneously refreshes, and displays the new setting

### Scenario: Learn More
1. Launch Simplenote Mac
2. Open the Privacy Settings
3. Click over the `Help us improve (...)` Label (or right image)
4. Verify Safari shows up with our Privacy Policy

### Scenario: Opt Out
1. Check out this commit: [2aa1b8e](
https://github.com/Automattic/simplenote-macos/pull/242/commits/2aa1b8e574e7ae2bb56c5ef0fca4b663b2e75ca5)
2. Enable the Tracks Opt Out
3. Trigger anything that might result in an event (ie. open a note)
4. Verify the following shows up in the console: `## Disregarding Event (...)`
5. Enable Tracks
6. Trigger something that might result in an event (ie. open a note)
7. Verify the following shows up in the console: `## Sending Event (...)`


---

<img width="1176" alt="screen shot 2018-09-25 at 11 25 15 am" src="https://user-images.githubusercontent.com/1195260/46020861-b7cbcb00-c0b5-11e8-8df1-bb290b2eb535.png">

<img width="1176" alt="screen shot 2018-09-25 at 11 25 35 am" src="https://user-images.githubusercontent.com/1195260/46020888-c31ef680-c0b5-11e8-8df3-b311d5fe9940.png">