### PR TITLE
Fix Undo Manager Crash

### DIFF
--- a/Simplenote/NSTextView+Simplenote.h
+++ b/Simplenote/NSTextView+Simplenote.h
@@ -10,7 +10,7 @@
 
 @interface NSTextView (Simplenote)
 
-- (BOOL)applyAutoBulletsWithReplacementText:(NSString *)replacementText replacementRange:(NSRange)replacementRange;
+- (BOOL)applyAutoBulletsForTabPress: (BOOL)isTabPress;
 - (NSRange)visibleTextRange;
 
 @end

--- a/Simplenote/NSTextView+Simplenote.h
+++ b/Simplenote/NSTextView+Simplenote.h
@@ -10,7 +10,8 @@
 
 @interface NSTextView (Simplenote)
 
-- (BOOL)applyAutoBulletsForTabPress: (BOOL)isTabPress;
+- (BOOL)applyAutoBulletsAfterTabPressed;
+- (BOOL)applyAutoBulletsAfterReturnPressed;
 - (NSRange)visibleTextRange;
 
 @end

--- a/Simplenote/NSTextView+Simplenote.m
+++ b/Simplenote/NSTextView+Simplenote.m
@@ -59,7 +59,7 @@
         insertionString                 = [NSString.tabString stringByAppendingString:lineString];
         currentRange.location           += NSString.tabString.length;
         
-        // Empty Line: Remove the bullet
+    // Empty Line: Remove the bullet
     } else if (cleanLineString.length == 1) {
         insertionString                 = [NSString newLineString];
         currentRange.location           -= lineRange.length - 1;

--- a/Simplenote/NSTextView+Simplenote.m
+++ b/Simplenote/NSTextView+Simplenote.m
@@ -17,7 +17,17 @@
 
 @implementation NSTextView (Simplenote)
 
-- (BOOL)applyAutoBulletsForTabPress: (BOOL)isTabPress
+- (BOOL)applyAutoBulletsAfterTabPressed
+{
+    return [self applyAutoBulletsForKeyPress:YES];
+}
+
+- (BOOL)applyAutoBulletsAfterReturnPressed
+{
+    return [self applyAutoBulletsForKeyPress:NO];
+}
+
+- (BOOL)applyAutoBulletsForKeyPress: (BOOL)isTabPress
 {
     // Determine what kind of bullet we should insert
     NSRange currentRange                = self.selectedRange;

--- a/Simplenote/NSTextView+Simplenote.m
+++ b/Simplenote/NSTextView+Simplenote.m
@@ -47,7 +47,6 @@
     NSInteger indexOfBullet             = [lineString rangeOfString:stringToAppendToNewLine].location;
     NSString *insertionString           = nil;
     NSRange insertionRange              = lineRange;
-    NSRange newSelectedRange            = self.selectedRange;
     
     // Tab entered: Move the bullet along
     if (replacementText.isTabString) {
@@ -62,12 +61,10 @@
         }
         
         insertionString                 = [replacementText stringByAppendingString:lineString];
-        newSelectedRange.location       += replacementText.length;
         
     // Empty Line: Remove the bullet
     } else if (cleanLineString.length == 1) {
         insertionString                 = [NSString newLineString];
-        newSelectedRange.location       -= lineRange.length - 1;
         
     // Attempt to apply the bullet
     } else  {
@@ -89,7 +86,6 @@
         // Replace!
         insertionString                 = [[NSString newLineString] stringByAppendingString:stringToAppendToNewLine];
         insertionRange                  = replacementRange;
-        newSelectedRange.location       += insertionString.length;
     }
     
     // Apply the Replacements
@@ -97,9 +93,6 @@
     [storage beginEditing];
     [storage replaceCharactersInRange:insertionRange withString:insertionString];
     [storage endEditing];
-    
-    // Update the Selected Range (If needed)
-    [self setSelectedRange:newSelectedRange];
     
     // Signal that the text was changed!
     NSNotification *note = [NSNotification notificationWithName:NSTextDidChangeNotification object:nil];

--- a/Simplenote/NoteEditorViewController.m
+++ b/Simplenote/NoteEditorViewController.m
@@ -440,9 +440,9 @@ static NSInteger const SPVersionSliderMaxVersions       = 10;
 
 - (BOOL)textView:(NSTextView *)textView doCommandBySelector:(SEL)selector {
     if (selector == @selector(insertNewline:)) {
-        return [_noteEditor applyAutoBulletsForTabPress:NO];
+        return [_noteEditor applyAutoBulletsAfterReturnPressed];
     } else if (selector == @selector(insertTab:)) {
-        return [_noteEditor applyAutoBulletsForTabPress:YES];
+        return [_noteEditor applyAutoBulletsAfterTabPressed];
     }
     
     return NO;

--- a/Simplenote/NoteEditorViewController.m
+++ b/Simplenote/NoteEditorViewController.m
@@ -438,12 +438,14 @@ static NSInteger const SPVersionSliderMaxVersions       = 10;
 
 #pragma mark - Text Delegates
 
-- (BOOL)textView:(NSTextView *)textView shouldChangeTextInRange:(NSRange)range replacementString:(NSString *)text
-{
-    // Apply Autobullets if needed
-    BOOL appliedAutoBullets = [self.noteEditor applyAutoBulletsWithReplacementText:text replacementRange:range];
-
-    return !appliedAutoBullets;
+- (BOOL)textView:(NSTextView *)textView doCommandBySelector:(SEL)selector {
+    if (selector == @selector(insertNewline:)) {
+        return [_noteEditor applyAutoBulletsForTabPress:NO];
+    } else if (selector == @selector(insertTab:)) {
+        return [_noteEditor applyAutoBulletsForTabPress:YES];
+    }
+    
+    return NO;
 }
 
 - (void)textDidChange:(NSNotification *)notification


### PR DESCRIPTION
~~#31 was caused when we attempted to restore the text selection when applying `auto bulleting`. I couldn't think of a scenario where we would _want_ the text selection to be preserved? So I just removed it~~

After lots and lots of debugging, I believe #31 was caused because we were modifying the text from within `shouldReplaceCharactersInRange`, which is bad because we shouldn't be messing with the state of the text there. I've instead listened for when the user enters a newline or tab key, then use `insertText` which will correctly set the undo state.

**To Test**
* Create an autobulleted list.
* Select a few of the items in the list, and press `return` to clear them out.
* The text should be deleted and a new auto-bullet should be in its place.
* Undo/redo should work.
* Press the tab key while within a bulleted line. It should indent the bullet and preserve the cursor position.
