### PR TITLE
Allow Theme Selection to Override System Theme Setting

### DIFF
--- a/DB5/VSThemeManager.h
+++ b/DB5/VSThemeManager.h
@@ -22,5 +22,6 @@ extern NSString *const VSThemeManagerThemePrefKey;
 - (VSThemeLoader *)themeLoader;
 
 - (void)swapTheme:(NSString *)theme;
+- (BOOL)isDarkMode;
 
 @end

--- a/DB5/VSThemeManager.m
+++ b/DB5/VSThemeManager.m
@@ -79,4 +79,16 @@ NSString *const VSThemeManagerThemePrefKey = @"VSThemeManagerThemePrefKey";
     }
 }
 
+- (BOOL)isDarkMode {
+    BOOL isDarkTheme = [self.theme boolForKey:@"dark"];
+    if (@available(macOS 10.14, *)) {
+        if (![[NSUserDefaults standardUserDefaults] stringForKey:VSThemeManagerThemePrefKey]) {
+            // Theme pref was never set, so default to system theme setting
+            isDarkTheme = [self.theme isMojaveDarkMode];
+        }
+    }
+    
+    return isDarkTheme;
+}
+
 @end

--- a/Simplenote/SPWindow.h
+++ b/Simplenote/SPWindow.h
@@ -16,4 +16,6 @@
 
 @interface SPWindow : INAppStoreWindow
 
+- (void)sp_layoutButtons;
+
 @end

--- a/Simplenote/SPWindow.h
+++ b/Simplenote/SPWindow.h
@@ -16,6 +16,6 @@
 
 @interface SPWindow : INAppStoreWindow
 
-- (void)sp_layoutButtons;
+- (void)applyMojaveThemeOverrideIfNecessary;
 
 @end

--- a/Simplenote/SPWindow.m
+++ b/Simplenote/SPWindow.m
@@ -7,7 +7,7 @@
 //
 
 #import "SPWindow.h"
-
+#import "VSThemeManager.h"
 
 
 #pragma mark ====================================================================================
@@ -29,6 +29,8 @@
         [self startListeningToNotifications];
     }
     
+    [self applyMojaveThemeOverrideIfNecessary];
+    
     return self;
 }
 
@@ -39,6 +41,8 @@
         [self setupTitle];
         [self startListeningToNotifications];
     }
+    
+    [self applyMojaveThemeOverrideIfNecessary];
     
     return self;
 }
@@ -179,6 +183,22 @@
         NSRect buttonFrame      = button.frame;
         buttonFrame.origin.y    = floor((self.titleBarHeight - buttonFrame.size.height) * 0.9f);
         button.frame            = buttonFrame;
+    }
+}
+
+- (void)applyMojaveThemeOverrideIfNecessary
+{
+    // Apply a theme override if necessary for >= 10.14
+    if (@available(macOS 10.14, *)) {
+        NSString *themeName = [[NSUserDefaults standardUserDefaults] objectForKey:VSThemeManagerThemePrefKey];
+        if (themeName) {
+            self.appearance = [NSAppearance appearanceNamed:
+                              [themeName isEqualToString:@"dark"] ?
+                                 NSAppearanceNameDarkAqua : NSAppearanceNameAqua];
+        }
+        
+        // Delay needed here in order to properly adjust the stoplight buttons after theme changes
+        [self performSelector:@selector(sp_layoutButtons) withObject:nil afterDelay:0.1f];
     }
 }
 

--- a/Simplenote/SimplenoteAppDelegate.m
+++ b/Simplenote/SimplenoteAppDelegate.m
@@ -156,8 +156,6 @@
                       andSelector:@selector(handleGetURLEvent:withReplyEvent:)
                     forEventClass:kInternetEventClass
                        andEventID:kAEGetURL];
-    
-    [self applyMojaveThemeOverrideIfNecessary];
 }
 
 - (void)applicationDidFinishLaunching:(NSNotification *)aNotification
@@ -777,30 +775,6 @@
     [self updateThemeMenuForPosition:[sender tag]];
 }
 
-- (void)applyMojaveThemeOverrideIfNecessary
-{
-    // Apply a theme override if necessary for >= 10.14
-    if (@available(macOS 10.14, *)) {
-        NSString *themeName = [[NSUserDefaults standardUserDefaults] objectForKey:VSThemeManagerThemePrefKey];
-        if (themeName) {
-            NSApplication *app = [NSApplication sharedApplication];
-            app.appearance = [NSAppearance appearanceNamed:
-                              [themeName isEqualToString:@"dark"] ?
-                                 NSAppearanceNameDarkAqua : NSAppearanceNameAqua];
-        }
-    
-        // Delay needed here in order to properly adjust the stoplight buttons after theme changes
-        [self performSelector:@selector(adjustWindowButtons) withObject:nil afterDelay:0.1f];
-    }
-}
-
-// Adjusts the position of the 'stoplight' buttons in the window
-- (void)adjustWindowButtons
-{
-    SPWindow *customWindow = (SPWindow *)self.window;
-    [customWindow sp_layoutButtons];
-}
-
 - (void)updateThemeMenuForPosition:(NSInteger)position
 {
     for (NSMenuItem *menuItem in themeMenu.itemArray) {
@@ -815,7 +789,8 @@
 - (void)applyStyle
 {
     if (@available(macOS 10.14, *)) {
-        [self applyMojaveThemeOverrideIfNecessary];
+        SPWindow *window = (SPWindow *)self.window;
+        [window applyMojaveThemeOverrideIfNecessary];
         return;
     }
     

--- a/Simplenote/SimplenoteAppDelegate.m
+++ b/Simplenote/SimplenoteAppDelegate.m
@@ -169,14 +169,7 @@
     [self configureWindow];
     [self hookWindowNotifications];
 
-    BOOL isDarkTheme = [self.theme boolForKey:@"dark"];
-    if (@available(macOS 10.14, *)) {
-        if (![[NSUserDefaults standardUserDefaults] stringForKey:VSThemeManagerThemePrefKey]) {
-            // Theme pref was never set, so default to system theme setting
-            isDarkTheme = [self.theme isMojaveDarkMode];
-        }
-    }
-    [self updateThemeMenuForPosition:isDarkTheme ? 1 : 0];
+    [self updateThemeMenuForPosition:[[VSThemeManager sharedManager] isDarkMode] ? 1 : 0];
     [self applyStyle];
     
 	self.simperium = [self configureSimperium];


### PR DESCRIPTION
Brings back the theme menu in macOS >= 10.14 that will override the system theme setting. It will only override once the user actively changes the theme setting, otherwise it just obeys the global macOS setting.

**To Test**
* On Mojave, use the theme menu to change the theme. It should persist when you restart the app.
* In `applicationDidFinishLaunching`, add this line to simulate that you've never selected a theme setting: `[[NSUserDefaults standardUserDefaults] removeObjectForKey:VSThemeManagerThemePrefKey];`
* Verify that switching the global mojave theme also changes the theme in Simplenote.

I've tested this on macOS 10.10 and it still works as expected there as well.

Fixes #245.