### PR TITLE
Fix unreadable login fields when in dark mode

### DIFF
--- a/Simplenote/LoginWindowController.m
+++ b/Simplenote/LoginWindowController.m
@@ -19,6 +19,11 @@ static NSString *SPAuthSessionKey                   = @"SPAuthSessionKey";
 - (instancetype)init {
     self = [super init];
     
+    // We want the login window to always have the 'light' aqua appearance
+    if (@available(macOS 10.14, *)) {
+        self.window.appearance = [NSAppearance appearanceNamed:NSAppearanceNameAqua];
+    }
+    
     // Sanity check for accessing the root view
     if (self.window.contentView.subviews.count < 1) {
         return self;

--- a/Simplenote/Simplenote-Info-Hockey.plist
+++ b/Simplenote/Simplenote-Info-Hockey.plist
@@ -38,7 +38,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>1380</string>
+	<string>1381</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.productivity</string>
 	<key>LSMinimumSystemVersion</key>

--- a/Simplenote/Simplenote-Info.plist
+++ b/Simplenote/Simplenote-Info.plist
@@ -38,7 +38,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>1380</string>
+	<string>1381</string>
 	<key>Fabric</key>
 	<dict>
 		<key>APIKey</key>


### PR DESCRIPTION
Enforce the light aqua appearance for the login window. 

Before (with dark mode enabled):
<img width="376" alt="screen shot 2018-10-09 at 4 41 44 pm" src="https://user-images.githubusercontent.com/789137/46705057-b2f13600-cbe2-11e8-8706-b64b37f3f2fc.png">

After:
<img width="376" alt="screen shot 2018-10-09 at 4 42 44 pm" src="https://user-images.githubusercontent.com/789137/46705067-c0a6bb80-cbe2-11e8-876d-7ac7d3623424.png">
