### PR TITLE
Allow user to reset to system appearance setting

### DIFF
--- a/DB5/VSThemeManager.h
+++ b/DB5/VSThemeManager.h
@@ -23,5 +23,6 @@ extern NSString *const VSThemeManagerThemePrefKey;
 
 - (void)swapTheme:(NSString *)theme;
 - (BOOL)isDarkMode;
+- (BOOL)isMojaveWithNoThemeSet;
 
 @end

--- a/DB5/VSThemeManager.m
+++ b/DB5/VSThemeManager.m
@@ -91,4 +91,12 @@ NSString *const VSThemeManagerThemePrefKey = @"VSThemeManagerThemePrefKey";
     return isDarkTheme;
 }
 
+- (BOOL)isMojaveWithNoThemeSet {
+    if (@available(macOS 10.14, *)) {
+        return [[NSUserDefaults standardUserDefaults] stringForKey:VSThemeManagerThemePrefKey] == nil;
+    }
+    
+    return NO;
+}
+
 @end

--- a/Simplenote/Simplenote-Info-Hockey.plist
+++ b/Simplenote/Simplenote-Info-Hockey.plist
@@ -21,7 +21,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.3.8</string>
+	<string>1.3.9</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -38,7 +38,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>1382</string>
+	<string>1390</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.productivity</string>
 	<key>LSMinimumSystemVersion</key>

--- a/Simplenote/Simplenote-Info.plist
+++ b/Simplenote/Simplenote-Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.3.8</string>
+	<string>1.3.9</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -38,7 +38,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>1382</string>
+	<string>1390</string>
 	<key>Fabric</key>
 	<dict>
 		<key>APIKey</key>

--- a/Simplenote/SimplenoteAppDelegate.m
+++ b/Simplenote/SimplenoteAppDelegate.m
@@ -46,6 +46,7 @@
 #define kFirstLaunchKey					@"SPFirstLaunch"
 #define kMinimumNoteListSplit			240
 #define kMaximumNoteListSplit			384
+#define kDefaultThemeAppearanceTag      2
 
 
 #pragma mark ====================================================================================
@@ -167,7 +168,12 @@
     [self configureWindow];
     [self hookWindowNotifications];
 
-    [self updateThemeMenuForPosition:[[VSThemeManager sharedManager] isDarkMode] ? 1 : 0];
+    VSThemeManager *themeManager = [VSThemeManager sharedManager];
+    if ([themeManager isMojaveWithNoThemeSet]) {
+        [self updateThemeMenuForPosition:kDefaultThemeAppearanceTag];
+    } else {
+        [self updateThemeMenuForPosition:[[VSThemeManager sharedManager] isDarkMode] ? 1 : 0];
+    }
     [self applyStyle];
     
 	self.simperium = [self configureSimperium];
@@ -228,6 +234,16 @@
     [self.textViewParent addSubview:markdownView];
     self.noteEditorViewController.markdownView = markdownView;
     [markdownView setNavigationDelegate:self.noteEditorViewController];
+    
+    // Add the System Appearance menu item to the 'Theme' menu on Mojave or later
+    if (@available(macOS 10.14, *)) {
+        NSMenuItem *separatorItem = [NSMenuItem separatorItem];
+        [themeMenu addItem:separatorItem];
+        
+        NSMenuItem *systemDefaultItem = [[NSMenuItem alloc] initWithTitle:NSLocalizedString(@"System Appearance", @"Menu item for using default macOS theme appearance.") action:@selector(changeThemeAction:) keyEquivalent:@""];
+        systemDefaultItem.tag = kDefaultThemeAppearanceTag;
+        [themeMenu addItem:systemDefaultItem];
+    }
 
     [self configureToolbar];
 }
@@ -767,11 +783,20 @@
     if (item.state == NSOnState) {
         return;
     }
-
-    NSString *newTheme = ([sender tag] == 0) ? @"default" : @"dark";
     
-    [SPTracker trackSettingsThemeUpdated:newTheme];
-    [[VSThemeManager sharedManager] swapTheme:newTheme];
+    if ([sender tag] == kDefaultThemeAppearanceTag) {
+        // Resetting to default macOS theme appearance
+        [[NSUserDefaults standardUserDefaults] removeObjectForKey:VSThemeManagerThemePrefKey];
+        if (@available(macOS 10.14, *)) {
+            BOOL isMojaveDarkMode = [[[VSThemeManager sharedManager] theme] isMojaveDarkMode];
+            self.window.appearance = [NSAppearance appearanceNamed: isMojaveDarkMode ? NSAppearanceNameDarkAqua : NSAppearanceNameAqua];
+        }
+    } else {
+        NSString *newTheme = ([sender tag] == 0) ? @"default" : @"dark";
+        [SPTracker trackSettingsThemeUpdated:newTheme];
+        [[VSThemeManager sharedManager] swapTheme:newTheme];
+    }
+    
     [self updateThemeMenuForPosition:[sender tag]];
 }
 

--- a/Simplenote/SimplenoteAppDelegate.m
+++ b/Simplenote/SimplenoteAppDelegate.m
@@ -788,8 +788,9 @@
         // Resetting to default macOS theme appearance
         [[NSUserDefaults standardUserDefaults] removeObjectForKey:VSThemeManagerThemePrefKey];
         if (@available(macOS 10.14, *)) {
-            BOOL isMojaveDarkMode = [[[VSThemeManager sharedManager] theme] isMojaveDarkMode];
-            self.window.appearance = [NSAppearance appearanceNamed: isMojaveDarkMode ? NSAppearanceNameDarkAqua : NSAppearanceNameAqua];
+            SPWindow *window = (SPWindow *)self.window;
+            window.appearance = nil;
+            [window applyMojaveThemeOverrideIfNecessary];
         }
     } else {
         NSString *newTheme = ([sender tag] == 0) ? @"default" : @"dark";


### PR DESCRIPTION
In this PR we're adding a new item to the Theme menu on Mojave and beyond that will allow the user to go back to using the system appearance:

<img width="366" alt="screen shot 2018-10-22 at 3 44 05 pm" src="https://user-images.githubusercontent.com/789137/47323707-c4d6ce00-d611-11e8-8dc1-994587047416.png">

This will be the default checked item if the user has never manually selected a theme (on Mojave only, otherwise it still defaults to `Light`).

**To Test**
* Open the app in Mojave, and select `View -> Theme -> System Appearance`.
* Switch the appearance in the main macOS settings, the app should adjust appearance accordingly.
* Now manually select a dark or light theme in `View -> Theme`. 
* Switching the macOS appearance should have no effect on the appearance of Simplenote.

Fixes #256