### PR TITLE
Adding links to various help websites in the help menu.

### DIFF
--- a/Simplenote/SPConstants.h
+++ b/Simplenote/SPConstants.h
@@ -25,3 +25,6 @@ extern NSString * const SPSimplenoteLogoImageName;
 extern NSString * const SPWPServiceName;
 extern NSString * const SPSignInErrorNotificationName;
 extern NSString * const SPWPSignInAuthURL;
+extern NSString * const SPHelpURL;
+extern NSString * const SPContactUsURL;
+extern NSString * const SPTwitterURL;

--- a/Simplenote/SPConstants.m
+++ b/Simplenote/SPConstants.m
@@ -25,3 +25,6 @@ NSString * const SPSimplenoteLogoImageName          = @"logo";
 NSString * const SPWPServiceName                    = @"simplenote-wpcom";
 NSString * const SPSignInErrorNotificationName      = @"SPSignInErrorNotificationName";
 NSString * const SPWPSignInAuthURL                  = @"https://public-api.wordpress.com/oauth2/authorize?response_type=code&scope=global&client_id=%@&redirect_uri=%@&state=%@";
+NSString * const SPHelpURL                          = @"https://simplenote.com/help";
+NSString * const SPContactUsURL                     = @"https://simplenote.com/contact-us";
+NSString * const SPTwitterURL                       = @"https://twitter.com/simplenoteapp";

--- a/Simplenote/SimplenoteAppDelegate.h
+++ b/Simplenote/SimplenoteAppDelegate.h
@@ -41,6 +41,7 @@
 - (IBAction)ensureMainWindowIsVisible:(id)sender;
 - (IBAction)aboutAction:(id)sender;
 - (IBAction)privacyAction:(id)sender;
+- (IBAction)helpAction:(id)sender;
 
 - (void)selectAllNotesTag;
 - (void)selectNoteWithKey:(NSString *)simperiumKey;

--- a/Simplenote/SimplenoteAppDelegate.m
+++ b/Simplenote/SimplenoteAppDelegate.m
@@ -778,6 +778,13 @@
     [self.splitView adjustSubviews];
 }
 
+- (IBAction)helpAction:(id)sender
+{
+    NSArray *helpLinks = @[SPHelpURL, SPContactUsURL, SPTwitterURL];
+    NSMenuItem *menuItem = (NSMenuItem *)sender;
+    [[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString: helpLinks[menuItem.tag]]];
+}
+
 - (IBAction)changeThemeAction:(id)sender
 {
     NSMenuItem *item = (NSMenuItem *)sender;

--- a/Simplenote/en.lproj/MainMenu.xib
+++ b/Simplenote/en.lproj/MainMenu.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14313.18" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14313.18"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14460.31"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -718,9 +718,23 @@
                     <modifierMask key="keyEquivalentModifierMask"/>
                     <menu key="submenu" title="Help" systemMenu="help" id="491">
                         <items>
-                            <menuItem title="Simplenote Help" keyEquivalent="?" id="492">
+                            <menuItem title="Help Website" id="492">
+                                <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>
-                                    <action selector="showHelp:" target="-1" id="493"/>
+                                    <action selector="helpAction:" target="494" id="sKP-L1-cGC"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="XOB-px-ckD"/>
+                            <menuItem title="Contact Us" tag="1" id="dkM-vi-cwv">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="helpAction:" target="494" id="T0P-1J-yFj"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Twitter" tag="2" id="E6O-ds-BEj">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="helpAction:" target="494" id="SG8-GN-hdQ"/>
                                 </connections>
                             </menuItem>
                         </items>


### PR DESCRIPTION
The reviewer for the 1.3.9 update didn't like that they saw this when clicking on `Simplenote Help`:

<img width="532" alt="attachment-5333097042998478663screenshot-1031-060625" src="https://user-images.githubusercontent.com/789137/47803472-d09c5180-dcef-11e8-9b38-6bb597e8e3b3.png">

I've added some help menu items that link to some of our more helpful websites :)

<img width="172" alt="screen shot 2018-10-31 at 9 29 25 am" src="https://user-images.githubusercontent.com/789137/47803501-e6117b80-dcef-11e8-8508-19b019c12fff.png">

**To Test**
* Verify the menu items in the help menu link to the correct sites.