### PR TITLE
Adding support for alphabetical tag sorting.

### DIFF
--- a/Simplenote/TagListViewController.h
+++ b/Simplenote/TagListViewController.h
@@ -18,6 +18,7 @@
     IBOutlet NSMenu *tagDropdownMenu;
     IBOutlet NSMenu *trashDropdownMenu;
     IBOutlet NSMenu *findMenu;
+    IBOutlet NSMenuItem *tagSortMenuItem;
     IBOutlet NSArrayController *notesArrayController;
 }
 
@@ -36,6 +37,7 @@ extern NSString * const kDidEmptyTrash;
 - (IBAction)deleteAction:(id)sender;
 - (IBAction)renameAction:(id)sender;
 - (IBAction)emptyTrashAction:(id)sender;
+- (IBAction)sortAction:(id)sender;
 - (void)reset;
 - (void)applyStyle;
 

--- a/Simplenote/TagListViewController.m
+++ b/Simplenote/TagListViewController.m
@@ -120,8 +120,16 @@ NSString * const kDidEmptyTrash = @"SPDidEmptyTrash";
 - (void)sortTags
 {
     BOOL sortAlphabetically = [[NSUserDefaults standardUserDefaults] boolForKey:kTagSortPreferencesKey];
-    NSString *sortKey = sortAlphabetically ? @"name" : @"index";
-    NSSortDescriptor *sortDescriptor = [[NSSortDescriptor alloc] initWithKey:sortKey ascending:YES];
+    NSSortDescriptor *sortDescriptor;
+    if (sortAlphabetically) {
+        sortDescriptor = [[NSSortDescriptor alloc]
+                          initWithKey:@"name"
+                          ascending:YES
+                          selector:@selector(localizedCaseInsensitiveCompare:)];
+    } else {
+        sortDescriptor = [[NSSortDescriptor alloc] initWithKey:@"index" ascending:YES];
+    }
+
     self.tagArray = [self.tagArray sortedArrayUsingDescriptors:[NSArray arrayWithObject:sortDescriptor]];
 }
 

--- a/Simplenote/TagListViewController.m
+++ b/Simplenote/TagListViewController.m
@@ -23,6 +23,7 @@
 #define kTrashRow 2
 #define kSeparatorRow 3
 #define kStartOfTagListRow 4
+#define kTagSortPreferencesKey @"kTagSortPreferencesKey"
 
 #define kRowHeight 30
 #define kSeparatorHeight 24
@@ -76,6 +77,9 @@ NSString * const kDidEmptyTrash = @"SPDidEmptyTrash";
     
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(tagAddedFromEditor:) name:SPTagAddedFromEditorNotificationName object:nil];
     
+    BOOL alphaTagSort = [[NSUserDefaults standardUserDefaults] boolForKey:kTagSortPreferencesKey];
+    [tagSortMenuItem setState:alphaTagSort ? NSOnState : NSOffState];
+    
     awake = YES;
 }
 
@@ -115,7 +119,9 @@ NSString * const kDidEmptyTrash = @"SPDidEmptyTrash";
 
 - (void)sortTags
 {
-    NSSortDescriptor *sortDescriptor = [[NSSortDescriptor alloc] initWithKey:@"index" ascending:YES];
+    BOOL sortAlphabetically = [[NSUserDefaults standardUserDefaults] boolForKey:kTagSortPreferencesKey];
+    NSString *sortKey = sortAlphabetically ? @"name" : @"index";
+    NSSortDescriptor *sortDescriptor = [[NSSortDescriptor alloc] initWithKey:sortKey ascending:YES];
     self.tagArray = [self.tagArray sortedArrayUsingDescriptors:[NSArray arrayWithObject:sortDescriptor]];
 }
 
@@ -180,7 +186,6 @@ NSString * const kDidEmptyTrash = @"SPDidEmptyTrash";
     
     // Force Resync!
     [notesArrayController fetchWithRequest:nil merge:NO error:nil];
-    
 }
 
 - (void)selectTag:(Tag *)tagToSelect
@@ -416,6 +421,15 @@ NSString * const kDidEmptyTrash = @"SPDidEmptyTrash";
     [[NSNotificationCenter defaultCenter] postNotificationName:kDidEmptyTrash object:self];
 }
 
+- (IBAction)sortAction:(id)sender
+{
+    NSMenuItem *item = (NSMenuItem *)sender;
+    [item setState:item.state == NSOnState ? NSOffState : NSOnState];
+    [[NSUserDefaults standardUserDefaults] setBool:item.state == NSOnState forKey:kTagSortPreferencesKey];
+    
+    [self loadTags];
+}
+
 
 #pragma mark - NSTableView delegate
 
@@ -602,7 +616,9 @@ NSString * const kDidEmptyTrash = @"SPDidEmptyTrash";
 // Much of this code is overly generalized for this use case, but it works
 - (BOOL)tableView:(NSTableView *)tableView writeRowsWithIndexes:(NSIndexSet *)rowIndexes toPasteboard:(NSPasteboard *)pboard
 {
-    if ([rowIndexes firstIndex] < kStartOfTagListRow) {
+    BOOL isAlphaSort = [[NSUserDefaults standardUserDefaults] boolForKey:kTagSortPreferencesKey];
+    if (isAlphaSort || [rowIndexes firstIndex] < kStartOfTagListRow) {
+        // Alphabetical tag sorting should not allow drag and drop
         return NO;
     }
     

--- a/Simplenote/en.lproj/MainMenu.xib
+++ b/Simplenote/en.lproj/MainMenu.xib
@@ -642,6 +642,19 @@
                                     </items>
                                 </menu>
                             </menuItem>
+                            <menuItem title="Tags List" id="4QQ-5e-Vxl">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="Tags List" autoenablesItems="NO" id="76D-S0-1JD">
+                                    <items>
+                                        <menuItem title="Sort Alphabetically" id="axW-cz-MnF">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="sortAction:" target="1461" id="jQp-2i-tQh"/>
+                                            </connections>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
                             <menuItem title="Theme" id="Jtf-4C-imn">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <menu key="submenu" title="Theme" systemMenu="font" id="SIP-Tf-W7J">
@@ -1209,6 +1222,7 @@
                 <outlet property="tableView" destination="1453" id="1469"/>
                 <outlet property="tagBox" destination="1731" id="690-39-pWj"/>
                 <outlet property="tagMenu" destination="1510" id="1517"/>
+                <outlet property="tagSortMenuItem" destination="axW-cz-MnF" id="vio-Yr-jb6"/>
                 <outlet property="view" destination="1452" id="1462"/>
             </connections>
         </viewController>


### PR DESCRIPTION
A long requested feature, this adds a new menu option that will sort the tags list alphabetically.

**To Test**
* Open the app, and view the tags list. You should be able to drag and drop tags to reorder them.
* Select `View -> Tags List -> Sort Alphabetically`. The tags should re-sort to alphabetical order.
* You should not be able to drag and drop the tags, unless you disable alphabetical sort again.