### PR TITLE
Updating Checklist Insertion Behavior

### DIFF
--- a/Simplenote/SPTextView.m
+++ b/Simplenote/SPTextView.m
@@ -160,7 +160,7 @@ NSInteger const ChecklistCursorAdjustment = 2;
         for (int i=0; i < [stringLines count]; i++) {
             NSString *line = stringLines[i];
             // Skip the last line if it is empty
-            if (i == [stringLines count] - 1 && [line length] == 0) {
+            if (i != 0 && i == [stringLines count] - 1 && [line length] == 0) {
                 continue;
             }
             

--- a/Simplenote/SPTextView.m
+++ b/Simplenote/SPTextView.m
@@ -134,24 +134,50 @@ NSInteger const ChecklistCursorAdjustment = 2;
 
 - (void)insertNewChecklist {
     NSRange lineRange = [self.string lineRangeForRange:self.selectedRange];
-    NSString *lineString = [self.string substringWithRange:lineRange];
+    NSUInteger cursorPosition = self.selectedRange.location;
+    NSUInteger selectionLength = self.selectedRange.length;
     
+    // Check if cursor is at a checkbox, if so we won't adjust cursor position
+    BOOL cursorIsAtCheckbox = NO;
+    if (self.string.length >= self.selectedRange.location + 1) {
+        NSString *characterAtCursor = [self.string substringWithRange:NSMakeRange(self.selectedRange.location, 1)];
+        cursorIsAtCheckbox = [characterAtCursor isEqualToString:TextAttachmentCharacterCode];
+    }
+    
+    NSString *lineString = [self.string substringWithRange:lineRange];
     BOOL didInsertCheckbox = NO;
-    if ([lineString hasPrefix:TextAttachmentCharacterCode] && [lineString length] >= 2) {
-        // Remove the checkbox
-        lineString = [lineString stringByReplacingCharactersInRange:NSMakeRange(0, 2) withString:@""];
+    NSString *resultString = @"";
+    
+    int addedCheckboxCount = 0;
+    if ([lineString hasPrefix:TextAttachmentCharacterCode] && [lineString length] >= ChecklistCursorAdjustment) {
+        // Remove the checkboxes in the selection
+        NSString *codeAndSpace = [TextAttachmentCharacterCode stringByAppendingString:@" "];
+        resultString = [lineString stringByReplacingOccurrencesOfString:codeAndSpace withString:@""];
     } else {
-        // Add a checkbox
+        // Add checkboxes to the selection
         NSString *checkboxString = [MarkdownUnchecked stringByAppendingString:@" "];
-        lineString = [checkboxString stringByAppendingString:[self.string substringWithRange:lineRange]];
+        NSArray *stringLines = [lineString componentsSeparatedByString:@"\n"];
+        for (int i=0; i < [stringLines count]; i++) {
+            NSString *line = stringLines[i];
+            // Skip any empty lines, except the first one
+            if (i != 0 && [line length] == 0) {
+                continue;
+            }
+            
+            resultString = [resultString stringByAppendingString:[checkboxString stringByAppendingString:line]];
+            // Skip adding newline to the last line
+            if (i != [stringLines count] - 1) {
+                resultString = [resultString stringByAppendingString:@"\n"];
+            }
+            addedCheckboxCount++;
+        }
+        
         didInsertCheckbox = YES;
     }
     
-    NSUInteger cursorPosition = self.selectedRange.location;
-    
     NSTextStorage *storage = self.textStorage;
     [storage beginEditing];
-    [storage replaceCharactersInRange:lineRange withString:lineString];
+    [storage replaceCharactersInRange:lineRange withString:resultString];
     [storage endEditing];
     
     [self processChecklists];
@@ -159,8 +185,16 @@ NSInteger const ChecklistCursorAdjustment = 2;
     [self.delegate textDidChange:note];
     
     // Update the cursor position
-    int cursorAdjustment = didInsertCheckbox ? ChecklistCursorAdjustment : -ChecklistCursorAdjustment;
-    [self setSelectedRange:NSMakeRange(cursorPosition + cursorAdjustment, self.selectedRange.length)];
+    NSUInteger cursorAdjustment = 0;
+    if (!cursorIsAtCheckbox) {
+        if (selectionLength > 0 && didInsertCheckbox) {
+            // Places cursor at end of insertion when text was selected
+            cursorAdjustment = selectionLength + (ChecklistCursorAdjustment * addedCheckboxCount);
+        } else {
+            cursorAdjustment = didInsertCheckbox ? ChecklistCursorAdjustment : -ChecklistCursorAdjustment;
+        }
+    }
+    [self setSelectedRange:NSMakeRange(cursorPosition + cursorAdjustment, 0)];
 }
 
 @end

--- a/Simplenote/SPTextView.m
+++ b/Simplenote/SPTextView.m
@@ -159,8 +159,8 @@ NSInteger const ChecklistCursorAdjustment = 2;
         NSArray *stringLines = [lineString componentsSeparatedByString:@"\n"];
         for (int i=0; i < [stringLines count]; i++) {
             NSString *line = stringLines[i];
-            // Skip any empty lines, except the first one
-            if (i != 0 && [line length] == 0) {
+            // Skip the last line if it is empty
+            if (i == [stringLines count] - 1 && [line length] == 0) {
                 continue;
             }
             

--- a/Simplenote/SPTextView.m
+++ b/Simplenote/SPTextView.m
@@ -19,7 +19,7 @@ NSString *const MarkdownUnchecked = @"- [ ]";
 NSString *const MarkdownChecked = @"- [x]";
 NSString *const TextAttachmentCharacterCode = @"\U0000fffc"; // Represents the glyph of an NSTextAttachment
 
-// One unicode character plus a space and a newline
+// One unicode character plus a space
 NSInteger const ChecklistCursorAdjustment = 2;
 
 @implementation SPTextView


### PR DESCRIPTION
This is essentially the same code changes as https://github.com/Automattic/simplenote-ios/pull/266

**To Test**
* Test inserting a checkbox using the `Format -> Insert Checklist` menu.
* If the cursor is on a line with an existing checkbox, that checkbox should be removed and the cursor position should adjust accordingly.
* If the cursor is on a line without an existing checkbox, a checkbox should be inserted and the cursor position should adjusted accordingly.