### PR TITLE
Fix versions slider with checklists

### DIFF
--- a/Simplenote/NoteEditorViewController.m
+++ b/Simplenote/NoteEditorViewController.m
@@ -639,7 +639,6 @@ static NSInteger const SPVersionSliderMaxVersions       = 10;
         [versionSlider setObjectValue:[NSNumber numberWithInteger:versionSlider.maxValue]];
         [self updateVersionLabel:self.note.modificationDate];
         [self.noteEditor setEditable:NO];
-        [self.noteEditor setTextColor:[self.theme colorForKey:@"tagViewPlaceholderColor"]];
 
         // Request the version data from Simperium
         Simperium *simperium = [[SimplenoteAppDelegate sharedDelegate] simperium];
@@ -674,7 +673,7 @@ static NSInteger const SPVersionSliderMaxVersions       = 10;
     restoreVersionButton.enabled = [versionSlider integerValue] != versionSlider.maxValue && versionData != nil;
 	if (versionData != nil) {
 		self.noteEditor.string = (NSString *)[versionData objectForKey:@"content"];
-        [self.noteEditor setTextColor:[self.theme colorForKey:@"tagViewPlaceholderColor"]];
+        [self.noteEditor processChecklists];
 
 		NSDate *versionDate = [NSDate dateWithTimeIntervalSince1970:[(NSString *)[versionData objectForKey:@"modificationDate"] doubleValue]];
 		[self updateVersionLabel:versionDate];
@@ -1094,7 +1093,7 @@ static NSInteger const SPVersionSliderMaxVersions       = 10;
     }
     
     [SPTracker trackEditorVersionsAccessed];
-    [self showViewController:self.versionsViewController relativeToView:self.noteEditor preferredEdge:NSMinXEdge];
+    [self showViewController:self.versionsViewController relativeToView:historyButton preferredEdge:NSMaxYEdge];
 }
 
 - (IBAction)shareNote:(id)sender

--- a/Simplenote/NoteEditorViewController.m
+++ b/Simplenote/NoteEditorViewController.m
@@ -657,8 +657,10 @@ static NSInteger const SPVersionSliderMaxVersions       = 10;
         
         // Unload versions and re-enable editor
         [self.noteEditor setEditable:YES];
-        [self.noteEditor setTextColor:[self.theme colorForKey:@"textColor"]];
         self.noteVersionData = nil;
+        
+        // Refreshes the note content in the editor, in case the popover was canceled
+        [self didReceiveNewContent];
     }
 }
 

--- a/Simplenote/en.lproj/MainMenu.xib
+++ b/Simplenote/en.lproj/MainMenu.xib
@@ -1353,11 +1353,11 @@
                                 </connections>
                             </slider>
                             <button verticalHuggingPriority="750" id="1088">
-                                <rect key="frame" x="143" y="51" width="72" height="17"/>
+                                <rect key="frame" x="139" y="43" width="81" height="32"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                <buttonCell key="cell" type="inline" title="Restore" bezelStyle="inline" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="1089">
+                                <buttonCell key="cell" type="push" title="Restore" bezelStyle="rounded" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="1089">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                    <font key="font" metaFont="smallSystemBold"/>
+                                    <font key="font" metaFont="system"/>
                                 </buttonCell>
                                 <connections>
                                     <action selector="restoreVersionAction:" target="1107" id="1665"/>
@@ -1378,6 +1378,7 @@
                     </textFieldCell>
                 </textField>
             </subviews>
+            <point key="canvasLocation" x="138.5" y="153.5"/>
         </customView>
         <menuItem title="Item" id="1668">
             <modifierMask key="keyEquivalentModifierMask"/>


### PR DESCRIPTION
The checklists were not displaying properly in the note history browser. I've also taken the opportunity to show the history slider from beneath the history button, instead of to the side of the note editor which makes more visual sense to me.

<img width="265" alt="screen shot 2019-01-07 at 2 39 59 pm" src="https://user-images.githubusercontent.com/789137/50797965-7689b080-128b-11e9-9207-0e15e3188023.png">

I also removed the text color from being changed while viewing history, it was really low contrast.

**To Test**
* View the history for a note that has a checklist.
* Changing/restoring versions should work as expected.
