### PR TITLE
Add Support for Nested Checklists

### DIFF
--- a/Simplenote/NSMutableAttributedString+Styling.m
+++ b/Simplenote/NSMutableAttributedString+Styling.m
@@ -12,6 +12,10 @@
 
 @implementation NSMutableAttributedString (Styling)
 
+const int RegexExpectedMatchGroups  = 3;
+const int RegexGroupIndexPrefix     = 1;
+const int RegexGroupIndexContent    = 2;
+
 - (NSMutableAttributedString*)stringByTruncatingToWidth:(CGFloat)width withFont:(NSFont *)font
 {
     // Create copy that will be the returned result
@@ -68,11 +72,11 @@
     
     int positionAdjustment = 0;
     for (NSTextCheckingResult *match in matches) {
-        if ([match numberOfRanges] < 3) {
+        if ([match numberOfRanges] < RegexExpectedMatchGroups) {
             continue;
         }
-        NSRange prefixRange = [match rangeAtIndex:1];
-        NSRange checkboxRange = [match rangeAtIndex:2];
+        NSRange prefixRange = [match rangeAtIndex:RegexGroupIndexPrefix];
+        NSRange checkboxRange = [match rangeAtIndex:RegexGroupIndexContent];
         
         NSString *markdownTag = [noteString substringWithRange:match.range];
         BOOL isChecked = [markdownTag localizedCaseInsensitiveContainsString:@"x"];

--- a/Simplenote/NSMutableAttributedString+Styling.m
+++ b/Simplenote/NSMutableAttributedString+Styling.m
@@ -69,7 +69,13 @@
     int positionAdjustment = 0;
     for (NSTextCheckingResult *match in matches) {
         NSString *markdownTag = [noteString substringWithRange:match.range];
-        BOOL isChecked = [markdownTag containsString:@"x"];
+        BOOL isChecked = [markdownTag localizedCaseInsensitiveContainsString:@"x"];
+        
+        if ([match numberOfRanges] < 3) {
+            continue;
+        }
+        NSRange prefixRange = [match rangeAtIndex:1];
+        NSRange checkboxRange = [match rangeAtIndex:2];
         
         SPTextAttachment *attachment = [[SPTextAttachment alloc] initWithColor:color];
         [attachment setIsChecked: isChecked];
@@ -77,10 +83,10 @@
         attachment.bounds = CGRectMake(0, verticalOffset, height, height);
         
         NSAttributedString *attachmentString = [NSAttributedString attributedStringWithAttachment:attachment];
-        NSRange adjustedRange = NSMakeRange(match.range.location - positionAdjustment, match.range.length);
+        NSRange adjustedRange = NSMakeRange(checkboxRange.location - positionAdjustment, checkboxRange.length);
         [self replaceCharactersInRange:adjustedRange withAttributedString:attachmentString];
         
-        positionAdjustment += markdownTag.length - 1;
+        positionAdjustment += markdownTag.length - 1 - prefixRange.length;
     }
 }
 

--- a/Simplenote/NSMutableAttributedString+Styling.m
+++ b/Simplenote/NSMutableAttributedString+Styling.m
@@ -68,14 +68,14 @@
     
     int positionAdjustment = 0;
     for (NSTextCheckingResult *match in matches) {
-        NSString *markdownTag = [noteString substringWithRange:match.range];
-        BOOL isChecked = [markdownTag localizedCaseInsensitiveContainsString:@"x"];
-        
         if ([match numberOfRanges] < 3) {
             continue;
         }
         NSRange prefixRange = [match rangeAtIndex:1];
         NSRange checkboxRange = [match rangeAtIndex:2];
+        
+        NSString *markdownTag = [noteString substringWithRange:match.range];
+        BOOL isChecked = [markdownTag localizedCaseInsensitiveContainsString:@"x"];
         
         SPTextAttachment *attachment = [[SPTextAttachment alloc] initWithColor:color];
         [attachment setIsChecked: isChecked];

--- a/Simplenote/NSTextView+Simplenote.m
+++ b/Simplenote/NSTextView+Simplenote.m
@@ -63,6 +63,9 @@ const int ChecklistItemLength = 3;
     
     // Tab entered: Move the bullet along
     if (isTabPress) {
+        if (isApplyingChecklist) {
+            return NO;
+        }
         // Proceed only if the user is entering Tab's right by the first one
         //  -   Something
         //     ^

--- a/Simplenote/NSTextView+Simplenote.m
+++ b/Simplenote/NSTextView+Simplenote.m
@@ -92,7 +92,7 @@ const int ChecklistItemLength = 3;
         }
         
         // Do we need to append a whitespace?
-        if (lineRange.length > indexOfBullet + bulletLength) {
+        if (lineRange.length > indexOfBullet + bulletLength && !isApplyingChecklist) {
             unichar bulletTrailing      = [lineString characterAtIndex:indexOfBullet + bulletLength];
             
             if ([[NSCharacterSet whitespaceCharacterSet] characterIsMember:bulletTrailing]) {

--- a/Simplenote/SPTextView.h
+++ b/Simplenote/SPTextView.h
@@ -10,7 +10,8 @@
 
 #define kMinEditorPadding 20
 #define kEditorWidthPreferencesKey @"kEditorWidthPreferencesKey"
-#define kChecklistRegexPattern @"^- (\\[([ |x])\\])"
+#define kChecklistRegexPattern @"^(\\s+)?(-[ \t]+\\[[xX\\s]\\])"
+
 
 @protocol SPTextViewDelegate <NSTextViewDelegate>
 - (void)didClickTextView:(id)sender;

--- a/Simplenote/SPTextView.m
+++ b/Simplenote/SPTextView.m
@@ -164,6 +164,7 @@ NSInteger const ChecklistCursorAdjustment = 2;
             }
             
             NSString *prefixedWhitespace = [self getLeadingWhiteSpaceForString:line];
+            line = [line substringFromIndex:[prefixedWhitespace length]];
             resultString = [[resultString
                              stringByAppendingString:prefixedWhitespace]
                              stringByAppendingString:[checkboxString

--- a/Simplenote/SPTextView.m
+++ b/Simplenote/SPTextView.m
@@ -14,7 +14,6 @@
 #import "Simplenote-Swift.h"
 
 #define kMaxEditorWidth 750 // Note: This matches the Electron apps max editor width
-NSString *const CheckListRegExPattern = @"^- (\\[([ |x])\\])";
 NSString *const MarkdownUnchecked = @"- [ ]";
 NSString *const MarkdownChecked = @"- [x]";
 NSString *const TextAttachmentCharacterCode = @"\U0000fffc"; // Represents the glyph of an NSTextAttachment

--- a/Simplenote/SPTextView.m
+++ b/Simplenote/SPTextView.m
@@ -148,7 +148,7 @@ NSInteger const ChecklistCursorAdjustment = 2;
     NSString *resultString = @"";
     
     int addedCheckboxCount = 0;
-    if ([lineString hasPrefix:TextAttachmentCharacterCode] && [lineString length] >= ChecklistCursorAdjustment) {
+    if ([lineString containsString:TextAttachmentCharacterCode] && [lineString length] >= ChecklistCursorAdjustment) {
         // Remove the checkboxes in the selection
         NSString *codeAndSpace = [TextAttachmentCharacterCode stringByAppendingString:@" "];
         resultString = [lineString stringByReplacingOccurrencesOfString:codeAndSpace withString:@""];
@@ -163,7 +163,11 @@ NSInteger const ChecklistCursorAdjustment = 2;
                 continue;
             }
             
-            resultString = [resultString stringByAppendingString:[checkboxString stringByAppendingString:line]];
+            NSString *prefixedWhitespace = [self getLeadingWhiteSpaceForString:line];
+            resultString = [[resultString
+                             stringByAppendingString:prefixedWhitespace]
+                             stringByAppendingString:[checkboxString
+                             stringByAppendingString:line]];
             // Skip adding newline to the last line
             if (i != [stringLines count] - 1) {
                 resultString = [resultString stringByAppendingString:@"\n"];
@@ -194,6 +198,15 @@ NSInteger const ChecklistCursorAdjustment = 2;
         }
     }
     [self setSelectedRange:NSMakeRange(cursorPosition + cursorAdjustment, 0)];
+}
+
+// Returns a NSString of any whitespace characters found at the start of a string
+- (NSString *)getLeadingWhiteSpaceForString: (NSString *)string
+{
+    NSRegularExpression *regex = [[NSRegularExpression alloc] initWithPattern:@"^\\s*" options:0 error:NULL];
+    NSTextCheckingResult *match = [regex firstMatchInString:string options:0 range:NSMakeRange(0, string.length)];
+    
+    return [string substringWithRange:match.range];
 }
 
 @end


### PR DESCRIPTION
I missed in the original checklists PR that GitHub checklists can be nested, so I'm adding support for that in the app:

<img width="229" alt="screen shot 2019-01-18 at 8 26 25 am" src="https://user-images.githubusercontent.com/789137/51400387-1c93b100-1afd-11e9-8b4b-5859aaabf5aa.png">

**To Test**
* Create a checklist at any position on a line. It should insert at the proper position.
* Pressing enter should 'autobullet' a new checklist item on the next line at the same position.
* Selecting multiple lines and/or one line of text and then inserting a checklist should still work as expected.