### PR TITLE
New Tracks Event for Checklist Insertion

### DIFF
--- a/Simplenote/NoteEditorViewController.m
+++ b/Simplenote/NoteEditorViewController.m
@@ -1161,6 +1161,8 @@ static NSInteger const SPVersionSliderMaxVersions       = 10;
 
 - (void)insertChecklistAction:(id)sender {
     [self.noteEditor insertNewChecklist];
+    
+    [SPTracker trackEditorChecklistInserted];
 }
 
 #pragma mark - NSSharingServicePicker delegate

--- a/Simplenote/SPTracker.h
+++ b/Simplenote/SPTracker.h
@@ -26,6 +26,7 @@
 + (void)trackApplicationTerminated;
 
 #pragma mark - Note Editor
++ (void)trackEditorChecklistInserted;
 + (void)trackEditorNoteCreated;
 + (void)trackEditorNoteDeleted;
 + (void)trackEditorNoteRestored;

--- a/Simplenote/SPTracker.m
+++ b/Simplenote/SPTracker.m
@@ -41,6 +41,10 @@
 
 
 #pragma mark - Note Editor
++ (void)trackEditorChecklistInserted
+{
+    [self trackAutomatticEventWithName:@"editor_checklist_inserted" properties:nil];
+}
 
 + (void)trackEditorNoteCreated
 {


### PR DESCRIPTION
Adding a new tracks event for when the insert checklist menu is used..

**To Test**
* Ensure analytics is enabled in the app settings.
* Open a note and choose `Format -> Insert Checklist` from the menu.
* Confirm the event shows up in the tracks live event view. The event is `sposx_editor_checklist_inserted`