### PR TITLE
Fix checklists displaying in wrong color in the notes list.

### DIFF
--- a/DB5/VSTheme.m
+++ b/DB5/VSTheme.m
@@ -164,7 +164,7 @@ static NSColor *colorWithHexString(NSString *hexString);
             return NSColor.controlBackgroundColor;
         } else if ([key isEqualToString:@"textColor"] || [key isEqualToString:@"noteHeadlineFontColor"]) {
             return NSColor.textColor;
-        } else if ([key isEqualToString:@"secondaryTextColor"] || [key isEqualToString:@"noteBodyFontPreviewColor"]) {
+        } else if ([key isEqualToString:@"secondaryTextColor"]) {
             return NSColor.secondaryLabelColor;
         }
     }

--- a/Simplenote/NoteListViewController.m
+++ b/Simplenote/NoteListViewController.m
@@ -496,6 +496,8 @@ NSString * const kPreviewLinesPref = @"kPreviewLinesPref";
 {
     VSTheme *theme = [[VSThemeManager sharedManager] theme];
     statusField.textColor = [theme colorForKey:@"emptyListViewFontColor"];
+    
+    [self.tableView reloadData];
 }
 
 - (IBAction)filterNotes:(id)sender {

--- a/Simplenote/Simplenote-DB5.plist
+++ b/Simplenote/Simplenote-DB5.plist
@@ -15,7 +15,7 @@
 		<key>dividerColor</key>
 		<string>dbdee0</string>
 		<key>secondaryTextColor</key>
-		<string>899199</string>
+		<string>808080</string>
 		<key>noteHeadlineFont</key>
 		<string>@boldFontName</string>
 		<key>noteHeadlineFontSize</key>
@@ -39,7 +39,7 @@
 		<key>noteBodyFontSize~ipad</key>
 		<string>19</string>
 		<key>noteBodyFontPreviewColor</key>
-		<string>@secondaryTextColor</string>
+		<string>808080</string>
 		<key>noteCellBackgroundSelectionColor</key>
 		<string>@lightBlueColor</string>
 		<key>noteSidePadding</key>
@@ -344,13 +344,13 @@
 		<key>textColor</key>
 		<string>dbdee0</string>
 		<key>secondaryTextColor</key>
-		<string>899199</string>
+		<string>999999</string>
 		<key>dividerColor</key>
 		<string>4b5157</string>
 		<key>noteHeadlineFontColor</key>
 		<string>@textColor</string>
 		<key>noteBodyFontPreviewColor</key>
-		<string>@secondaryTextColor</string>
+		<string>999999</string>
 		<key>noteCellBackgroundSelectionColor</key>
 		<string>@lightBlueColor</string>
 		<key>switchTintColor</key>

--- a/Simplenote/SimplenoteAppDelegate.m
+++ b/Simplenote/SimplenoteAppDelegate.m
@@ -827,6 +827,7 @@
         [window applyMojaveThemeOverrideIfNecessary];
         [self.noteEditorViewController applyStyle];
         [self.noteEditorViewController fixChecklistColoring];
+        [self.noteListViewController applyStyle];
         return;
     }
     


### PR DESCRIPTION
Some notes would have the wrong color for a checklist item in the notes list:

<img width="116" alt="screen shot 2019-01-22 at 2 08 02 pm" src="https://user-images.githubusercontent.com/789137/51569696-fdc15180-1e51-11e9-8bee-ef4f28258e1f.png">

I fixed it by not applying the Mojave "secondary label" color, as it seems to be the cause of the issue. The colors are pulled from the theme plist instead.

**To Test**
* Create multiple notes that have checklists that appear in the preview of the notes list.
* The coloring should match in the preview line with the text. (It won't match if it is in the title, but that is expected)
* Changing themes should adjust the text and checklist colors.