### PR TITLE
Add the unicode bullet • to the list of bullets

### DIFF
--- a/Simplenote/NSTextView+Simplenote.m
+++ b/Simplenote/NSTextView+Simplenote.m
@@ -38,7 +38,7 @@ const int ChecklistItemLength = 3;
     NSString *lineString                = [rawString substringWithRange:lineRange];
     NSString *cleanLineString           = [lineString stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
     NSString *textAttachmentCode = @"\U0000fffc"; // Represents the glyph of an NSTextAttachment
-    NSArray *const bullets              = @[@"*", @"-", @"+", textAttachmentCode];
+    NSArray *const bullets              = @[@"*", @"-", @"+", @"•", textAttachmentCode];
     NSString *stringToAppendToNewLine   = nil;
     
     for (NSString *bullet in bullets) {


### PR DESCRIPTION
When typing an unordered list you can press enter to add a new item after the current one, as long as the list item denoter is one of the predefined prefixes. Currently the prefixes are `*`, `-`, and `+`. Add a real bullet `•` because the symbol is common in word documents and may be copied over from there.