### PR TITLE
Fix links from showing across entire note.

### DIFF
--- a/External/Notepad/Storage.swift
+++ b/External/Notepad/Storage.swift
@@ -19,6 +19,8 @@
             let wholeRange = NSRange(location: 0, length: (self.string as NSString).length)
 
             self.beginEditing()
+            // Clear out the attributes on the backing NSTextStorage
+            self.backingStore.setAttributes([:], range: wholeRange)
             self.applyStyles(wholeRange)
             self.edited(.editedAttributes, range: wholeRange, changeInLength: 0)
             self.endEditing()


### PR DESCRIPTION
The attributes applied to the text storage were not getting cleared out when you switched notes, so the link would apply to the entire range of text.

Fixed by removing all attributes on the text storage when a note is switched in the note editor.

Fixes #298

**To Test**
* Create a note that has a url in the title. It should become a link.
* Click on any other note, it should display normally.