### PR TITLE
Enable hoedown's Span-Extentions

### DIFF
--- a/Simplenote/SPMarkdownParser.m
+++ b/Simplenote/SPMarkdownParser.m
@@ -25,7 +25,8 @@
                                                       HOEDOWN_EXT_AUTOLINK |
                                                       HOEDOWN_EXT_FENCED_CODE |
                                                       HOEDOWN_EXT_FOOTNOTES |
-                                                      HOEDOWN_EXT_TABLES,
+                                                      HOEDOWN_EXT_TABLES |
+                                                      HOEDOWN_EXT_SPAN ,
                                                       16, 0, NULL, NULL);
     hoedown_buffer *html = hoedown_buffer_new(16);
     


### PR DESCRIPTION
Enable hoedown's Span-Extentions including strikethrough

Then markdown can support these extends:

- strikethrough： ~~stikethrough~~
- underline： _underline_
- highlight : ==highlight==
- superscript:  100^2
- math: $$math$$