### PR TITLE
Updated Simperium lib from 0.8.19 to 0.8.21

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -16,7 +16,7 @@ abstract_target 'Automattic' do
 	# Automattic Shared
 	#
 	pod 'Automattic-Tracks-iOS', '0.3.4'
-	pod 'Simperium-OSX', '0.8.19'
+	pod 'Simperium-OSX', '0.8.21'
 
 	# Main Target
 	#

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -10,22 +10,22 @@ PODS:
   - CocoaLumberjack/Extensions (3.4.2):
     - CocoaLumberjack/Default
   - Reachability (3.2)
-  - Simperium-OSX (0.8.19):
-    - Simperium-OSX/DiffMatchPach (= 0.8.19)
-    - Simperium-OSX/JRSwizzle (= 0.8.19)
-    - Simperium-OSX/SocketRocket (= 0.8.19)
-    - Simperium-OSX/SPReachability (= 0.8.19)
-    - Simperium-OSX/SSKeychain (= 0.8.19)
-  - Simperium-OSX/DiffMatchPach (0.8.19)
-  - Simperium-OSX/JRSwizzle (0.8.19)
-  - Simperium-OSX/SocketRocket (0.8.19)
-  - Simperium-OSX/SPReachability (0.8.19)
-  - Simperium-OSX/SSKeychain (0.8.19)
+  - Simperium-OSX (0.8.21):
+    - Simperium-OSX/DiffMatchPach (= 0.8.21)
+    - Simperium-OSX/JRSwizzle (= 0.8.21)
+    - Simperium-OSX/SocketRocket (= 0.8.21)
+    - Simperium-OSX/SPReachability (= 0.8.21)
+    - Simperium-OSX/SSKeychain (= 0.8.21)
+  - Simperium-OSX/DiffMatchPach (0.8.21)
+  - Simperium-OSX/JRSwizzle (0.8.21)
+  - Simperium-OSX/SocketRocket (0.8.21)
+  - Simperium-OSX/SPReachability (0.8.21)
+  - Simperium-OSX/SSKeychain (0.8.21)
   - Sparkle (1.18.1)
 
 DEPENDENCIES:
   - Automattic-Tracks-iOS (= 0.3.4)
-  - Simperium-OSX (= 0.8.19)
+  - Simperium-OSX (= 0.8.21)
   - Sparkle (= 1.18.1)
 
 SPEC REPOS:
@@ -40,9 +40,9 @@ SPEC CHECKSUMS:
   Automattic-Tracks-iOS: 67d00f2f20e1978ee09154f26cdf3475d158508c
   CocoaLumberjack: db7cc9e464771f12054c22ff6947c5a58d43a0fd
   Reachability: 33e18b67625424e47b6cde6d202dce689ad7af96
-  Simperium-OSX: 14761d688e7255f00d9959010f2d79255709ceab
+  Simperium-OSX: 8eba2c7b1c0d1dfc37c66eedefdc1bd22c388c32
   Sparkle: 06ea33170007c5937ee54da481b4481af98fac79
 
-PODFILE CHECKSUM: 9849ef6cedeb76d13423e1a52cbbd02437c7e02f
+PODFILE CHECKSUM: b6a524bc48fcccb0284d33c4c54ac08524b102a8
 
 COCOAPODS: 1.6.1


### PR DESCRIPTION
### Fix
Updated the Simperium lib to the latest version. This should address the potential memory leak referenced in #206.

Fixes: #328 

### Test
Testing is basically the same as https://github.com/Automattic/simplenote-ios/pull/308 → Run the app and make sure you are able to:
* Sign in/out
* Update notes
* Create new notes
* Delete notes
* Add tags
* Changes made in the production version of the app (note edits, new notes, un-trashing notes) sync properly to this version of the app, and fairly quickly
* etc

In short, test out all corners of the app and make sure everything is still working as expected. Verify any updates to notes on https://app.simplenote.com/new

### Review
@jkmassel This is the last of these "update Simperium" PRs — thank you very much 🙇 
