### PR TITLE
Editor: History Versions is now capped to 30

### DIFF
--- a/Simplenote/NoteEditorViewController.m
+++ b/Simplenote/NoteEditorViewController.m
@@ -48,7 +48,7 @@ NSString * const SPWillAddNewNoteNotificationName       = @"SPWillAddNewNote";
 static NSString * const SPTextViewPreferencesKey        = @"kTextViewPreferencesKey";
 static NSString * const SPFontSizePreferencesKey        = @"kFontSizePreferencesKey";
 static NSString * const SPMarkdownPreferencesKey        = @"kMarkdownPreferencesKey";
-static NSInteger const SPVersionSliderMaxVersions       = 10;
+static NSInteger const SPVersionSliderMaxVersions       = 30;
 
 
 #pragma mark ====================================================================================
@@ -504,7 +504,7 @@ static NSInteger const SPVersionSliderMaxVersions       = 10;
 {
     if (self.viewingVersions) {
         if (self.noteVersionData == nil) {
-            self.noteVersionData = [NSMutableDictionary dictionaryWithCapacity:10];
+            self.noteVersionData = [NSMutableDictionary dictionaryWithCapacity:SPVersionSliderMaxVersions];
         }
         
         [self.noteVersionData setObject:data forKey:@(version.integerValue)];
@@ -642,7 +642,7 @@ static NSInteger const SPVersionSliderMaxVersions       = 10;
 
         // Request the version data from Simperium
         Simperium *simperium = [[SimplenoteAppDelegate sharedDelegate] simperium];
-        [[simperium bucketForName:@"Note"] requestVersions:10 key:self.note.simperiumKey];
+        [[simperium bucketForName:@"Note"] requestVersions:SPVersionSliderMaxVersions key:self.note.simperiumKey];
         
     } else if (self.activePopover.contentViewController == self.publishViewController) {
         NSLog(@"popOverDidShow update publish ui");


### PR DESCRIPTION
### Details:
In this PR we're updating the History's maximum number of versions to 30.

For reference, iOS is capped to 30 as weel (see [here](https://github.com/Automattic/simplenote-ios/blob/develop/Simplenote/Classes/SPNoteEditorViewController.m#L1850) and [here](https://github.com/Automattic/simplenote-ios/blob/develop/Simplenote/Classes/SPNoteEditorViewController.m#L1850)).

Closes #51

cc @bummytime 
Thanks in advance Matt!!

### Testing:
1. Log into a testing account
2. Open a note with +30 revisions
3. Click over the **History** button
- [ ] Verify the versions slider shows up to 30 entries