### PR TITLE
Publish Button Visibility

### DIFF
--- a/Simplenote/NoteEditorViewController.m
+++ b/Simplenote/NoteEditorViewController.m
@@ -148,7 +148,7 @@ static NSInteger const SPVersionSliderMaxVersions       = 10;
     // Focus can become lost when a note saves; work around that
     BOOL editorHasFocus = [[NSApp keyWindow] firstResponder] == self.noteEditor;
     NSRange range = [self.noteEditor selectedRange];
-    
+
     self.note.modificationDate = [NSDate date];
     [self.note createPreviews:self.note.content];
     

--- a/Simplenote/NoteEditorViewController.m
+++ b/Simplenote/NoteEditorViewController.m
@@ -1216,13 +1216,10 @@ static NSInteger const SPVersionSliderMaxVersions       = 10;
 
 - (NSPopover *)newPopoverWithContentViewController:(NSViewController *)viewController
 {
-    BOOL isDarkTheme                = [[[VSThemeManager sharedManager] theme] isDark];
-    NSAppearanceName appearanceName = isDarkTheme ? NSAppearanceNameVibrantLight : NSAppearanceNameVibrantDark;
-
-    NSPopover *popover              = [[NSPopover alloc] init];
+    NSPopover *popover              = [NSPopover new];
     popover.contentViewController   = viewController;
     popover.delegate                = self;
-    popover.appearance              = [NSAppearance appearanceNamed:appearanceName];
+    popover.appearance              = [NSAppearance appearanceNamed:NSAppearanceNameVibrantDark];
     popover.behavior                = NSPopoverBehaviorTransient;
     
     return popover;

--- a/Simplenote/NoteEditorViewController.m
+++ b/Simplenote/NoteEditorViewController.m
@@ -144,7 +144,7 @@ static NSInteger const SPVersionSliderMaxVersions       = 10;
     }
     
     [SPTracker trackEditorNoteEdited];
-    
+
     // Focus can become lost when a note saves; work around that
     BOOL editorHasFocus = [[NSApp keyWindow] firstResponder] == self.noteEditor;
     NSRange range = [self.noteEditor selectedRange];

--- a/Simplenote/NoteEditorViewController.m
+++ b/Simplenote/NoteEditorViewController.m
@@ -160,7 +160,7 @@ static NSInteger const SPVersionSliderMaxVersions       = 10;
 
     if (editorHasFocus) {
         [[NSApp keyWindow] makeFirstResponder:self.noteEditor];
-        
+
         if (range.location != NSNotFound && range.location < self.noteEditor.string.length) {
             [self.noteEditor setSelectedRange:range];
         }

--- a/Simplenote/NoteEditorViewController.m
+++ b/Simplenote/NoteEditorViewController.m
@@ -157,7 +157,7 @@ static NSInteger const SPVersionSliderMaxVersions       = 10;
     
 	[self.saveTimer invalidate];
 	self.saveTimer = nil;
-    
+
     if (editorHasFocus) {
         [[NSApp keyWindow] makeFirstResponder:self.noteEditor];
         

--- a/Simplenote/SPTextView.m
+++ b/Simplenote/SPTextView.m
@@ -74,7 +74,6 @@ NSInteger const ChecklistCursorAdjustment = 2;
             checklistColor = [NSColor secondaryLabelColor];
         }
     }
-    [[NSUserDefaults standardUserDefaults] objectForKey:VSThemeManagerThemePrefKey];
     
     [self.textStorage addChecklistAttachmentsForHeight:self.font.pointSize andColor:checklistColor andVerticalOffset:-4.0f];
 }

--- a/Simplenote/SPWindow.m
+++ b/Simplenote/SPWindow.m
@@ -194,9 +194,9 @@
         if (themeName) {
             self.appearance = [NSAppearance appearanceNamed:
                               [themeName isEqualToString:@"dark"] ?
-                                 NSAppearanceNameDarkAqua : NSAppearanceNameAqua];
+                                 NSAppearanceNameVibrantDark : NSAppearanceNameVibrantLight];
         }
-        
+
         // Delay needed here in order to properly adjust the stoplight buttons after theme changes
         [self performSelector:@selector(sp_layoutButtons) withObject:nil afterDelay:0.1f];
     }

--- a/Simplenote/Simplenote-DB5.plist
+++ b/Simplenote/Simplenote-DB5.plist
@@ -470,9 +470,9 @@
 		<key>lockTextColor</key>
 		<string>@textColor</string>
 		<key>popoverTextColor</key>
-		<string>000000</string>
+		<string>FFFFFF</string>
 		<key>shareUrlBackgroundColor</key>
-		<string>DDDDDD</string>
+		<string>555555</string>
 	</dict>
 </dict>
 </plist>

--- a/Simplenote/en.lproj/MainMenu.xib
+++ b/Simplenote/en.lproj/MainMenu.xib
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14460.31"/>
+        <deployment identifier="macosx"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14490.70"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -802,7 +803,7 @@
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                         <clipView key="contentView" copiesOnScroll="NO" id="UOf-YZ-mq1">
                                             <rect key="frame" x="0.0" y="0.0" width="136" height="618"/>
-                                            <autoresizingMask key="autoresizingMask"/>
+                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
                                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnSelection="YES" multipleSelection="NO" emptySelection="NO" autosaveColumns="NO" rowHeight="30" rowSizeStyle="automatic" viewBased="YES" id="1453" customClass="SPTableView">
                                                     <rect key="frame" x="0.0" y="0.0" width="136" height="618"/>
@@ -889,7 +890,7 @@
                                                                             <rect key="frame" x="0.0" y="15" width="151" height="1"/>
                                                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                                             <view key="contentView" id="8LT-ym-mnf">
-                                                                                <rect key="frame" x="1" y="0.5" width="149" height="0.0"/>
+                                                                                <rect key="frame" x="1" y="1" width="149" height="0.0"/>
                                                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                             </view>
                                                                         </box>
@@ -952,17 +953,17 @@
                                         <rect key="frame" x="0.0" y="0.0" width="270" height="618"/>
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                         <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="AdS-Q8-czF">
-                                            <rect key="frame" x="0.0" y="0.0" width="255" height="618"/>
-                                            <autoresizingMask key="autoresizingMask"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="270" height="618"/>
+                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
                                                 <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="firstColumnOnly" selectionHighlightStyle="sourceList" emptySelection="NO" autosaveColumns="NO" typeSelect="NO" rowHeight="64" rowSizeStyle="automatic" viewBased="YES" floatsGroupRows="NO" id="561" customClass="SPTableView">
-                                                    <rect key="frame" x="0.0" y="0.0" width="255" height="606"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="270" height="606"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <size key="intercellSpacing" width="0.0" height="8"/>
                                                     <color key="backgroundColor" red="1" green="0.0" blue="0.0" alpha="0.0" colorSpace="calibratedRGB"/>
                                                     <color key="gridColor" white="0.94999999999999996" alpha="1" colorSpace="deviceWhite"/>
                                                     <tableColumns>
-                                                        <tableColumn width="255" maxWidth="10000000" id="565">
+                                                        <tableColumn width="270" maxWidth="10000000" id="565">
                                                             <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left">
                                                                 <font key="font" metaFont="smallSystem"/>
                                                                 <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
@@ -977,11 +978,11 @@
                                                             <tableColumnResizingMask key="resizingMask" resizeWithTable="YES"/>
                                                             <prototypeCellViews>
                                                                 <tableCellView identifier="CustomCell" id="607" customClass="SPNoteCellView">
-                                                                    <rect key="frame" x="0.0" y="4" width="255" height="64"/>
+                                                                    <rect key="frame" x="0.0" y="4" width="270" height="64"/>
                                                                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMaxX="YES" flexibleMinY="YES" heightSizable="YES" flexibleMaxY="YES"/>
                                                                     <subviews>
                                                                         <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" allowsCharacterPickerTouchBarItem="YES" id="1103">
-                                                                            <rect key="frame" x="18" y="0.0" width="229" height="59"/>
+                                                                            <rect key="frame" x="18" y="0.0" width="244" height="59"/>
                                                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES" heightSizable="YES"/>
                                                                             <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="This is some text in a note that is long enough to allow us to preview what it will look like inside the app." placeholderString="" allowsEditingTextAttributes="YES" id="1104">
                                                                                 <font key="font" size="12" name="Helvetica"/>
@@ -1017,7 +1018,7 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                         </scroller>
                                         <scroller key="verticalScroller" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="564" customClass="MMScroller">
-                                            <rect key="frame" x="255" y="0.0" width="15" height="618"/>
+                                            <rect key="frame" x="254" y="0.0" width="16" height="618"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                         </scroller>
                                         <connections>
@@ -1047,8 +1048,8 @@
                                         <rect key="frame" x="0.0" y="43" width="493" height="575"/>
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                         <clipView key="contentView" copiesOnScroll="NO" id="LKV-y0-209">
-                                            <rect key="frame" x="0.0" y="0.0" width="478" height="575"/>
-                                            <autoresizingMask key="autoresizingMask"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="493" height="575"/>
+                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
                                                 <textView drawsBackground="NO" importsGraphics="NO" richText="NO" verticallyResizable="YES" findStyle="panel" incrementalSearchingEnabled="YES" continuousSpellChecking="YES" allowsUndo="YES" allowsNonContiguousLayout="YES" linkDetection="YES" dataDetection="YES" spellingCorrection="YES" smartInsertDelete="YES" id="934" customClass="SPTextView">
                                                     <rect key="frame" x="0.0" y="0.0" width="478" height="575"/>
@@ -1070,7 +1071,7 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                         </scroller>
                                         <scroller key="verticalScroller" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="936" customClass="MMScroller">
-                                            <rect key="frame" x="478" y="0.0" width="15" height="575"/>
+                                            <rect key="frame" x="477" y="0.0" width="16" height="575"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                         </scroller>
                                     </scrollView>
@@ -1298,17 +1299,6 @@
                                     <color key="backgroundColor" white="0.0" alpha="0.31" colorSpace="calibratedWhite"/>
                                 </textFieldCell>
                             </textField>
-                            <button toolTip="Publishes this note to a public web page" verticalHuggingPriority="750" id="1063">
-                                <rect key="frame" x="21" y="67" width="195" height="17"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                <buttonCell key="cell" type="inline" title="Publish to Web Page" bezelStyle="inline" alignment="center" borderStyle="border" inset="2" id="1064">
-                                    <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES" changeBackground="YES" changeGray="YES"/>
-                                    <font key="font" metaFont="smallSystemBold"/>
-                                </buttonCell>
-                                <connections>
-                                    <action selector="publishAction:" target="1107" id="1664"/>
-                                </connections>
-                            </button>
                             <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" allowsCharacterPickerTouchBarItem="YES" id="1068">
                                 <rect key="frame" x="12" y="3" width="214" height="54"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
@@ -1318,13 +1308,25 @@
                                     <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                 </textFieldCell>
                             </textField>
+                            <button toolTip="Publishes this note to a public web page" verticalHuggingPriority="750" id="1063">
+                                <rect key="frame" x="9" y="56" width="220" height="32"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                <buttonCell key="cell" type="push" title="Publish to Web Page" bezelStyle="rounded" alignment="center" borderStyle="border" inset="2" id="1064">
+                                    <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                    <font key="font" metaFont="system"/>
+                                </buttonCell>
+                                <color key="contentTintColor" red="0.58188301320000002" green="0.21569153669999999" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <connections>
+                                    <action selector="publishAction:" target="1107" id="1664"/>
+                                </connections>
+                            </button>
                         </subviews>
                     </view>
                     <color key="borderColor" white="0.5" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
                     <color key="fillColor" name="textColor" catalog="System" colorSpace="catalog"/>
                 </box>
             </subviews>
-            <point key="canvasLocation" x="176" y="395.5"/>
+            <point key="canvasLocation" x="-191" y="607"/>
         </customView>
         <viewController id="1090" userLabel="Versions Popover Controller" customClass="VersionsViewController">
             <connections>
@@ -1378,7 +1380,7 @@
                     </textFieldCell>
                 </textField>
             </subviews>
-            <point key="canvasLocation" x="138.5" y="153.5"/>
+            <point key="canvasLocation" x="107" y="580"/>
         </customView>
         <menuItem title="Item" id="1668">
             <modifierMask key="keyEquivalentModifierMask"/>


### PR DESCRIPTION
### Details:
Our **Publish** UI was using a NSButton of the **Inline** type, **bordered**. This means that: the text's background color, itself, is taken from the NSView placed immediately below such button.

Instead of adding another NSView below, and attempt to tint the button, I've opted for replicating the exact same UI we've got for the **History** picker.

Closes #311 


### Testing
1. Launch Simplenote
2. Set the **Dark Theme**
3. Open any random note
4. Click over the **Share button** >> **Publish to Web**
5. Verify the `Publish to Webpage` button looks correctly
6. Switch to **Light Theme**
7. Repeat the same steps and verify the button also looks well

---

### Screenshots: Dark Theme (Now)

<img width="270" alt="Screen Shot 2019-05-29 at 9 37 18 AM" src="https://user-images.githubusercontent.com/1195260/58557831-b844d480-81f5-11e9-8bc8-f3ad96e99eee.png">
<img width="250" alt="Screen Shot 2019-05-29 at 9 37 12 AM" src="https://user-images.githubusercontent.com/1195260/58557832-b844d480-81f5-11e9-837a-3ab5d50404c3.png">

### Screenshots: Light Theme (Now)

<img width="262" alt="Screen Shot 2019-05-29 at 9 37 45 AM" src="https://user-images.githubusercontent.com/1195260/58557847-bed34c00-81f5-11e9-9ce1-fbf3cb26dfbf.png">
<img width="276" alt="Screen Shot 2019-05-29 at 9 37 51 AM" src="https://user-images.githubusercontent.com/1195260/58557848-bf6be280-81f5-11e9-8b47-650ec4f61a29.png">
