### PR TITLE
Add CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,33 @@
+version: 2.1
+
+orbs:
+  # This uses the Orbs located at https://github.com/wordpress-mobile/circleci-orbs
+  ios: wordpress-mobile/ios@0.0.27
+
+jobs:
+  Build:
+    executor:
+      name: ios/default
+      xcode-version: "10.2.0"
+    steps:
+      - checkout
+      - run:
+          name: Copy demo config.plist
+          command: cp Simplenote/config-demo.plist Simplenote/config.plist
+      - ios/install-dependencies:
+          bundle-install: true
+          pod-install: true
+      - run:
+          name: Build
+          command: |
+            # Build without code signing to avoid missing cert errors
+            xcodebuild COMPILER_INDEX_STORE_ENABLE=NO CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO \
+                       -workspace 'Simplenote.xcworkspace' \
+                       -scheme 'Simplenote' \
+                       -configuration 'Debug' \
+                       build
+
+workflows:
+  simplenote_macos:
+    jobs:
+      - Build

--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,6 @@ Icon
 !default.mode2v3
 *.perspectivev3
 !default.perspectivev3
-*.xcworkspace
 !default.xcworkspace
 xcuserdata
 profile

--- a/Simplenote.xcworkspace/contents.xcworkspacedata
+++ b/Simplenote.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:Simplenote.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/Simplenote.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Simplenote.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
This adds a CircleCI config to the repo as we have in all other projects. It runs this job on each push:

- Build: Installs dependencies and builds the `Simplenote` scheme. Run time with warm cache is about 1.5 minutes.

I have also removed `Simplenote.xcworkspace` from `.gitignore` as in https://github.com/Automattic/simplenote-ios/pull/316.

See also https://github.com/Automattic/simplenote-ios/pull/316 and https://github.com/Automattic/simplenote-android/pull/685

### Test

See that the CircleCI checks on this PR are green and that the build runs successfully.
