### PR TITLE
Add configuration for Hound and Swiftlint

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,7 @@
+fail_on_violations: true
+
+rubocop:
+  enabled: false
+  
+swiftlint:
+  config_file: .swiftlint.yml

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,79 @@
+# Project configuration
+excluded:
+  - Pods
+  - fastlane
+  - vendor
+  - External
+
+# Rules
+whitelist_rules:
+  # Colons should be next to the identifier when specifying a type.
+  - colon
+
+  # There should be no space before and one after any comma.
+  - comma
+
+  # if,for,while,do statements shouldn't wrap their conditionals in parentheses.
+  - control_statement
+
+  # Arguments can be omitted when matching enums with associated types if they
+  # are not used.
+  - empty_enum_arguments
+
+  # Prefer `() -> ` over `Void -> `.
+  - empty_parameters
+
+  # MARK comment should be in valid format.
+  - mark
+
+  # Opening braces should be preceded by a single space and on the same line as
+  # the declaration.
+  - opening_brace
+
+  # Files should have a single trailing newline.
+  - trailing_newline
+
+  # Lines should not have trailing semicolons.
+  - trailing_semicolon
+
+  # Lines should not have trailing whitespace.
+  - trailing_whitespace
+
+  - custom_rules
+
+# Rules configuration
+
+control_statement: 
+  severity: error 
+
+custom_rules:
+
+  natural_content_alignment:
+    name: "Natural Content Alignment"
+    regex: '\.contentHorizontalAlignment(\s*)=(\s*)(\.left|\.right)'
+    message: "Forcing content alignment left or right can affect the Right-to-Left layout. Use naturalContentHorizontalAlignment instead."
+    severity: warning
+
+  natural_text_alignment:
+    name: "Natural Text Alignment"
+    regex: '\.textAlignment(\s*)=(\s*).left'
+    message: "Forcing text alignment to left can affect the Right-to-Left layout. Consider setting it to `natural`"
+    severity: warning
+
+  inverse_text_alignment:
+    name: "Inverse Text Alignment"
+    regex: '\.textAlignment(\s*)=(\s*).right'
+    message: "When forcing text alignment to the right, be sure to handle the Right-to-Left layout case properly, and then silence this warning with this line `// swiftlint:disable:next inverse_text_alignment`"
+    severity: warning
+
+  localization_comment:
+    name: "Localization Comment"
+    regex: 'NSLocalizedString([^,]+,\s+comment:\s*"")'
+    message: "Localized strings should include a description giving context for how the string is used."
+    severity: warning
+
+  string_interpolation_in_localized_string:
+    name: "String Interpolation in Localized String"
+    regex: 'NSLocalizedString\("[^"]*\\\(\S*\)'
+    message: "Localized strings must not use interpolated variables. Instead, use `String(format:`"
+    severity: error


### PR DESCRIPTION
### Fix

This adds the necessary config to run Swiftlint/Hound on every PR. As a starting point, I have copied the configuration from WordPress-iOS. It is the same config as I have added in https://github.com/Automattic/simplenote-ios/pull/317.

**Note:** CircleCI will show as failing until https://github.com/Automattic/simplenote-macos/pull/335 is merged.

### Test

- See that Hound has run on this PR. You can see an example failing PR here: https://github.com/Automattic/simplenote-macos/pull/337.
- Run `rake lint` to see the existing lint violations in the repo.