### PR TITLE
Fix beta build

### DIFF
--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -1529,7 +1529,7 @@
 					"-all_load",
 					"${inherited}",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.Simplenote;
+				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.SimplenoteMac.beta;
 				PRODUCT_NAME = Simplenote;
 				PROVISIONING_PROFILE = "";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1579,7 +1579,7 @@
 					"-all_load",
 					"${inherited}",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.Simplenote;
+				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.SimplenoteMac.beta;
 				PRODUCT_NAME = Simplenote;
 				PROVISIONING_PROFILE = "";
 				PROVISIONING_PROFILE_SPECIFIER = "";


### PR DESCRIPTION
This PR changes the App ID for the beta build in order to match the new one we had to create on the App Developer portal. 

## To Test:
1. Verify that the build completes without errors.
2. Archive the app and verity that it's possible to export it signing with Developer ID.