### PR TITLE
Update the project to use external xcconfig file for versioning

### DIFF
--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -158,6 +158,9 @@
 		71D83D7014D744FB00A25E69 /* SPNoteCellView.m in Sources */ = {isa = PBXBuildFile; fileRef = 71D83D6F14D744FB00A25E69 /* SPNoteCellView.m */; };
 		71D83D7314D75C0A00A25E69 /* SPTagCellView.m in Sources */ = {isa = PBXBuildFile; fileRef = 71D83D7214D75C0A00A25E69 /* SPTagCellView.m */; };
 		71DCEBE7152E2ED1002744C0 /* NSMutableAttributedString+Styling.m in Sources */ = {isa = PBXBuildFile; fileRef = 71DCEBE6152E2ED1002744C0 /* NSMutableAttributedString+Styling.m */; };
+		8C902F8822D3ED910018D654 /* Simplenote.release.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 8C902F8722D3ED910018D654 /* Simplenote.release.xcconfig */; };
+		8C902F8922D3ED910018D654 /* Simplenote.release.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 8C902F8722D3ED910018D654 /* Simplenote.release.xcconfig */; };
+		8C902F8D22D3EE350018D654 /* Version.public.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 8C902F8C22D3EE350018D654 /* Version.public.xcconfig */; };
 		B5087A151AF3AB9D00505A2B /* ShareViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = B5087A141AF3AB9D00505A2B /* ShareViewController.m */; };
 		B5087A161AF3AB9D00505A2B /* ShareViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = B5087A141AF3AB9D00505A2B /* ShareViewController.m */; };
 		B5087A1E1AF3AF5E00505A2B /* VersionsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = B5087A1D1AF3AF5E00505A2B /* VersionsViewController.m */; };
@@ -421,6 +424,9 @@
 		71D83D7214D75C0A00A25E69 /* SPTagCellView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPTagCellView.m; sourceTree = "<group>"; };
 		71DCEBE5152E2ED1002744C0 /* NSMutableAttributedString+Styling.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSMutableAttributedString+Styling.h"; sourceTree = "<group>"; };
 		71DCEBE6152E2ED1002744C0 /* NSMutableAttributedString+Styling.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSMutableAttributedString+Styling.m"; sourceTree = "<group>"; };
+		8C902F8722D3ED910018D654 /* Simplenote.release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Simplenote.release.xcconfig; path = config/Simplenote.release.xcconfig; sourceTree = "<group>"; };
+		8C902F8C22D3EE350018D654 /* Version.public.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Version.public.xcconfig; path = config/Version.public.xcconfig; sourceTree = "<group>"; };
+		8C902F8E22D3EFE60018D654 /* Simplenote.debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Simplenote.debug.xcconfig; path = config/Simplenote.debug.xcconfig; sourceTree = "<group>"; };
 		A87415AA90AE50393BFC666C /* Pods-Simplenote-AppStore.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Simplenote-AppStore.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Simplenote-AppStore/Pods-Simplenote-AppStore.debug.xcconfig"; sourceTree = "<group>"; };
 		B5087A131AF3AB9D00505A2B /* ShareViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ShareViewController.h; sourceTree = "<group>"; };
 		B5087A141AF3AB9D00505A2B /* ShareViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ShareViewController.m; sourceTree = "<group>"; };
@@ -536,6 +542,7 @@
 		26F72A7D14032D2900A7935E = {
 			isa = PBXGroup;
 			children = (
+				8C902F8B22D3EDB30018D654 /* config */,
 				26F72A9214032D2A00A7935E /* Simplenote */,
 				26DBB1F61405A6E600186392 /* External */,
 				714BA64814D2333C00A6CCC1 /* Resources */,
@@ -859,6 +866,16 @@
 			name = "Custom Views";
 			sourceTree = "<group>";
 		};
+		8C902F8B22D3EDB30018D654 /* config */ = {
+			isa = PBXGroup;
+			children = (
+				8C902F8C22D3EE350018D654 /* Version.public.xcconfig */,
+				8C902F8722D3ED910018D654 /* Simplenote.release.xcconfig */,
+				8C902F8E22D3EFE60018D654 /* Simplenote.debug.xcconfig */,
+			);
+			name = config;
+			sourceTree = "<group>";
+		};
 		B54739DC1A3F389300B68A4D /* HockeySDK */ = {
 			isa = PBXGroup;
 			children = (
@@ -998,7 +1015,9 @@
 				26F72A9714032D2A00A7935E /* InfoPlist.strings in Resources */,
 				376EE3E9202A558E00E3812E /* simplenote.iconset in Resources */,
 				378AA6F81ACB04FD00CA87DC /* Simplenote-DB5.plist in Resources */,
+				8C902F8822D3ED910018D654 /* Simplenote.release.xcconfig in Resources */,
 				26F72AA314032D2A00A7935E /* MainMenu.xib in Resources */,
+				8C902F8D22D3EE350018D654 /* Version.public.xcconfig in Resources */,
 				3712FCA21FE1ACAA008544AC /* Info.plist in Resources */,
 				B5F04FD3215964BC004B1AA0 /* Privacy.storyboard in Resources */,
 				37AE49C91FFEBB0B00FCB165 /* markdown-dark.css in Resources */,
@@ -1016,6 +1035,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B5B410BF1B17F28500CFCF8D /* Simplenote-DB5.plist in Resources */,
+				8C902F8922D3ED910018D654 /* Simplenote.release.xcconfig in Resources */,
 				466FFEE617CC10A800399652 /* InfoPlist.strings in Resources */,
 				466FFEE717CC10A800399652 /* Credits.rtf in Resources */,
 				B5F04FD4215964BC004B1AA0 /* Privacy.storyboard in Resources */,
@@ -1392,6 +1412,7 @@
 /* Begin XCBuildConfiguration section */
 		26F72AA714032D2A00A7935E /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 8C902F8E22D3EFE60018D654 /* Simplenote.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = YES;
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
@@ -1447,6 +1468,7 @@
 		};
 		26F72AA814032D2A00A7935E /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 8C902F8722D3ED910018D654 /* Simplenote.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = YES;
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;

--- a/Simplenote/Simplenote-Info-Hockey.plist
+++ b/Simplenote/Simplenote-Info-Hockey.plist
@@ -21,7 +21,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.5.0</string>
+	<string>$VERSION_SHORT</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -38,7 +38,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>1500</string>
+	<string>$VERSION_LONG</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.productivity</string>
 	<key>LSMinimumSystemVersion</key>

--- a/Simplenote/Simplenote-Info.plist
+++ b/Simplenote/Simplenote-Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.5.0</string>
+	<string>$VERSION_SHORT</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -38,7 +38,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>1500</string>
+	<string>$VERSION_LONG</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.productivity</string>
 	<key>LSMinimumSystemVersion</key>

--- a/config/Simplenote.debug.xcconfig
+++ b/config/Simplenote.debug.xcconfig
@@ -1,0 +1,1 @@
+#include "Version.public.xcconfig"

--- a/config/Simplenote.release.xcconfig
+++ b/config/Simplenote.release.xcconfig
@@ -1,0 +1,1 @@
+#include "Version.public.xcconfig"

--- a/config/Version.public.xcconfig
+++ b/config/Version.public.xcconfig
@@ -1,0 +1,4 @@
+VERSION_SHORT=1.5
+
+// Public long version example: VERSION_LONG=9.9.0.0
+VERSION_LONG=1.5.0.0


### PR DESCRIPTION
This PR moves the management of the version of the app from the project file to .xcconfig files, following what we already do in other apps, in order to be able to share some releasing tools.

# To Test:
1. Clean your build folder and build the app
2. Locate Products > Simplenote.app within Xcode.
3. Right click on it and select "Show in finder"
4. Right click on the app icon and select "Show Contents"
5. Locate the "Info.plist" file, open it, and make sure the version number is correct.
6. Run the app and verify that everything is working and that the version is correctly picked in the about screen.