### PR TITLE
Fix incorrect crash log environment detection

### DIFF
--- a/Simplenote/CrashLogging.swift
+++ b/Simplenote/CrashLogging.swift
@@ -57,16 +57,7 @@ private class SNCrashLoggingDataProvider: CrashLoggingDataProvider {
     }
 
     var buildType: String {
-
-        #if APP_STORE_BUILD
-        return  "app-store"
-        #endif
-
-        #if PUBLIC_BUILD
-        return "public"
-        #endif
-
-        return "developer-internal"
+        return SPBuildType
     }
 
     var currentUser: TracksUser? {

--- a/Simplenote/SPConstants.h
+++ b/Simplenote/SPConstants.h
@@ -28,3 +28,5 @@ extern NSString * const SPWPSignInAuthURL;
 extern NSString * const SPHelpURL;
 extern NSString * const SPContactUsURL;
 extern NSString * const SPTwitterURL;
+
+extern NSString * const SPBuildType;

--- a/Simplenote/SPConstants.m
+++ b/Simplenote/SPConstants.m
@@ -28,3 +28,11 @@ NSString * const SPWPSignInAuthURL                  = @"https://public-api.wordp
 NSString * const SPHelpURL                          = @"https://simplenote.com/help";
 NSString * const SPContactUsURL                     = @"https://simplenote.com/contact-us";
 NSString * const SPTwitterURL                       = @"https://twitter.com/simplenoteapp";
+
+#if APP_STORE_BUILD
+NSString * const SPBuildType                       = @"app-store";
+#elif PUBLIC_BUILD
+NSString * const SPBuildType                       = @"public";
+#else
+NSString * const SPBuildType                       = @"developer-internal";
+#endif


### PR DESCRIPTION
### Fix
Currently, the environment detection isn't working correctly. The code tries to read GCC preprocessor macros from Swift, which can't be done. 

The fix moves the environment detection into a constant which is simply read by Swift.

### Test
0. Checkout this branch, run `bundle exec pod install`.
1. Add `debugPrint("Starting Crash Logging Data Provider with build type: \(self.buildType)")` [here](https://github.com/Automattic/simplenote-macos/blob/550273893c3309ae68bee93c45abc6009c94d0c7/Simplenote/CrashLogging.swift#L35).
2. Run the `Simplenote` target, and filter your Xcode console to search for "build type".
3. Confirm that the console reports `developer-internal` as the build type. 
4. To simulate an App Store release build, add `APP_STORE_BUILD=1` to Project Settings > Target: Simplenote > Build Settings > Preprocessor Macros > Debug. Run the app again, and confirm that the console now reports `app-store` as the build type.
5. To simulate an ad-hoc release build, replace `APP_STORE_BUILD=1` with `PUBLIC_BUILD=1`. Run the app again, and confirm that the console now reports `public` as the build type.

### Review
This change will not survive a transition to Swift. If we go that way, I think we'd likely adopt a system [like this](https://github.com/woocommerce/woocommerce-ios/blob/develop/WooCommerce/Classes/System/BuildConfiguration.swift), with some modifications to support the difference between App Store / ad-hoc distribution. For now, this was a quick, clean fix.

### Release
This is not a user-facing change, so no release note changes are required.