### PR TITLE
Update fastlane

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ source 'https://rubygems.org' do
   gem 'octokit', "~> 4.0"
   gem 'dotenv'
   gem 'rubyzip', "~> 1.2.2"
-  gem "fastlane", "~> 2.103"
+  gem "fastlane", "~> 2.127.2"
 end
 
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,7 +77,7 @@ GEM
     dotenv (2.7.2)
     emoji_regex (1.0.1)
     escape (0.0.4)
-    excon (0.64.0)
+    excon (0.65.0)
     faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
     faraday-cookie_jar (0.0.6)
@@ -86,7 +86,7 @@ GEM
     faraday_middleware (0.13.1)
       faraday (>= 0.7.4, < 1.0)
     fastimage (2.1.5)
-    fastlane (2.127.1)
+    fastlane (2.127.2)
       CFPropertyList (>= 2.3, < 4.0.0)
       addressable (>= 2.3, < 3.0.0)
       babosa (>= 1.0.2, < 2.0.0)
@@ -106,7 +106,7 @@ GEM
       highline (>= 1.7.2, < 2.0.0)
       json (< 3.0.0)
       jwt (~> 2.1.0)
-      mini_magick (~> 4.5.1)
+      mini_magick (>= 4.9.4, < 5.0.0)
       multi_xml (~> 0.5)
       multipart-post (~> 2.0.0)
       plist (>= 3.1.0, < 4.0.0)
@@ -166,7 +166,7 @@ GEM
     mime-types (3.2.2)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2019.0331)
-    mini_magick (4.5.1)
+    mini_magick (4.9.5)
     mini_portile2 (2.4.0)
     minitest (5.11.3)
     molinillo (0.6.6)
@@ -249,7 +249,7 @@ DEPENDENCIES
   cocoapods (= 1.6.1)!
   cocoapods-repo-update (~> 0.0.3)!
   dotenv!
-  fastlane (~> 2.103)!
+  fastlane (~> 2.127.2)!
   fastlane-plugin-wpmreleasetoolkit!
   octokit (~> 4.0)!
   rake!


### PR DESCRIPTION
This PR updates Fastlane to get rid of the mini_magick security alert.

To test:

1. Run `bundle install`.
2. Run one of the release lanes (like build_and_upload_internal) and verify that it works.