### PR TITLE
1 Infinite Loop Bugfix

### DIFF
--- a/External/custom-scroller/MMScrollView.m
+++ b/External/custom-scroller/MMScrollView.m
@@ -19,7 +19,15 @@
     height = [self bounds].size.height;
 	frame = NSMakeRect([self bounds].size.width - 15, 0, 15, height);
 	[[self verticalScroller] setFrame:frame];
-	
+
+
+    // The following (legacy) workaround triggers a layout loop in 10.12. Disabling this behavior for 10.12 and upwards.
+    // Ref. https://github.com/Automattic/simplenote-macos/issues/369
+    //
+    if (@available(macOS 10.12, *)) {
+        return;
+    }
+
 	[[self verticalScroller] retain];
 	[[self verticalScroller] removeFromSuperview];
 	[self addSubview:[self verticalScroller]];


### PR DESCRIPTION
### Details:
In this PR we're neutralizing a legacy workaround which, starting from the latest High Sierra build, triggers a layout loop that kills the CPU.

cc @bummytime 
Closes #369

### Testing:
- [x] Verify the app builds correctly
- [x] Verify all of the NSScrolllView instances behave and look as ever: Left / Center / Right panels
