### PR TITLE
Updates SignUp password length

### DIFF
--- a/Simplenote/LoginWindowController.m
+++ b/Simplenote/LoginWindowController.m
@@ -12,6 +12,8 @@
 
 static CGFloat const SPLoginAdditionalHeight        = 40.0f;
 static CGFloat const SPLoginWPButtonWidth           = 270.0f;
+static NSInteger const SPLoginPasswordLength        = 4;
+static NSInteger const SPSignupPasswordLength       = 6;
 static NSString *SPAuthSessionKey                   = @"SPAuthSessionKey";
 
 @implementation LoginWindowController
@@ -101,7 +103,7 @@ static NSString *SPAuthSessionKey                   = @"SPAuthSessionKey";
     [alert runModal];
 }
 
-#pragma mark - Overriden Methods
+#pragma mark - Overridden Methods
 
 - (IBAction)signUpAction:(id)sender
 {
@@ -117,6 +119,13 @@ static NSString *SPAuthSessionKey                   = @"SPAuthSessionKey";
 
 - (void)dealloc {
     [[NSNotificationCenter defaultCenter] removeObserver: self];
+}
+
+#pragma mark - Overridden Properties
+
+- (void)setSigningIn:(BOOL)signingIn {
+    [super setSigningIn:signingIn];
+    self.validator.minimumPasswordLength = signingIn ? SPLoginPasswordLength : SPSignupPasswordLength;
 }
 
 @end


### PR DESCRIPTION
### Detaills:
In this PR we're updating the minimum password length to 6 characters (for SignUp).

Closes #371
@aerych may i trouble you with yet another Simplenote PR? (THANK YOU!!!)

### Testing: Warning / Signup
1. Fresh install the app
2. Enter a valid email
3. Click over the **SignUp** button (blue background)

- [x] Verify that the warning requires a password with at least 6 characters.

### Testing: Warning / Login
1. Fresh install the app
2. Click over the **SignIn** button (at the bottom)
2. Enter a valid email
4. Click over the **SignIn** button (blue background)

- [x] Verify that the warning requires a password with at least 4 characters.

### Testing: Regressions
- [x] Verify that the SignUp UI effectively creates a new user, whenever the password is 6 characters in length
- [x] Verify that the LogIn UI works as expected, with users that have passwords with 4 characters in length (DM me for testing creds here!)
