### PR TITLE
Fixing Emoji's AWOL Bug

### DIFF
--- a/External/Notepad/Storage.swift
+++ b/External/Notepad/Storage.swift
@@ -100,7 +100,7 @@ class Storage: NSTextStorage {
         replaceBackingStringSubrange(range, with: attrString.string)
 
         let change = attrString.length - range.length
-        self.edited(.editedCharacters, range: range, changeInLength: change)
+        self.edited([.editedCharacters, .editedAttributes], range: range, changeInLength: change)
         self.endEditing()
     }
 

--- a/External/Notepad/Storage.swift
+++ b/External/Notepad/Storage.swift
@@ -17,7 +17,7 @@ class Storage: NSTextStorage {
 
     /// The Theme for the Notepad
     ///
-    public var theme: Theme? {
+    private var theme: Theme = Theme(markdownEnabled: false) {
         didSet {
             let wholeRange = NSRange(location: 0, length: (self.backingString as NSString).length)
 
@@ -35,11 +35,11 @@ class Storage: NSTextStorage {
 
     /// The underlying text storage implementation.
     ///
-    var backingStore = NSMutableAttributedString(string: "", attributes: [:])
+    private let backingStore = NSMutableAttributedString(string: "", attributes: [:])
 
     /// Indicates if Markdown is enabled
     ///
-    var markdownEnabled = false
+    private var markdownEnabled = false
 
     /// Returns the BackingString
     ///
@@ -52,12 +52,6 @@ class Storage: NSTextStorage {
     ///
     override init() {
         super.init()
-    }
-
-    @objc class func newInstance() -> Storage {
-        let storage = Storage()
-        storage.theme = Theme(markdownEnabled: false)
-        return storage
     }
 
     override init(attributedString attrStr: NSAttributedString) {

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,8 @@
+1.7.1
+-----
+
+- Fixed a bug that caused emojis to disappear
+
 1.6.0
 -----
 

--- a/Simplenote/NoteEditorViewController.m
+++ b/Simplenote/NoteEditorViewController.m
@@ -102,7 +102,7 @@ static NSInteger const SPVersionSliderMaxVersions       = 30;
 - (void)awakeFromNib
 {
     [self.noteEditor setFrameSize:NSMakeSize(self.noteEditor.frame.size.width-kMinEditorPadding/2, self.noteEditor.frame.size.height-kMinEditorPadding/2)];
-    self.storage = [Storage newInstance];
+    self.storage = [Storage new];
     [self.noteEditor.layoutManager replaceTextStorage:self.storage];
     [self.noteEditor.layoutManager setDefaultAttachmentScaling:NSImageScaleProportionallyDown];
     

--- a/Simplenote/SPTextView.m
+++ b/Simplenote/SPTextView.m
@@ -209,4 +209,22 @@ NSInteger const ChecklistCursorAdjustment = 2;
     return [string substringWithRange:match.range];
 }
 
+- (void)setSelectedRange:(NSRange)selectedRange
+{
+    NSRange patchedSelectionRange = [self fixSelectedRange:selectedRange];
+    [super setSelectedRange:patchedSelectionRange];
+}
+
+// HACK HACK: Only required in macOS Catalina.
+// See Storage.swift `perserveRealEditedRange` for details!
+- (NSRange)fixSelectedRange:(NSRange)selectedRange
+{
+    if (![self.textStorage isKindOfClass:[Storage class]]) {
+        return selectedRange;
+    }
+
+    Storage* storage = (Storage *)self.textStorage;
+    return storage.shouldOverrideSelectionRange ? storage.overrideSelectionRange : selectedRange;
+}
+
 @end


### PR DESCRIPTION
### Fix
In this PR we're fixing a bug that caused emojis to disappear in macOS Catalina + Xcode 11.x.

@aerych Last quick one, I promise!! Thanks in advance!!!
Closes #395 

### Test
1. Log into your account
2. Create a new note
3. Insert 😃
4. Insert ☺️

- [x] Verify both emojis show up side by side!

### Release
> `RELEASE-NOTES.txt` was updated in aece060 with:
> 
> > Fixed a bug that caused emojis to disappear
