### PR TITLE
Update XCode version on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
   Build:
     executor:
       name: ios/default
-      xcode-version: "10.2.0"
+      xcode-version: "11.2.1"
     steps:
       - checkout
       - run:


### PR DESCRIPTION
### Fix
This PR updates the version of XCode used by the CI in order to make it match the one we use for development.

### Test
1. Check CI is green

### Release
These changes do not require release notes.
