### PR TITLE
Fix: Surrogate Pairs (Mark II)

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -16,7 +16,7 @@ abstract_target 'Automattic' do
   # Automattic Shared
   #
   pod 'Automattic-Tracks-iOS', '~> 0.4'
-  pod 'Simperium-OSX', '0.8.24'
+  pod 'Simperium-OSX', '0.8.25'
 
   # Main Target
   #

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -11,21 +11,21 @@ PODS:
   - Sentry (4.3.4):
     - Sentry/Core (= 4.3.4)
   - Sentry/Core (4.3.4)
-  - Simperium-OSX (0.8.24):
-    - Simperium-OSX/DiffMatchPach (= 0.8.24)
-    - Simperium-OSX/JRSwizzle (= 0.8.24)
-    - Simperium-OSX/SocketRocket (= 0.8.24)
-    - Simperium-OSX/SPReachability (= 0.8.24)
-    - Simperium-OSX/SSKeychain (= 0.8.24)
-  - Simperium-OSX/DiffMatchPach (0.8.24)
-  - Simperium-OSX/JRSwizzle (0.8.24)
-  - Simperium-OSX/SocketRocket (0.8.24)
-  - Simperium-OSX/SPReachability (0.8.24)
-  - Simperium-OSX/SSKeychain (0.8.24)
+  - Simperium-OSX (0.8.25):
+    - Simperium-OSX/DiffMatchPach (= 0.8.25)
+    - Simperium-OSX/JRSwizzle (= 0.8.25)
+    - Simperium-OSX/SocketRocket (= 0.8.25)
+    - Simperium-OSX/SPReachability (= 0.8.25)
+    - Simperium-OSX/SSKeychain (= 0.8.25)
+  - Simperium-OSX/DiffMatchPach (0.8.25)
+  - Simperium-OSX/JRSwizzle (0.8.25)
+  - Simperium-OSX/SocketRocket (0.8.25)
+  - Simperium-OSX/SPReachability (0.8.25)
+  - Simperium-OSX/SSKeychain (0.8.25)
 
 DEPENDENCIES:
   - Automattic-Tracks-iOS (~> 0.4)
-  - Simperium-OSX (= 0.8.24)
+  - Simperium-OSX (= 0.8.25)
 
 SPEC REPOS:
   https://github.com/cocoapods/specs.git:
@@ -40,8 +40,8 @@ SPEC CHECKSUMS:
   CocoaLumberjack: 2f44e60eb91c176d471fdba43b9e3eae6a721947
   Reachability: 33e18b67625424e47b6cde6d202dce689ad7af96
   Sentry: 26f0e6492b103e87434d1a5eea2d241a36f2c2a2
-  Simperium-OSX: 188702ea73e75fdb00fcc4b507b7f3148c020187
+  Simperium-OSX: 2a8542be36ec1de3c3cb2470bf9ccf40cbe939f2
 
-PODFILE CHECKSUM: 9ac46160d8fbf4edfe9eb83a7cf81419c75c82e3
+PODFILE CHECKSUM: a993425d1037cca48cdf7080d495ac64e06e9afc
 
 COCOAPODS: 1.6.1

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,7 @@
+1.8.1
+-----
+- Fixed a bug that caused notes with specific emoji sequences to crash the app
+
 1.8.0
 -----
 - Fixed a bug that caused emojis to disappear


### PR DESCRIPTION
### Fix
In this PR we're updating the Simperium dependency to Mark 0.8.25, which contains a second Surrogate Pairs fix.

Closes #419

### Test: Regression!
1. Add a new note
2. Enter the following emojis: ☺️🖖🏿
3. Insert the following emoji in between: 😃

- [x] Verify the app doesn't break!

### Test: New Crash!
1. Add a new note
2. Enter the following string

```
😃🖖🏻🖖🏻🖖🏿
🥶🥶🥶👈🏼🖖🏻😉🖖🏽🖖🏿😉🥶🥶🥶👈🏼🖖🏻😉🖖🏽🖖🏿😉🥶🥶🥶👈🏼🖖🏻😉🖖🏽🖖🏿😉

.👉🏽👉🏽👉🏽👉🏽👉🏽👉🏽👉🏽👉🏽👉🏽s👈🏿👈🏿👈🏿👈🏿👈🏿👈🏿👈🏿👈🏿👈🏿.
🥶🥶🥶👈🏼🖖🏻😉🖖🏽🖖🏿😉🥶🥶🥶👈🏼🖖🏻😉🖖🏽🖖🏿😉🥶🥶🥶👈🏼🖖🏻😉🖖🏽🖖🏿😉
.👉🏽👈🏿👈🏿👈🏿🥶🥶🥶🥶🥶👈🏼🖖🏻👈🏼s🖖🏻👈🏼😋

dasdas
dasvafksdldasfadsxc vzx
```

3. Replace with the following string

```
😃🖖🏻🖖🏻🖖🏿
🥶🥶🥶👈🏼🖖🏻😉🖖🏽🖖🏿😉🥶🥶🥶👈🏼🖖🏻😉🖖🏽🖖🏿😉🥶🥶🥶👈🏼🖖🏻😉🖖🏽🖖🏿😉
fds
.👉🏽👉🏽👉🏽👉🏽👉🏽👉🏽👉🏽👉🏽👉🏽s👈🏿👈🏿👈🏿👈🏿👈🏿👈🏿👈🏿👈🏿👈🏿.
🥶🥶🥶👈🏼🖖🏻😉🖖🏽🖖🏿😉fdsvadsfewdsfdsafsdafsd
```

- [x] Verify Simplenote doesn't crash



### Release
`RELEASE-NOTES.txt` was updated in 296b7bc with:

> Fixed a bug that caused notes with specific emoji sequences to crash the app.
