### PR TITLE
Updates Simperium to Mark 0.8.26

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -16,7 +16,7 @@ abstract_target 'Automattic' do
   # Automattic Shared
   #
   pod 'Automattic-Tracks-iOS', '~> 0.4'
-  pod 'Simperium-OSX', '0.8.25'
+  pod 'Simperium-OSX', '0.8.26'
 
   # Main Target
   #

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -11,21 +11,21 @@ PODS:
   - Sentry (4.3.4):
     - Sentry/Core (= 4.3.4)
   - Sentry/Core (4.3.4)
-  - Simperium-OSX (0.8.25):
-    - Simperium-OSX/DiffMatchPach (= 0.8.25)
-    - Simperium-OSX/JRSwizzle (= 0.8.25)
-    - Simperium-OSX/SocketRocket (= 0.8.25)
-    - Simperium-OSX/SPReachability (= 0.8.25)
-    - Simperium-OSX/SSKeychain (= 0.8.25)
-  - Simperium-OSX/DiffMatchPach (0.8.25)
-  - Simperium-OSX/JRSwizzle (0.8.25)
-  - Simperium-OSX/SocketRocket (0.8.25)
-  - Simperium-OSX/SPReachability (0.8.25)
-  - Simperium-OSX/SSKeychain (0.8.25)
+  - Simperium-OSX (0.8.26):
+    - Simperium-OSX/DiffMatchPach (= 0.8.26)
+    - Simperium-OSX/JRSwizzle (= 0.8.26)
+    - Simperium-OSX/SocketRocket (= 0.8.26)
+    - Simperium-OSX/SPReachability (= 0.8.26)
+    - Simperium-OSX/SSKeychain (= 0.8.26)
+  - Simperium-OSX/DiffMatchPach (0.8.26)
+  - Simperium-OSX/JRSwizzle (0.8.26)
+  - Simperium-OSX/SocketRocket (0.8.26)
+  - Simperium-OSX/SPReachability (0.8.26)
+  - Simperium-OSX/SSKeychain (0.8.26)
 
 DEPENDENCIES:
   - Automattic-Tracks-iOS (~> 0.4)
-  - Simperium-OSX (= 0.8.25)
+  - Simperium-OSX (= 0.8.26)
 
 SPEC REPOS:
   https://github.com/cocoapods/specs.git:
@@ -40,8 +40,8 @@ SPEC CHECKSUMS:
   CocoaLumberjack: 2f44e60eb91c176d471fdba43b9e3eae6a721947
   Reachability: 33e18b67625424e47b6cde6d202dce689ad7af96
   Sentry: 26f0e6492b103e87434d1a5eea2d241a36f2c2a2
-  Simperium-OSX: 2a8542be36ec1de3c3cb2470bf9ccf40cbe939f2
+  Simperium-OSX: 6e1ff09900f1a4e19044f302567d077bb2316b62
 
-PODFILE CHECKSUM: a993425d1037cca48cdf7080d495ac64e06e9afc
+PODFILE CHECKSUM: 42b4dcbed27c12df82f813c8c49e16a334a8cf7c
 
 COCOAPODS: 1.6.1


### PR DESCRIPTION
### Fix
We're updating Simperium to Mk 0.8.26, which contains an improved error handling mechanism, aiming at preventing crashes caused by malformed diffs.

### Test
1. Map the Simperium dependency to 0.8.23
2. Clean + Rebuild
3. Log into your account
4. Add a new note
5. Insert the following emojis: ☺️🖖🏿
6. Insert the following emoji in between: 😃
7. Re-map to Simperium 0.8.26
8. Clean + Rebuild

- [ ] Verify the app doesn't crash anymore

### Release
These changes do not require release notes.
