### PR TITLE
Fixing Warnings

### DIFF
--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -171,9 +171,6 @@
 		71D83D7014D744FB00A25E69 /* SPNoteCellView.m in Sources */ = {isa = PBXBuildFile; fileRef = 71D83D6F14D744FB00A25E69 /* SPNoteCellView.m */; };
 		71D83D7314D75C0A00A25E69 /* SPTagCellView.m in Sources */ = {isa = PBXBuildFile; fileRef = 71D83D7214D75C0A00A25E69 /* SPTagCellView.m */; };
 		71DCEBE7152E2ED1002744C0 /* NSMutableAttributedString+Styling.m in Sources */ = {isa = PBXBuildFile; fileRef = 71DCEBE6152E2ED1002744C0 /* NSMutableAttributedString+Styling.m */; };
-		8C902F8822D3ED910018D654 /* Simplenote.release.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 8C902F8722D3ED910018D654 /* Simplenote.release.xcconfig */; };
-		8C902F8922D3ED910018D654 /* Simplenote.release.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 8C902F8722D3ED910018D654 /* Simplenote.release.xcconfig */; };
-		8C902F8D22D3EE350018D654 /* Version.public.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 8C902F8C22D3EE350018D654 /* Version.public.xcconfig */; };
 		B5087A151AF3AB9D00505A2B /* ShareViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = B5087A141AF3AB9D00505A2B /* ShareViewController.m */; };
 		B5087A161AF3AB9D00505A2B /* ShareViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = B5087A141AF3AB9D00505A2B /* ShareViewController.m */; };
 		B5087A1E1AF3AF5E00505A2B /* VersionsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = B5087A1D1AF3AF5E00505A2B /* VersionsViewController.m */; };
@@ -1055,7 +1052,7 @@
 		26F72A7F14032D2900A7935E /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1020;
+				LastUpgradeCheck = 1130;
 				ORGANIZATIONNAME = Simperium;
 				TargetAttributes = {
 					26F72A8714032D2A00A7935E = {
@@ -1102,9 +1099,7 @@
 				26F72A9714032D2A00A7935E /* InfoPlist.strings in Resources */,
 				376EE3E9202A558E00E3812E /* simplenote.iconset in Resources */,
 				378AA6F81ACB04FD00CA87DC /* Simplenote-DB5.plist in Resources */,
-				8C902F8822D3ED910018D654 /* Simplenote.release.xcconfig in Resources */,
 				26F72AA314032D2A00A7935E /* MainMenu.xib in Resources */,
-				8C902F8D22D3EE350018D654 /* Version.public.xcconfig in Resources */,
 				B5A8919A231ECB3C0007EDCB /* INSTALL.markdown in Resources */,
 				3712FCA21FE1ACAA008544AC /* Info.plist in Resources */,
 				B5F04FD3215964BC004B1AA0 /* Privacy.storyboard in Resources */,
@@ -1123,7 +1118,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				B5B410BF1B17F28500CFCF8D /* Simplenote-DB5.plist in Resources */,
-				8C902F8922D3ED910018D654 /* Simplenote.release.xcconfig in Resources */,
 				466FFEE617CC10A800399652 /* InfoPlist.strings in Resources */,
 				466FFEE717CC10A800399652 /* Credits.rtf in Resources */,
 				B5F04FD4215964BC004B1AA0 /* Privacy.storyboard in Resources */,

--- a/Simplenote.xcodeproj/xcshareddata/xcschemes/Simplenote-AppStore.xcscheme
+++ b/Simplenote.xcodeproj/xcshareddata/xcschemes/Simplenote-AppStore.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1020"
+   LastUpgradeVersion = "1130"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -27,8 +27,6 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
-      <Testables>
-      </Testables>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -38,8 +36,8 @@
             ReferencedContainer = "container:Simplenote.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
+      <Testables>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -61,8 +59,6 @@
             ReferencedContainer = "container:Simplenote.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Simplenote.xcodeproj/xcshareddata/xcschemes/Simplenote.xcscheme
+++ b/Simplenote.xcodeproj/xcshareddata/xcschemes/Simplenote.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1100"
+   LastUpgradeVersion = "1130"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Simplenote/Note.h
+++ b/Simplenote/Note.h
@@ -39,7 +39,28 @@
 @property int lastPosition;
 @property (nonatomic, copy) NSString * tags;
 @property (nonatomic, strong) NSMutableArray *tagsArray;
+
+
+// What's going on:
+//
+//  -   Since Simplenote's inception, logic deletion flag was a simple boolean called `deleted`
+//  -   Collision with NSManagedObject's `deleted` flag wasn't picked up
+//  -   Eventually CLANG enhanced checks allowed us to notice there's a collision
+//
+//  Proper fix involves a heavy modification in Simperium, which would allow us to keep the `deleted` "internal"
+//  property name, while exposing a different property setter / getter, and thus, avoiding the collision.
+//
+// In This thermonuclear massive super workaround, we're simply silencing the warning.
+//
+// Proper course of action should be taken as soon as the next steps for Simperium are outlined.
+//
+// TODO: JLP Dec.27.2019.
+//
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wproperty-attribute-mismatch"
 @property BOOL deleted;
+#pragma clang diagnostic pop
+
 @property (nonatomic, copy) NSString * shareURL;
 @property (nonatomic, copy) NSDate * creationDate;
 @property (nonatomic, copy) NSString * systemTags;


### PR DESCRIPTION
### Fix
In this PR we're fixing several Xcode build warnings. This PR is analog to [this SPiOS counterpart](https://github.com/Automattic/simplenote-ios/pull/547).

Proper fix for the `Note.h` warning will come... hopefully as soon as Simperium's next steps are outlined.

cc @bummytime (Thank you!!)

### Test
- [x] Verify the app builds correctly

### Release
These changes do not require release notes.
