### PR TITLE
Restoring Trash Menu

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,7 @@
+1.9.0
+-----
+- Fixed a bug in which the Trash couldn't be emptied with a right click action
+
 1.8.1
 -----
 - Fixed a bug that caused notes with specific emoji sequences to crash the app

--- a/Simplenote/SPTableView.h
+++ b/Simplenote/SPTableView.h
@@ -9,6 +9,14 @@
 #import <Cocoa/Cocoa.h>
 #import "SPTextView.h"
 
+@protocol SPTableViewDelegate <NSTableViewDelegate>
+
+- (NSMenu *)tableView:(NSTableView *)tableView menuForTableColumn:(NSInteger)column row:(NSInteger)row;
+
+@end
+
+
+
 @interface SPTableView : NSTableView<SPTextViewDelegate, NSTextFieldDelegate> {
     NSMutableArray *validFirstResponders;
 }

--- a/Simplenote/SPTableView.m
+++ b/Simplenote/SPTableView.m
@@ -53,12 +53,16 @@
 
 - (NSMenu *)menuForEvent:(NSEvent*)theEvent
 {
-    NSMenu *menu = [super menuForEvent:theEvent];
     NSPoint mousePoint = [self convertPoint:[theEvent locationInWindow] fromView:nil];
     NSInteger row = [self rowAtPoint:mousePoint];
+    NSInteger column = [self columnAtPoint:mousePoint];
     [self selectRowIndexes:[NSIndexSet indexSetWithIndex:row] byExtendingSelection:NO];
-    
-    return menu;
+
+    if ([self.delegate respondsToSelector:@selector(tableView:menuForTableColumn:row:)] == false) {
+        return [super menuForEvent:theEvent];
+    }
+
+    return [(id<SPTableViewDelegate>)self.delegate tableView:self menuForTableColumn:column row:row];
 }
 
 @end

--- a/Simplenote/SPTagCellView.h
+++ b/Simplenote/SPTagCellView.h
@@ -14,7 +14,6 @@
 @property (nonatomic, assign) BOOL mouseInside;
 
 - (void)setSelected:(BOOL)selected;
-- (void)setDropdownMenu:(NSMenu *)menu;
 - (void)applyStyle;
 
 @end

--- a/Simplenote/SPTagCellView.m
+++ b/Simplenote/SPTagCellView.m
@@ -64,15 +64,6 @@ static CGFloat SPTagCellPopUpButtonAlpha    = 0.5f;
     return _button;
 }
 
-- (void)setDropdownMenu:(NSMenu *)menu
-{
-    if (menu == nil) {
-        return;
-    }
-    
-    self.button.menu = menu;
-}
-
 - (void)setMouseInside:(BOOL)value
 {
     if (_mouseInside == value) {

--- a/Simplenote/TagListViewController.h
+++ b/Simplenote/TagListViewController.h
@@ -14,7 +14,6 @@
 @interface TagListViewController : NSViewController <NSTableViewDataSource, NSTableViewDelegate, NSMenuDelegate, NSTextDelegate, NSTextFieldDelegate, NSControlTextEditingDelegate, NSDraggingDestination> {
     IBOutlet NoteListViewController *noteListViewController;
     IBOutlet NSBox *tagBox;
-    IBOutlet NSMenu *tagMenu;
     IBOutlet NSMenu *tagDropdownMenu;
     IBOutlet NSMenu *trashDropdownMenu;
     IBOutlet NSMenu *findMenu;

--- a/Simplenote/TagListViewController.m
+++ b/Simplenote/TagListViewController.m
@@ -96,12 +96,10 @@ NSString * const kDidEmptyTrash = @"SPDidEmptyTrash";
 
 - (void)buildDropdownMenus
 {
-    // Dropdowns with this style need an empty item at the top; build them dynamically
     trashDropdownMenu = [[NSMenu alloc] initWithTitle:@""];
     trashDropdownMenu.delegate = self;
     
     trashDropdownMenu.autoenablesItems = YES;
-    [trashDropdownMenu addItemWithTitle:@"" action:nil keyEquivalent:@""];
     [trashDropdownMenu addItemWithTitle:@"Empty Trash" action:@selector(emptyTrashAction:) keyEquivalent:@""];
     for (NSMenuItem *item in trashDropdownMenu.itemArray)
         [item setTarget:self];
@@ -109,7 +107,6 @@ NSString * const kDidEmptyTrash = @"SPDidEmptyTrash";
     tagDropdownMenu = [[NSMenu alloc] initWithTitle:@""];
     tagDropdownMenu.delegate = self;
     tagDropdownMenu.autoenablesItems = YES;
-    [tagDropdownMenu addItemWithTitle:@"" action:nil keyEquivalent:@""];
     [tagDropdownMenu addItemWithTitle:@"Rename Tag" action:@selector(renameAction:) keyEquivalent:@""];
     [tagDropdownMenu addItemWithTitle:@"Delete Tag" action:@selector(deleteAction:) keyEquivalent:@""];
     for (NSMenuItem *item in tagDropdownMenu.itemArray)

--- a/Simplenote/TagListViewController.m
+++ b/Simplenote/TagListViewController.m
@@ -98,20 +98,22 @@ NSString * const kDidEmptyTrash = @"SPDidEmptyTrash";
 {
     trashDropdownMenu = [[NSMenu alloc] initWithTitle:@""];
     trashDropdownMenu.delegate = self;
-    
     trashDropdownMenu.autoenablesItems = YES;
     [trashDropdownMenu addItemWithTitle:@"Empty Trash" action:@selector(emptyTrashAction:) keyEquivalent:@""];
-    for (NSMenuItem *item in trashDropdownMenu.itemArray)
+
+    for (NSMenuItem *item in trashDropdownMenu.itemArray) {
         [item setTarget:self];
+    }
     
     tagDropdownMenu = [[NSMenu alloc] initWithTitle:@""];
     tagDropdownMenu.delegate = self;
     tagDropdownMenu.autoenablesItems = YES;
     [tagDropdownMenu addItemWithTitle:@"Rename Tag" action:@selector(renameAction:) keyEquivalent:@""];
     [tagDropdownMenu addItemWithTitle:@"Delete Tag" action:@selector(deleteAction:) keyEquivalent:@""];
-    for (NSMenuItem *item in tagDropdownMenu.itemArray)
-        [item setTarget:self];
 
+    for (NSMenuItem *item in tagDropdownMenu.itemArray) {
+        [item setTarget:self];
+    }
 }
 
 - (void)sortTags

--- a/Simplenote/TagListViewController.m
+++ b/Simplenote/TagListViewController.m
@@ -485,16 +485,27 @@ NSString * const kDidEmptyTrash = @"SPDidEmptyTrash";
         tagView.textField.stringValue = NSLocalizedString(@"All Notes", @"Title of the view that displays all your notes");
     } else if (row == kTrashRow) {
         tagView.textField.stringValue = NSLocalizedString(@"Trash", @"Title of the view that displays all your deleted notes");
-        [tagView setDropdownMenu:trashDropdownMenu];
     } else if (row == kSeparatorRow) {
         tagView.textField.stringValue = @"";
     } else {
         Tag *tag = [self.tagArray objectAtIndex:row-kStartOfTagListRow];
         tagView.textField.stringValue = tag.name;
-        [tagView setDropdownMenu:tagDropdownMenu];
     }
     
     return tagView;
+}
+
+- (NSMenu *)tableView:(NSTableView *)tableView menuForTableColumn:(NSTableColumn *)tableColumn row:(NSInteger)row
+{
+    switch (row) {
+        case kAllNotesRow:
+        case kSeparatorRow:
+            return nil;
+        case kTrashRow:
+            return trashDropdownMenu;
+        default:
+            return tagDropdownMenu;
+    }
 }
 
 - (NSTableRowView *)tableView:(NSTableView *)tableView rowViewForRow:(NSInteger)row

--- a/Simplenote/en.lproj/MainMenu.xib
+++ b/Simplenote/en.lproj/MainMenu.xib
@@ -13,26 +13,6 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <menu id="1510" userLabel="Tag List Menu">
-            <items>
-                <menuItem title="Rename Tag" id="1511">
-                    <modifierMask key="keyEquivalentModifierMask"/>
-                    <connections>
-                        <action selector="renameAction:" target="1461" id="1515"/>
-                    </connections>
-                </menuItem>
-                <menuItem title="Delete Tag" id="1512">
-                    <modifierMask key="keyEquivalentModifierMask"/>
-                    <connections>
-                        <action selector="deleteAction:" target="1461" id="1516"/>
-                    </connections>
-                </menuItem>
-            </items>
-            <connections>
-                <outlet property="delegate" destination="1461" id="1520"/>
-            </connections>
-            <point key="canvasLocation" x="-58" y="411"/>
-        </menu>
         <menu id="1504" userLabel="Note List Menu">
             <items>
                 <menuItem title="Delete Note" id="1505" userLabel="Delete Note">
@@ -940,9 +920,6 @@
                                             <rect key="frame" x="-100" y="-100" width="16" height="576"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                         </scroller>
-                                        <connections>
-                                            <outlet property="menu" destination="1510" id="1519"/>
-                                        </connections>
                                     </scrollView>
                                 </subviews>
                             </customView>
@@ -1256,7 +1233,6 @@
                 <outlet property="notesArrayController" destination="573" id="1672"/>
                 <outlet property="tableView" destination="1453" id="1469"/>
                 <outlet property="tagBox" destination="1731" id="690-39-pWj"/>
-                <outlet property="tagMenu" destination="1510" id="1517"/>
                 <outlet property="tagSortMenuItem" destination="axW-cz-MnF" id="vio-Yr-jb6"/>
                 <outlet property="view" destination="1452" id="1462"/>
             </connections>


### PR DESCRIPTION
### Fix
In this PR we're restoring the specific **NSMenu** (we always had) that was displayed whenever the user right-clicked over the **Trash** label.

Closes #249

cc @bummytime 
Thank you Bummy!!

### Test
1. Launch Simplenote
2. Trash a Note
3. Right click over the **Trash** label

- [x] Verify a Menu shows up, and the option **Empty Trash** is enabled
- [x] Verify that clicking **Empty Trash** effectively removes all of the trashed notes
- [x] Verify that the **Empty Trash** action is disabled whenever there are no Trashed notes

### Release
`RELEASE-NOTES.txt` was updated in d15eab1 with:

> Fixed a bug in which the Trash couldn't be emptied with a right click action
