### PR TITLE
Fixing Checklists Orientation

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 - Fixed an issue affecting multibyte characters.
 - Fixed a bug in which Checklist Icons were disappearing
 - Fixed a bug in which the Trash couldn't be emptied with a right click action
+- Fixed Checklists Assets for macOS < 10.15
 
 1.8.1
 -----

--- a/Simplenote/SPTextAttachment.swift
+++ b/Simplenote/SPTextAttachment.swift
@@ -23,7 +23,24 @@ import Foundation
         set(isChecked) {
             checked = isChecked
             let name = checked ? "icon_task_checked" : "icon_task_unchecked"
-            image = NSImage(named: name)?.colorized(with: attachmentColor)
+            guard let asset = NSImage(named: name)?.colorized(with: attachmentColor) else {
+                fatalError()
+            }
+
+            if #available(macOS 10.15, *) {
+                image = asset
+                return
+            }
+
+            // macOS < 10.15 inverts the NSTextAttachment.image when drawn. So cool.
+            // References:
+            //  -   https://stackoverflow.com/questions/49649553/the-image-of-nstextattachment-is-flipped?noredirect=1&lq=1
+            //  -   https://github.com/Automattic/simplenote-macos/pull/403
+            //
+            image = NSImage(size: asset.size, flipped: true) { rect in
+                asset.draw(in: rect, from: .zero, operation: .sourceOver, fraction: 1.0)
+                return true
+            }
         }
     }
 }


### PR DESCRIPTION
### Fix
In this PR we're fixing an issue affecting macOS < Catalina, in which Checklists are being rendered upside down.

### Details:
What's going on:

- **NSTextView isFlipped = true**
- Because of the above, images were always drawn upside down
- In Catalina, even though the textView isFlipped, the system started rendering the images as you would expect
- When we fixed things up for Catalina, unknowingly, things got broken for everyone else =(

Reference [here](https://stackoverflow.com/questions/46666322/images-being-flipped-when-adding-to-nsattributedstring) and [here](https://stackoverflow.com/questions/49649553/the-image-of-nstextattachment-is-flipped?noredirect=1&lq=1)

### Test
1. Insert a checklist
2. Click over any of the items ✅ 

- [ ] Verify the asset looks good!
- [ ] Re-test (if possible) in macOS < 10.15

### Release
`RELEASE-NOTES.txt` was updated in 0ba9603 with:
 
> Fixed Checklists Assets for macOS < 10.15
