### PR TITLE
Checklists: Dynamic Sizing

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,8 @@
+1.10.0
+------
+- Checklists now will grow in size, and match your selected font
+- Checklists now will properly work in macOS 10.11 and 10.12
+
 1.9.0
 -----
 - Fixed an issue affecting multibyte characters.

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,13 +1,10 @@
-1.10.0
-------
-- Checklists now will grow in size, and match your selected font
-- Checklists now will properly work in macOS 10.11 and 10.12
-
 1.9.0
 -----
 - Fixed an issue affecting multibyte characters.
 - Fixed a bug in which Checklist Icons were disappearing
 - Fixed a bug in which the Trash couldn't be emptied with a right click action
+- Checklists now will grow in size, and match your selected font
+- Checklists now will properly work in macOS 10.11 and 10.12
 
 1.8.1
 -----

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -171,6 +171,8 @@
 		B5087A1F1AF3AF5E00505A2B /* VersionsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = B5087A1D1AF3AF5E00505A2B /* VersionsViewController.m */; };
 		B5087A221AF3B16A00505A2B /* PublishViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = B5087A211AF3B16A00505A2B /* PublishViewController.m */; };
 		B5087A231AF3B16A00505A2B /* PublishViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = B5087A211AF3B16A00505A2B /* PublishViewController.m */; };
+		B5132FA823C4B9760065DD80 /* NSTextStorage+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5132FA723C4B9760065DD80 /* NSTextStorage+Simplenote.swift */; };
+		B5132FA923C4B9760065DD80 /* NSTextStorage+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5132FA723C4B9760065DD80 /* NSTextStorage+Simplenote.swift */; };
 		B51374F61AC0591900825FCC /* SPConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = B51374F51AC0591900825FCC /* SPConstants.m */; };
 		B51374F71AC0591900825FCC /* SPConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = B51374F51AC0591900825FCC /* SPConstants.m */; };
 		B51E9FE122E615FA004F16B4 /* SPExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B51E9FE022E615FA004F16B4 /* SPExporter.swift */; };
@@ -437,6 +439,7 @@
 		B5087A1D1AF3AF5E00505A2B /* VersionsViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = VersionsViewController.m; sourceTree = "<group>"; };
 		B5087A201AF3B16A00505A2B /* PublishViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PublishViewController.h; sourceTree = "<group>"; };
 		B5087A211AF3B16A00505A2B /* PublishViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PublishViewController.m; sourceTree = "<group>"; };
+		B5132FA723C4B9760065DD80 /* NSTextStorage+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSTextStorage+Simplenote.swift"; sourceTree = "<group>"; };
 		B51374F41AC0591900825FCC /* SPConstants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPConstants.h; sourceTree = "<group>"; };
 		B51374F51AC0591900825FCC /* SPConstants.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPConstants.m; sourceTree = "<group>"; };
 		B51E9FE022E615FA004F16B4 /* SPExporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPExporter.swift; sourceTree = "<group>"; };
@@ -886,6 +889,7 @@
 			children = (
 				B51E9FE422E644A0004F16B4 /* NSObject+Helpers.swift */,
 				B5283BCF23B679C00085826F /* NSMutableAttributedString+Simplenote.swift */,
+				B5132FA723C4B9760065DD80 /* NSTextStorage+Simplenote.swift */,
 			);
 			name = Extensions;
 			sourceTree = "<group>";
@@ -1277,6 +1281,7 @@
 				375D293C21E033D1007AB25A /* hash.c in Sources */,
 				714BA65B14D32DCB00A6CCC1 /* SPBackgroundView.m in Sources */,
 				714BA66314D37C2000A6CCC1 /* SPTableRowView.m in Sources */,
+				B5132FA823C4B9760065DD80 /* NSTextStorage+Simplenote.swift in Sources */,
 				714BA66A14D4A3F600A6CCC1 /* NoteListViewController.m in Sources */,
 				714BA66E14D4AE6300A6CCC1 /* DateTransformer.m in Sources */,
 				375D293621E033D1007AB25A /* document.c in Sources */,
@@ -1370,6 +1375,7 @@
 				375D293D21E033D1007AB25A /* hash.c in Sources */,
 				466FFEB317CC10A800399652 /* NoteListViewController.m in Sources */,
 				466FFEB417CC10A800399652 /* DateTransformer.m in Sources */,
+				B5132FA923C4B9760065DD80 /* NSTextStorage+Simplenote.swift in Sources */,
 				466FFEB517CC10A800399652 /* SPNoteCellView.m in Sources */,
 				466FFEB617CC10A800399652 /* SPTagCellView.m in Sources */,
 				375D293721E033D1007AB25A /* document.c in Sources */,

--- a/Simplenote/NSMutableAttributedString+Styling.h
+++ b/Simplenote/NSMutableAttributedString+Styling.h
@@ -10,6 +10,6 @@
 
 @interface NSMutableAttributedString (Styling)
 
-- (void)addChecklistAttachmentsWithColor:(NSColor *)color;
+- (NSArray *)insertChecklistAttachmentsWithColor:(NSColor *)color;
 
 @end

--- a/Simplenote/NSMutableAttributedString+Styling.h
+++ b/Simplenote/NSMutableAttributedString+Styling.h
@@ -10,6 +10,6 @@
 
 @interface NSMutableAttributedString (Styling)
 
-- (void)addChecklistAttachmentsForHeight:(CGFloat) height andColor: (NSColor *)color andVerticalOffset:(CGFloat)verticalOffset;
+- (void)addChecklistAttachmentsWithColor:(NSColor *)color;
 
 @end

--- a/Simplenote/NSMutableAttributedString+Styling.m
+++ b/Simplenote/NSMutableAttributedString+Styling.m
@@ -17,10 +17,11 @@ const int RegexGroupIndexPrefix     = 1;
 const int RegexGroupIndexContent    = 2;
 
 // Replaces checklist markdown syntax with SPTextAttachment images in an attributed string
-- (void)addChecklistAttachmentsWithColor:(NSColor *)color
+- (NSArray *)insertChecklistAttachmentsWithColor:(NSColor *)color
 {
+    NSMutableArray *attachments = [NSMutableArray new];
     if (self.length == 0) {
-        return;
+        return attachments;
     }
     
     NSError *error;
@@ -31,7 +32,7 @@ const int RegexGroupIndexContent    = 2;
     NSArray *matches = [regex matchesInString:noteString options:0 range:[noteString rangeOfString:noteString]];
     
     if (matches.count == 0) {
-        return;
+        return attachments;
     }
     
     int positionAdjustment = 0;
@@ -48,6 +49,7 @@ const int RegexGroupIndexContent    = 2;
         SPTextAttachment *attachment = [SPTextAttachment new];
         attachment.isChecked = isChecked;
         attachment.tintColor = color;
+        [attachments addObject:attachment];
 
         NSAttributedString *attachmentString = [NSAttributedString attributedStringWithAttachment:attachment];
         NSRange adjustedRange = NSMakeRange(checkboxRange.location - positionAdjustment, checkboxRange.length);
@@ -55,6 +57,8 @@ const int RegexGroupIndexContent    = 2;
         
         positionAdjustment += markdownTag.length - 1 - prefixRange.length;
     }
+
+    return attachments;
 }
 
 @end

--- a/Simplenote/NSMutableAttributedString+Styling.m
+++ b/Simplenote/NSMutableAttributedString+Styling.m
@@ -17,7 +17,8 @@ const int RegexGroupIndexPrefix     = 1;
 const int RegexGroupIndexContent    = 2;
 
 // Replaces checklist markdown syntax with SPTextAttachment images in an attributed string
-- (void)addChecklistAttachmentsForHeight:(CGFloat) height andColor: (NSColor *)color andVerticalOffset:(CGFloat)verticalOffset {
+- (void)addChecklistAttachmentsWithColor:(NSColor *)color
+{
     if (self.length == 0) {
         return;
     }
@@ -44,11 +45,10 @@ const int RegexGroupIndexContent    = 2;
         NSString *markdownTag = [noteString substringWithRange:match.range];
         BOOL isChecked = [markdownTag localizedCaseInsensitiveContainsString:@"x"];
         
-        SPTextAttachment *attachment = [[SPTextAttachment alloc] initWithColor:color];
-        [attachment setIsChecked: isChecked];
-        
-        attachment.bounds = CGRectMake(0, verticalOffset, height, height);
-        
+        SPTextAttachment *attachment = [SPTextAttachment new];
+        attachment.isChecked = isChecked;
+        attachment.tintColor = color;
+
         NSAttributedString *attachmentString = [NSAttributedString attributedStringWithAttachment:attachment];
         NSRange adjustedRange = NSMakeRange(checkboxRange.location - positionAdjustment, checkboxRange.length);
         [self replaceCharactersInRange:adjustedRange withAttributedString:attachmentString];

--- a/Simplenote/NSString+Styling.m
+++ b/Simplenote/NSString+Styling.m
@@ -20,9 +20,8 @@
                                                         bodyColor:(NSColor *)bodyColor
 {
     NSMutableAttributedString *attributedString = [[NSMutableAttributedString alloc] initWithString:self];
+    [attributedString addChecklistAttachmentsWithColor:bodyColor];
 
-    CGFloat offset = -1.5f;
-    [attributedString addChecklistAttachmentsForHeight:bodyFont.pointSize andColor:bodyColor andVerticalOffset: offset];
     NSRange firstLineRange = [attributedString.string rangeOfString:@"\n"];
     
     NSMutableParagraphStyle *bodyStyle = [[NSMutableParagraphStyle alloc] init];
@@ -55,7 +54,7 @@
      NSForegroundColorAttributeName: headlineColor,
       NSParagraphStyleAttributeName: titleStyle}
                               range:titleRange];
-    
+
     return attributedString;
 }
 

--- a/Simplenote/NSString+Styling.m
+++ b/Simplenote/NSString+Styling.m
@@ -12,6 +12,8 @@
 #import "NSMutableAttributedString+Styling.h"
 #import "SPTextView.h"
 
+static NSEdgeInsets const SPTextAttachmentInsets = {-1.5, 0, 0, 0};
+
 @implementation NSString (Styling)
 
 - (NSAttributedString *)headlinedAttributedStringWithHeadlineFont:(NSFont *)headlineFont
@@ -20,7 +22,11 @@
                                                         bodyColor:(NSColor *)bodyColor
 {
     NSMutableAttributedString *attributedString = [[NSMutableAttributedString alloc] initWithString:self];
-    [attributedString addChecklistAttachmentsWithColor:bodyColor];
+    NSArray *attachments = [attributedString insertChecklistAttachmentsWithColor:bodyColor];
+
+    for (SPTextAttachment *attachment in attachments) {
+        attachment.overrideDynamicBounds = NSMakeRect(SPTextAttachmentInsets.left, SPTextAttachmentInsets.top, bodyFont.pointSize, bodyFont.pointSize);
+    }
 
     NSRange firstLineRange = [attributedString.string rangeOfString:@"\n"];
     

--- a/Simplenote/NSTextStorage+Simplenote.swift
+++ b/Simplenote/NSTextStorage+Simplenote.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+
+// MARK: - NSTextStorage
+//
+extension NSTextStorage {
+
+    /// Returns the font at the specified character, if any
+    ///
+    func font(at charIndex: Int) -> NSFont? {
+        return attribute(.font, at: charIndex, effectiveRange: nil) as? NSFont
+    }
+}

--- a/Simplenote/SPTextAttachment.swift
+++ b/Simplenote/SPTextAttachment.swift
@@ -6,24 +6,75 @@
 
 import Foundation
 
-@objcMembers class SPTextAttachment: NSTextAttachment {
-    private var checked = false
-    var attachmentColor: NSColor?
-    
-    @objc public convenience init(color: NSColor) {
-        self.init()
-        
-        attachmentColor = color
+
+// MARK: - SPTextAttachment
+//
+@objcMembers
+class SPTextAttachment: NSTextAttachment {
+
+    /// Attachment State
+    ///
+    private enum State: String {
+        case checked = "icon_task_checked"
+        case unchecked = "icon_task_unchecked"
     }
-    
-    var isChecked: Bool {
-        get {
-            return checked
+
+    /// Attachment Image Tint Color
+    ///
+    var tintColor: NSColor? {
+        didSet {
+            refreshImage()
         }
-        set(isChecked) {
-            checked = isChecked
-            let name = checked ? "icon_task_checked" : "icon_task_unchecked"
-            image = NSImage(named: name)?.colorized(with: attachmentColor)
+    }
+
+    /// Indicates if the Attachment is checked or not. We're keeping this one as Boolean (for now) for ObjC interop purposes
+    ///
+    var isChecked = false {
+        didSet {
+            refreshImage()
         }
+    }
+
+
+    private func refreshImage() {
+        guard let tintColor = tintColor else {
+            return
+        }
+
+        let state = isChecked ? State.checked : State.unchecked
+        let image = NSImage(named: state.rawValue)?.colorized(with: tintColor)
+        attachmentCell = SPTextAttachmentCell(imageCell: image)
+    }
+}
+
+
+// MARK: - SPTextAttachmentCell
+//
+class SPTextAttachmentCell: NSTextAttachmentCell {
+
+    // MARK: - Overridden Methods
+
+    override func cellFrame(for textContainer: NSTextContainer, proposedLineFragment lineFrag: NSRect, glyphPosition position: NSPoint, characterIndex charIndex: Int) -> NSRect {
+        guard let image = image,
+            let storage = textContainer.layoutManager?.textStorage,
+            let font = storage.attribute(.font, at: charIndex, effectiveRange: nil) as? NSFont
+            else {
+                return super.cellFrame(for: textContainer, proposedLineFragment: lineFrag, glyphPosition: position, characterIndex: charIndex)
+        }
+
+
+        let ratio = font.pointSize / image.size.height
+        let side = floor(max(image.size.width, image.size.height) * ratio)
+        let paddingY = floor((lineFrag.height - side) * -0.5)
+
+        return CGRect(x: 0, y: paddingY, width: side, height: side)
+    }
+
+    override func draw(withFrame cellFrame: NSRect, in controlView: NSView?) {
+        image?.draw(in: cellFrame)
+    }
+
+    override func draw(withFrame cellFrame: NSRect, in controlView: NSView?, characterIndex charIndex: Int, layoutManager: NSLayoutManager) {
+        image?.draw(in: cellFrame)
     }
 }

--- a/Simplenote/SPTextAttachment.swift
+++ b/Simplenote/SPTextAttachment.swift
@@ -19,14 +19,6 @@ class SPTextAttachment: NSTextAttachment {
         case unchecked = "icon_task_unchecked"
     }
 
-    /// Attachment Image Tint Color
-    ///
-    var tintColor: NSColor? {
-        didSet {
-            refreshImage()
-        }
-    }
-
     /// Indicates if the Attachment is checked or not. We're keeping this one as Boolean (for now) for ObjC interop purposes
     ///
     var isChecked = false {
@@ -35,6 +27,20 @@ class SPTextAttachment: NSTextAttachment {
         }
     }
 
+    /// Attachment Image Tint Color
+    ///
+    var tintColor: NSColor? {
+        didSet {
+            refreshImage()
+        }
+    }
+
+    ///
+    /// Note: Why not optional? Because of ObjC Interop. Optionals NSRect won't bridge.
+    ///
+    var overrideDynamicBounds: NSRect = .zero
+
+    // MARK: - Private Methods
 
     private func refreshImage() {
         guard let tintColor = tintColor else {
@@ -52,29 +58,43 @@ class SPTextAttachment: NSTextAttachment {
 //
 class SPTextAttachmentCell: NSTextAttachmentCell {
 
+    /// Parent TextAttachment, if any
+    ///
+    var parentTextAttachment: SPTextAttachment? {
+        return attachment as? SPTextAttachment
+    }
+
     // MARK: - Overridden Methods
 
     override func cellFrame(for textContainer: NSTextContainer, proposedLineFragment lineFrag: NSRect, glyphPosition position: NSPoint, characterIndex charIndex: Int) -> NSRect {
-        guard let image = image,
-            let storage = textContainer.layoutManager?.textStorage,
-            let font = storage.attribute(.font, at: charIndex, effectiveRange: nil) as? NSFont
-            else {
-                return super.cellFrame(for: textContainer, proposedLineFragment: lineFrag, glyphPosition: position, characterIndex: charIndex)
+        if let overriddenBounds = parentTextAttachment?.overrideDynamicBounds, overriddenBounds != .zero {
+            return overriddenBounds
         }
 
+        guard let image = image, let font = textContainer.layoutManager?.textStorage?.font(at: charIndex) else {
+            return super.cellFrame(for: textContainer, proposedLineFragment: lineFrag, glyphPosition: position, characterIndex: charIndex)
+        }
 
-        let ratio = font.pointSize / image.size.height
-        let side = floor(max(image.size.width, image.size.height) * ratio)
-        let paddingY = floor((lineFrag.height - side) * -0.5)
-
-        return CGRect(x: 0, y: paddingY, width: side, height: side)
+        return bounds(image: image, font: font, lineFragment: lineFrag)
     }
 
     override func draw(withFrame cellFrame: NSRect, in controlView: NSView?) {
         image?.draw(in: cellFrame)
+
     }
 
     override func draw(withFrame cellFrame: NSRect, in controlView: NSView?, characterIndex charIndex: Int, layoutManager: NSLayoutManager) {
         image?.draw(in: cellFrame)
+    }
+
+
+    // MARK: - Private Methods
+
+    private func bounds(image: NSImage, font: NSFont, lineFragment: NSRect) -> NSRect {
+        let ratio = font.pointSize / image.size.height
+        let side = max(image.size.width, image.size.height) * ratio
+        let paddingY = (lineFragment.height - side) * -0.5
+
+        return CGRect(x: 0, y: paddingY, width: side, height: side)
     }
 }

--- a/Simplenote/SPTextAttachment.swift
+++ b/Simplenote/SPTextAttachment.swift
@@ -35,8 +35,10 @@ class SPTextAttachment: NSTextAttachment {
         }
     }
 
+    /// This class relies on TextKit to calculate proper sizing and metrics, so that its image matches characters onScreen. However: in some scenarios, such as "Usage within NSTextField" (Notes List),
+    /// the LayoutManager is not always initialized / nor accessible.
     ///
-    /// Note: Why not optional? Because of ObjC Interop. Optionals NSRect won't bridge.
+    /// For this reason, we're providing an Override mechanism. Plus: Because of ObjC Interop, it must not be optional (otherwise it won't bridge).
     ///
     var overrideDynamicBounds: NSRect = .zero
 
@@ -80,7 +82,6 @@ class SPTextAttachmentCell: NSTextAttachmentCell {
 
     override func draw(withFrame cellFrame: NSRect, in controlView: NSView?) {
         image?.draw(in: cellFrame)
-
     }
 
     override func draw(withFrame cellFrame: NSRect, in controlView: NSView?, characterIndex charIndex: Int, layoutManager: NSLayoutManager) {

--- a/Simplenote/SPTextView.m
+++ b/Simplenote/SPTextView.m
@@ -75,7 +75,7 @@ NSInteger const ChecklistCursorAdjustment = 2;
         }
     }
     
-    [self.textStorage addChecklistAttachmentsWithColor:checklistColor];
+    [self.textStorage insertChecklistAttachmentsWithColor:checklistColor];
 }
 
 // Processes content of note editor, and replaces special string attachments with their plain

--- a/Simplenote/SPTextView.m
+++ b/Simplenote/SPTextView.m
@@ -75,7 +75,7 @@ NSInteger const ChecklistCursorAdjustment = 2;
         }
     }
     
-    [self.textStorage addChecklistAttachmentsForHeight:self.font.pointSize andColor:checklistColor andVerticalOffset:-4.0f];
+    [self.textStorage addChecklistAttachmentsWithColor:checklistColor];
 }
 
 // Processes content of note editor, and replaces special string attachments with their plain


### PR DESCRIPTION
### Fix:
In this PR we're addressing a few Checklists issue:

- We're updating the mechanism used to render Checklists, and fixing rendering in macOS El Capitan (and higher)
- We're enhancing Checklists, so that they grow in size, and match the selected font size

Closes #297
Closes #414
Closes #436

Thanks in advance Bummy!!

### Scenario: Adaptivity
1. Log into your account
2. Insert a new note, and add a checklist (single line)
3. Insert a second new note, and add a checklists (three lines)
4. Insert a third note, and add a title + several checklist lines below

- [x] Verify the notes look good in the editor
- [x] Verify the notes look as expected in the Notes List (preview!)
- [x] Verify that the editor reacts properly to font increases / decreases

**Please** repeat for (as many virtual machines) as you've got. Verified in macOS Catalina and macOS El Capitan (10.11).

### Scenario: Orientation
1. Insert a checklist
2. Click over any of the items ✅ 

- [x] Verify the asset doesn't look inverted

**Please** repeat for Catalina and (any release below)

### Release
`RELEASE-NOTES.txt` was updated in 4989df9 with:

> - Checklists now will grow in size, and match your selected font
> - Checklists now will properly work in macOS 10.11 and 10.12
