### PR TITLE
Preventing Over-Linkifying

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,7 @@
+1.9.1
+ ----
+ - Fixed a bug that caused the entire document to become linkified
+
 1.9.0
 -----
 - Fixed an issue affecting multibyte characters.


### PR DESCRIPTION
### Fix
In this PR we're fixing a bug that caused the full document to become linkified,

This is "the most encapsulated" approach I could manage to pull together, any feedback is always **very very very** welcome. Alternate approach involved explicitly dropping the link attribute, when switching notes, which felt... a bit off perhaps?

Thank you @bummytime !!

Closes #448 

### Test
1. Create a note with just the URL in it, no title, no text
2. Click into that note
3. Click into any other note

- [x] Verify that the (newly) clicked note is onScreen
- [x] Verify that the entire document does not get linkified

### Release
`RELEASE-NOTES.txt` was updated in 50ddc15 with:
 
> Fixed a bug that caused the entire document to become linkified
