### PR TITLE
Fixing Undo + Linkification crashes

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 ------
 - Simplenote now requires macOS 10.13 or higher
 - Updated Checklist Icons
+- Fixed a crash related to Text Linkification and Undo Support
 
 1.9.1
 -----

--- a/Simplenote/NoteEditorViewController.m
+++ b/Simplenote/NoteEditorViewController.m
@@ -182,6 +182,9 @@ static NSInteger const SPVersionSliderMaxVersions       = 30;
     if (!self.markdownView.isHidden) {
         [self toggleMarkdownView:nil];
     }
+
+    // Issue #472: Explicitly reset the UndoManager. NSTextView appears not to be doing so for us, in specific scenarios.
+    [self.noteEditor.undoManager removeAllActions];
     
     if (selectedNote == nil) {
         [self.noteEditor setEditable:NO];
@@ -296,7 +299,12 @@ static NSInteger const SPVersionSliderMaxVersions       = 30;
         // fires `textDidChange` which will erroneously modify the note's modification
         // date and unintentionally change the sort order of the note in the list as a result
         [self.noteEditor setDelegate:nil];
+
+        // Issue #472: Linkification should not be undoable
+        [self.noteEditor.undoManager disableUndoRegistration];
         [self.noteEditor checkTextInDocument:nil];
+        [self.noteEditor.undoManager enableUndoRegistration];
+
         [self.noteEditor setNeedsDisplay:YES];
         [self.noteEditor setDelegate:self];
     });


### PR DESCRIPTION
### Fix
In this PR we're fixing a crash triggered after undoing Text Linkification (which should actually be non undoable!)

@etoledom sir, may I bug you with this one?
Thanks in advance!!

Closes #472
Ref. #467

### Test
1. Add a new note with the following content: www.simplenote.com
2. Add a new Tag named T1 to the newly created note
3. As soon as T1 shows up on the Tags List, remove the tag from the newly created note: we need a Tag with no notes in it
4. Relaunch Simplenote: open the Note you've added in (1)
5. Click over the tag T1

- [x] Verify the UI shows up 100% empty
- [x] Verify that pressing `CTRL + Z` does not trigger an exception in the console!

### Release
`RELEASE-NOTES.txt` was updated in d4751fa with:
 
> Fixed a crash related to Text Linkification and Undo Support
