### PR TITLE
Lists: Undo Exceptions Mark IV

### DIFF
--- a/Simplenote/NSAttributedStringToMarkdownConverter.swift
+++ b/Simplenote/NSAttributedStringToMarkdownConverter.swift
@@ -17,7 +17,7 @@ class NSAttributedStringToMarkdownConverter: NSObject {
     /// Returns the NSString representation of a given NSAttributedString.
     ///
     @objc
-    static func convert(string: NSAttributedString) -> NSString {
+    static func convert(string: NSAttributedString) -> String {
         let adjusted = NSMutableAttributedString(attributedString: string)
         adjusted.enumerateAttribute(.attachment, in: adjusted.fullRange, options: .reverse) { (value, range, _) in
             guard let attachment = value as? SPTextAttachment else {
@@ -28,6 +28,6 @@ class NSAttributedStringToMarkdownConverter: NSObject {
             adjusted.replaceCharacters(in: range, with: markdown)
         }
 
-        return adjusted.string as NSString
+        return adjusted.string
     }
 }

--- a/Simplenote/NSMutableAttributedString+Styling.h
+++ b/Simplenote/NSMutableAttributedString+Styling.h
@@ -10,8 +10,12 @@
 
 @class SPTextAttachment;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface NSMutableAttributedString (Styling)
 
 - (NSArray<SPTextAttachment *> *)processChecklistsWithColor:(NSColor *)color;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Simplenote/NSTextView+Simplenote.swift
+++ b/Simplenote/NSTextView+Simplenote.swift
@@ -30,6 +30,25 @@ extension NSTextView {
 //
 extension NSTextView {
 
+    /// Displays the specified Note's Contents
+    ///
+    ///     -   List Markers will be replaced by Text Attachments
+    ///     -   Our UndoManager will be reset right after processing the Lists. Otherwise CTRL + Z would
+    ///         result in Attachments replacee by `-[]`!
+    ///
+    @objc
+    func displayNote(content: String) {
+        string = content
+        textStorage?.processChecklists(with: .textListColor)
+        undoManager?.removeAllActions()
+    }
+}
+
+
+// MARK: - Processing Special Characters
+//
+extension NSTextView {
+
     /// Indents the List at the selected range (if any)
     ///
     @objc

--- a/Simplenote/NSTextView+Simplenote.swift
+++ b/Simplenote/NSTextView+Simplenote.swift
@@ -26,7 +26,7 @@ extension NSTextView {
 }
 
 
-// MARK: - Processing Special Characters
+// MARK: - I/O
 //
 extension NSTextView {
 
@@ -41,6 +41,13 @@ extension NSTextView {
         string = content
         textStorage?.processChecklists(with: .textListColor)
         undoManager?.removeAllActions()
+    }
+
+    /// Returns the content represented as Plain Text
+    ///
+    @objc
+    func plainTextContent() -> String {
+        return NSAttributedStringToMarkdownConverter.convert(string: attributedString())
     }
 }
 

--- a/Simplenote/NoteEditorViewController.m
+++ b/Simplenote/NoteEditorViewController.m
@@ -271,7 +271,7 @@ static NSInteger const SPVersionSliderMaxVersions       = 30;
 {
     self.note = nil;
     self.selectedNotes = notes;
-    [self.noteEditor setString:@""];
+    [self.noteEditor displayNoteWithContent:@""];
     [self.noteEditor setEditable:NO];
     [self.noteEditor setSelectable:NO];
     [tagTokenField setEditable:NO];

--- a/Simplenote/NoteEditorViewController.m
+++ b/Simplenote/NoteEditorViewController.m
@@ -183,13 +183,10 @@ static NSInteger const SPVersionSliderMaxVersions       = 30;
         [self toggleMarkdownView:nil];
     }
 
-    // Issue #472: Explicitly reset the UndoManager. NSTextView appears not to be doing so for us, in specific scenarios.
-    [self.noteEditor.undoManager removeAllActions];
-    
     if (selectedNote == nil) {
         [self.noteEditor setEditable:NO];
         [self.noteEditor setSelectable:NO];
-        [self.noteEditor setString:@""];
+        [self.noteEditor displayNoteWithContent:@""];
         [tagTokenField setEditable:NO];
         [self.bottomBar setEnabled:NO];
         
@@ -239,9 +236,9 @@ static NSInteger const SPVersionSliderMaxVersions       = 30;
         // Force selection to start; not doing this can cause an NSTextStorage exception when
         // switching away from long notes (> 5000 characters)
         [self.noteEditor setSelectedRange:NSMakeRange(0, 0)];
-        self.noteEditor.string = self.note.content;
+        [self.noteEditor displayNoteWithContent:self.note.content];
     } else {
-        self.noteEditor.string = @"";
+        [self.noteEditor displayNoteWithContent:@""];
     }
     
     [previewButton setHidden:!self.note.markdown || self.viewingTrash];
@@ -268,8 +265,6 @@ static NSInteger const SPVersionSliderMaxVersions       = 30;
         NSString *html = [SPMarkdownParser renderHTMLFromMarkdownString:@""];
         [self.markdownView loadHTMLString:html baseURL:[[NSBundle mainBundle] bundleURL]];
     }
-    
-    [self.noteEditor processChecklists];
 }
 
 - (void)displayNotes:(NSArray *)notes
@@ -470,7 +465,6 @@ static NSInteger const SPVersionSliderMaxVersions       = 30;
     
     // Update the note list preview
     [noteListViewController reloadRowForNoteKey:self.note.simperiumKey];
-    [self.noteEditor processChecklists];
 }
 
 -(void)updateShareButtonVisibility
@@ -486,12 +480,9 @@ static NSInteger const SPVersionSliderMaxVersions       = 30;
                                              oldText:self.noteContentBeforeRemoteUpdate
                                      currentLocation:self.cursorLocationBeforeRemoteUpdate];
 
-    self.noteEditor.string = self.note.content;
-    
-    NSRange newRange = NSMakeRange(newLocation, 0);
-    [self.noteEditor setSelectedRange:newRange];
-    [self.noteEditor processChecklists];
-    
+    [self.noteEditor displayNoteWithContent:self.note.content];
+    self.noteEditor.selectedRange = NSMakeRange(newLocation, 0);
+
     [self updatePublishUI];
 }
 
@@ -682,8 +673,8 @@ static NSInteger const SPVersionSliderMaxVersions       = 30;
     
     restoreVersionButton.enabled = [versionSlider integerValue] != versionSlider.maxValue && versionData != nil;
 	if (versionData != nil) {
-		self.noteEditor.string = (NSString *)[versionData objectForKey:@"content"];
-        [self.noteEditor processChecklists];
+        NSString *content = (NSString *)[versionData objectForKey:@"content"];
+        [self.noteEditor displayNoteWithContent:content];
 
 		NSDate *versionDate = [NSDate dateWithTimeIntervalSince1970:[(NSString *)[versionData objectForKey:@"modificationDate"] doubleValue]];
 		[self updateVersionLabel:versionDate];
@@ -697,7 +688,6 @@ static NSInteger const SPVersionSliderMaxVersions       = 30;
     self.note.content = [self.noteEditor plainTextContent];
     [self save];
     [self dismissActivePopover];
-    [self.noteEditor processChecklists];
 }
 
 - (IBAction)pinAction:(id)sender
@@ -983,7 +973,6 @@ static NSInteger const SPVersionSliderMaxVersions       = 30;
     [[NSUserDefaults standardUserDefaults] setInteger:currentFontSize forKey:SPFontSizePreferencesKey];
     [self applyStyle];
     [self checkTextInDocument];
-    [self.noteEditor processChecklists];
 }
 
 #pragma mark - NoteEditor Preferences Helpers
@@ -1082,8 +1071,8 @@ static NSInteger const SPVersionSliderMaxVersions       = 30;
 // Reprocesses note checklists after switching themes, so they apply the correct color
 - (void)fixChecklistColoring
 {
-    self.noteEditor.string = [self.noteEditor plainTextContent];
-    [self.noteEditor processChecklists];
+    NSString *content = [self.noteEditor plainTextContent];
+    [self.noteEditor displayNoteWithContent:content];
 }
 
 #pragma mark - NSButton Delegate Methods

--- a/Simplenote/SPTextView.h
+++ b/Simplenote/SPTextView.h
@@ -19,7 +19,4 @@
 
 @interface SPTextView : NSTextView
 
-- (void)processChecklists;
-- (NSString *)plainTextContent;
-
 @end

--- a/Simplenote/SPTextView.m
+++ b/Simplenote/SPTextView.m
@@ -55,15 +55,13 @@
     return lroundf(adjustedInset) + kMinEditorPadding;
 }
 
-- (void)processChecklists
+- (void)didChangeText
 {
+    [super didChangeText];
+
+    // TODO: FIX
     NSColor *checklistColor = [NSColor textListColor];
     [self.textStorage processChecklistsWithColor:checklistColor];
-}
-
-- (NSString *)plainTextContent
-{
-    return [NSAttributedStringToMarkdownConverter convertWithString:self.attributedString];
 }
 
 - (BOOL)checkForChecklistClick:(NSEvent *)event

--- a/Simplenote/SPTextView.m
+++ b/Simplenote/SPTextView.m
@@ -59,7 +59,7 @@
 {
     [super didChangeText];
 
-    // TODO: FIX
+    // FIXME: Realtime injection of `- [ ]` will trigger, still, an exception
     NSColor *checklistColor = [NSColor textListColor];
     [self.textStorage processChecklistsWithColor:checklistColor];
 }

--- a/Simplenote/Simplenote-Bridging-Header.h
+++ b/Simplenote/Simplenote-Bridging-Header.h
@@ -1,11 +1,22 @@
 //
-//  Simplenote-Bridging-Header.h
-//  Simplenote
+//  Use this file to import your target's public headers that you would like to expose to Swift.
 //
 
+
+#pragma mark - External
+
 #import "VSThemeManager.h"
-#import "SimplenoteAppDelegate.h"
-#import "Simperium+Simplenote.h"
-#import "SPConstants.h"
-#import "NSImage+Colorize.h"
+
+
+#pragma mark - Simplenote-Y
+
 #import "Note.h"
+#import "SimplenoteAppDelegate.h"
+#import "SPConstants.h"
+
+
+#pragma mark - Extensions
+
+#import "Simperium+Simplenote.h"
+#import "NSImage+Colorize.h"
+#import "NSMutableAttributedString+Styling.h"

--- a/SimplenoteTests/NSAttributedStringToMarkdownConverterTests.swift
+++ b/SimplenoteTests/NSAttributedStringToMarkdownConverterTests.swift
@@ -21,7 +21,7 @@ class NSAttributedStringToMarkdownConverterTests: XCTestCase {
         let document = documentWithoutAttachments()
         let output = NSAttributedStringToMarkdownConverter.convert(string: document)
 
-        XCTAssertEqual(output, document.string as NSString)
+        XCTAssertEqual(output, document.string)
     }
 }
 
@@ -30,7 +30,7 @@ class NSAttributedStringToMarkdownConverterTests: XCTestCase {
 //
 private extension NSAttributedStringToMarkdownConverterTests {
 
-    func documentWithAttachments(lines: Int = 100) -> (document: NSAttributedString, markdown: NSString) {
+    func documentWithAttachments(lines: Int = 100) -> (document: NSAttributedString, markdown: String) {
         let document = NSMutableAttributedString()
         var markdown = String()
 
@@ -48,7 +48,7 @@ private extension NSAttributedStringToMarkdownConverterTests {
             markdown += prefix + payload
         }
 
-        return (document, markdown as NSString)
+        return (document, markdown)
     }
 
     func documentWithoutAttachments() -> NSAttributedString {

--- a/SimplenoteTests/NSTextViewSimplenoteTests.swift
+++ b/SimplenoteTests/NSTextViewSimplenoteTests.swift
@@ -278,6 +278,42 @@ class NSTextViewSimplenoteTests: XCTestCase {
 
         XCTAssertEqual(textView.string, expected)
     }
+
+    /// Verifies that `displayNote` effectively replaces all of the List Markers (`- [ ]`) with a corresponding TextAttachment
+    ///
+    func testDisplayNoteAddsOneTextAttachmentPerValidListMarker() {
+        let list = sampleListText
+        let text = list.joined()
+
+        textView.displayNote(content: text)
+
+        let attrString = textView.attributedString()
+        var attachments = Set<NSTextAttachment>()
+
+        attrString.enumerateAttribute(.attachment, in: attrString.fullRange, options: []) { (attachment, _, _) in
+            guard let attachment = attachment as? NSTextAttachment else {
+                return
+            }
+
+            attachments.insert(attachment)
+        }
+
+        XCTAssertEqual(sampleListText.count, attachments.count)
+    }
+
+    /// Verifies that `plainTextContent` encodes (TextAttachment based) Lists as Markdown
+    ///
+    func testPlainTextContentEncodesTextAttachmentBasedListsAsMarkdown() {
+        let sample = samplePlainText.joined()
+        let expected = sampleListText.joined()
+
+        textView.displayNote(content: sample)
+
+        textView.setSelectedRange(sample.asNSString.fullRange)
+        textView.toggleListMarkersAtSelectedRange()
+
+        XCTAssertEqual(textView.plainTextContent(), expected)
+    }
 }
 
 
@@ -340,6 +376,15 @@ private extension NSTextViewSimplenoteTests {
             "Donec in arcu efficitur, aliquam nulla sed, venenatis justo.\n",
             "Nunc imperdiet sem quis ultricies efficitur.\n",
             "Sed a enim at justo dictum pellentesque sollicitudin sed enim."
+        ]
+    }
+
+    var sampleListText: [String] {
+        return [
+            "- [ ] Lorem ipsum dolor sit amet, consectetur adipiscing elit.\n",
+            "- [ ] Donec in arcu efficitur, aliquam nulla sed, venenatis justo.\n",
+            "- [ ] Nunc imperdiet sem quis ultricies efficitur.\n",
+            "- [ ] Sed a enim at justo dictum pellentesque sollicitudin sed enim."
         ]
     }
 }


### PR DESCRIPTION
### Fix
In this PR we're adding a new NSTextView API, responsible for displaying a Note's Contents:

A. Sets the TextView's String
B. Replaces Lists Markdown with Attachments
C. Resets the Undo Stack, so that step B isn't undoable

**Plus** new Unit Tests have been added.

@diegoreymendez @aerych Gentlemen, may I bug you the both of you? SMALL PR, but splitting Test Cases just to keep it lean.

**THANKYOU!!!**

Ref #467

---

@diegoreymendez **Thankyouyhankyou Diegooo!!**  👇👇👇

### Scenario A: Undo on an Empty Editor
1. Add a new note with the following content: www.simplenote.com
2. Add a new Tag named T1 to the newly created note
3. As soon as T1 shows up on the Tags List, remove the tag from the newly created note: we need a Tag with no notes in it
4. Relaunch Simplenote: open the Note you've added in (1)
5. Click over the tag T1

- [x] Verify the UI shows up 100% empty
- [x] Verify that pressing `CTRL + Z` does not trigger an exception in the console!

### Scenario B: Undo right Opening a Note
1. Add a new note
2. Insert a list (Format > Insert Checklist) and add few items
3. Relaunch the app
4. Reopen the note added in (1)

- [x] Verify that pressing `CTRL + Z` does not trigger an exception

### Scenario C: Versions Slider / Restore
1. Add a new note
2. Insert a list (Format > Insert Checklist) and type some random text
3. Wait 3 seconds (this should store a new version in the backend)
4. Press return and add another line

- [x] Verify that pressing the Versions button (top right corner) lets you revert to (2)
- [x] Verify that as soon as you reverted to (2) the List Marker is visible


---

@aerych  **Thankyouyhankyou Eric!!!**  👇👇👇

### Scenario D: Adjust Font
1. Add a new note
2. Insert a list (Format > Insert Checklist) and add few items

- [x] Verify that the List Markers (bullets) don't disappear and grow / shrink accordingly

### Scenario E: Remote Update
1. Open `www.simplenote.com` in a browser and log into your account
2. Launch Simplenote iOS and log into the same account
3. In iOS: add an empty note and leave the phone unlocked
4. In Web: Add a checklist with some random text

- [x] Verify that the checklist remotely-added renders well
- [x] Verify that pressing `CTRL + Z` does not undo anything (and it does not crash the app either)

**Yes** remote updates aren't undoable 😄 


### Release
These changes do not require release notes.
