### PR TITLE
Analytics: User Defaults

### DIFF
--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -197,6 +197,8 @@
 		B57CB875244DEBC300BA7969 /* Options.swift in Sources */ = {isa = PBXBuildFile; fileRef = B57CB873244DEBC300BA7969 /* Options.swift */; };
 		B57CB877244DEBCE00BA7969 /* UserDefaults+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B57CB876244DEBCE00BA7969 /* UserDefaults+Simplenote.swift */; };
 		B57CB878244DEBCE00BA7969 /* UserDefaults+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B57CB876244DEBCE00BA7969 /* UserDefaults+Simplenote.swift */; };
+		B57CB87B244DEC4B00BA7969 /* MigrationsHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B57CB87A244DEC4A00BA7969 /* MigrationsHandler.swift */; };
+		B57CB87C244DEC4B00BA7969 /* MigrationsHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B57CB87A244DEC4A00BA7969 /* MigrationsHandler.swift */; };
 		B57CB87E244DED2300BA7969 /* Bundle+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B57CB87D244DED2300BA7969 /* Bundle+Simplenote.swift */; };
 		B57CB87F244DED2300BA7969 /* Bundle+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B57CB87D244DED2300BA7969 /* Bundle+Simplenote.swift */; };
 		B59848801BCDB95A005EFBBE /* SPAutomatticTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = B598487D1BCDB95A005EFBBE /* SPAutomatticTracker.m */; };
@@ -489,6 +491,7 @@
 		B579E0B31AF2946F00A07036 /* VSTheme+Simplenote.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "VSTheme+Simplenote.m"; sourceTree = "<group>"; };
 		B57CB873244DEBC300BA7969 /* Options.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Options.swift; sourceTree = "<group>"; };
 		B57CB876244DEBCE00BA7969 /* UserDefaults+Simplenote.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UserDefaults+Simplenote.swift"; sourceTree = "<group>"; };
+		B57CB87A244DEC4A00BA7969 /* MigrationsHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MigrationsHandler.swift; sourceTree = "<group>"; };
 		B57CB87D244DED2300BA7969 /* Bundle+Simplenote.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Bundle+Simplenote.swift"; sourceTree = "<group>"; };
 		B57F50B2231971670074D535 /* RELEASE-NOTES.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = "RELEASE-NOTES.txt"; sourceTree = "<group>"; };
 		B598487C1BCDB95A005EFBBE /* SPAutomatticTracker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPAutomatticTracker.h; sourceTree = "<group>"; };
@@ -783,6 +786,7 @@
 			isa = PBXGroup;
 			children = (
 				F998F3EA22853C29008C2B59 /* CrashLogging.swift */,
+				B57CB87A244DEC4A00BA7969 /* MigrationsHandler.swift */,
 				B51E9FE022E615FA004F16B4 /* SPExporter.swift */,
 				37D4DD6920B3574C00C225EA /* WPAuthHandler.h */,
 				37D4DD6820B3574C00C225EA /* WPAuthHandler.m */,
@@ -1502,6 +1506,7 @@
 				B579E0B41AF2946F00A07036 /* VSTheme+Simplenote.m in Sources */,
 				B5985AD5242950B40044EDE9 /* NSColor+Simplenote.swift in Sources */,
 				B5C7DD3D243E1F1900BEE354 /* VersionsViewController.swift in Sources */,
+				B57CB87B244DEC4B00BA7969 /* MigrationsHandler.swift in Sources */,
 				2614F1E51405A0C60031AE94 /* Simplenote.xcdatamodeld in Sources */,
 				B5A2F1F02432DE54003B29C6 /* NSRange+Simplenote.swift in Sources */,
 				26DBB1F41405A6A800186392 /* NSString+Condensing.m in Sources */,
@@ -1607,6 +1612,7 @@
 				B579E0B51AF2946F00A07036 /* VSTheme+Simplenote.m in Sources */,
 				B5985AD6242950B40044EDE9 /* NSColor+Simplenote.swift in Sources */,
 				B5C7DD3E243E1F1900BEE354 /* VersionsViewController.swift in Sources */,
+				B57CB87C244DEC4B00BA7969 /* MigrationsHandler.swift in Sources */,
 				466FFEAE17CC10A800399652 /* NSString+Metadata.m in Sources */,
 				B5A2F1F12432DE54003B29C6 /* NSRange+Simplenote.swift in Sources */,
 				466FFEAF17CC10A800399652 /* NotesArrayController.m in Sources */,

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -193,6 +193,12 @@
 		B574CA74242D552100F8D02F /* TextViewInputHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B574CA72242D552100F8D02F /* TextViewInputHandler.swift */; };
 		B579E0B41AF2946F00A07036 /* VSTheme+Simplenote.m in Sources */ = {isa = PBXBuildFile; fileRef = B579E0B31AF2946F00A07036 /* VSTheme+Simplenote.m */; };
 		B579E0B51AF2946F00A07036 /* VSTheme+Simplenote.m in Sources */ = {isa = PBXBuildFile; fileRef = B579E0B31AF2946F00A07036 /* VSTheme+Simplenote.m */; };
+		B57CB874244DEBC300BA7969 /* Options.swift in Sources */ = {isa = PBXBuildFile; fileRef = B57CB873244DEBC300BA7969 /* Options.swift */; };
+		B57CB875244DEBC300BA7969 /* Options.swift in Sources */ = {isa = PBXBuildFile; fileRef = B57CB873244DEBC300BA7969 /* Options.swift */; };
+		B57CB877244DEBCE00BA7969 /* UserDefaults+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B57CB876244DEBCE00BA7969 /* UserDefaults+Simplenote.swift */; };
+		B57CB878244DEBCE00BA7969 /* UserDefaults+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B57CB876244DEBCE00BA7969 /* UserDefaults+Simplenote.swift */; };
+		B57CB87E244DED2300BA7969 /* Bundle+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B57CB87D244DED2300BA7969 /* Bundle+Simplenote.swift */; };
+		B57CB87F244DED2300BA7969 /* Bundle+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B57CB87D244DED2300BA7969 /* Bundle+Simplenote.swift */; };
 		B59848801BCDB95A005EFBBE /* SPAutomatticTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = B598487D1BCDB95A005EFBBE /* SPAutomatticTracker.m */; };
 		B59848811BCDB95A005EFBBE /* SPAutomatticTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = B598487D1BCDB95A005EFBBE /* SPAutomatticTracker.m */; };
 		B59848821BCDB95A005EFBBE /* SPTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = B598487F1BCDB95A005EFBBE /* SPTracker.m */; };
@@ -481,6 +487,9 @@
 		B574CA72242D552100F8D02F /* TextViewInputHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextViewInputHandler.swift; sourceTree = "<group>"; };
 		B579E0B21AF2946F00A07036 /* VSTheme+Simplenote.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "VSTheme+Simplenote.h"; sourceTree = "<group>"; };
 		B579E0B31AF2946F00A07036 /* VSTheme+Simplenote.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "VSTheme+Simplenote.m"; sourceTree = "<group>"; };
+		B57CB873244DEBC300BA7969 /* Options.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Options.swift; sourceTree = "<group>"; };
+		B57CB876244DEBCE00BA7969 /* UserDefaults+Simplenote.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UserDefaults+Simplenote.swift"; sourceTree = "<group>"; };
+		B57CB87D244DED2300BA7969 /* Bundle+Simplenote.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Bundle+Simplenote.swift"; sourceTree = "<group>"; };
 		B57F50B2231971670074D535 /* RELEASE-NOTES.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = "RELEASE-NOTES.txt"; sourceTree = "<group>"; };
 		B598487C1BCDB95A005EFBBE /* SPAutomatticTracker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPAutomatticTracker.h; sourceTree = "<group>"; };
 		B598487D1BCDB95A005EFBBE /* SPAutomatticTracker.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPAutomatticTracker.m; sourceTree = "<group>"; };
@@ -651,6 +660,7 @@
 				B51E9FE322E64473004F16B4 /* Extensions */,
 				B574CA71242D539400F8D02F /* Handlers */,
 				463774DB171F111600E2E333 /* Models */,
+				B57CB879244DEBD500BA7969 /* Settings */,
 				B56FA78D2437C650002CB9FF /* Themes */,
 				37E10E7A20B356E800864E43 /* Tools */,
 				B59848891BCDB961005EFBBE /* Trackers */,
@@ -772,10 +782,10 @@
 		37E10E7A20B356E800864E43 /* Tools */ = {
 			isa = PBXGroup;
 			children = (
-				37D4DD6920B3574C00C225EA /* WPAuthHandler.h */,
-				37D4DD6820B3574C00C225EA /* WPAuthHandler.m */,
 				F998F3EA22853C29008C2B59 /* CrashLogging.swift */,
 				B51E9FE022E615FA004F16B4 /* SPExporter.swift */,
+				37D4DD6920B3574C00C225EA /* WPAuthHandler.h */,
+				37D4DD6820B3574C00C225EA /* WPAuthHandler.m */,
 			);
 			name = Tools;
 			sourceTree = "<group>";
@@ -918,6 +928,7 @@
 		B51E9FE322E64473004F16B4 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				B57CB87D244DED2300BA7969 /* Bundle+Simplenote.swift */,
 				B56FA79A2437D2E0002CB9FF /* NSAppearance+Simplenote.swift */,
 				B5B17F392425668400DD5B34 /* NSAttributedString+Simplenote.swift */,
 				B5283BCF23B679C00085826F /* NSMutableAttributedString+Simplenote.swift */,
@@ -931,6 +942,7 @@
 				B511799A242036BD005F8936 /* NSTextView+Simplenote.swift */,
 				B500993B24213B370037A431 /* String+Simplenote.swift */,
 				B5009936242130F70037A431 /* UnicodeScalar+Simplenote.swift */,
+				B57CB876244DEBCE00BA7969 /* UserDefaults+Simplenote.swift */,
 			);
 			name = Extensions;
 			sourceTree = "<group>";
@@ -967,6 +979,14 @@
 				B574CA72242D552100F8D02F /* TextViewInputHandler.swift */,
 			);
 			name = Handlers;
+			sourceTree = "<group>";
+		};
+		B57CB879244DEBD500BA7969 /* Settings */ = {
+			isa = PBXGroup;
+			children = (
+				B57CB873244DEBC300BA7969 /* Options.swift */,
+			);
+			name = Settings;
 			sourceTree = "<group>";
 		};
 		B59848891BCDB961005EFBBE /* Trackers */ = {
@@ -1488,6 +1508,7 @@
 				B5117998242036B1005F8936 /* NSString+Simplenote.swift in Sources */,
 				26DBB1F51405A6A800186392 /* NSString+Metadata.m in Sources */,
 				375D293A21E033D1007AB25A /* stack.c in Sources */,
+				B57CB877244DEBCE00BA7969 /* UserDefaults+Simplenote.swift in Sources */,
 				375D294221E033D1007AB25A /* html5_blocks.c in Sources */,
 				26F592551408BF75003A5174 /* NotesArrayController.m in Sources */,
 				714BA65814D3264200A6CCC1 /* SPGradientView.m in Sources */,
@@ -1515,6 +1536,7 @@
 				375D293221E033D1007AB25A /* buffer.c in Sources */,
 				375D294421E033D1007AB25A /* html.c in Sources */,
 				B5F04FCC215949FE004B1AA0 /* Preferences.m in Sources */,
+				B57CB874244DEBC300BA7969 /* Options.swift in Sources */,
 				3700E97621C1E390004771C9 /* SPTextAttachment.swift in Sources */,
 				B5C92EC01B03D5E400A4FFD0 /* NSObject+Simplenote.m in Sources */,
 				3712FC8E1FE1ACAA008544AC /* Theme.swift in Sources */,
@@ -1549,6 +1571,7 @@
 				46EEA3C317B2DC7200914D1A /* NSString+Styling.m in Sources */,
 				46EEA3C717B2FEA500914D1A /* SPTextView.m in Sources */,
 				B501AAD42437E5600084CDA3 /* AppKitConstants.swift in Sources */,
+				B57CB87E244DED2300BA7969 /* Bundle+Simplenote.swift in Sources */,
 				3712FC821FE1ACAA008544AC /* Storage.swift in Sources */,
 				375D293421E033D1007AB25A /* autolink.c in Sources */,
 				B5CD5F7E241AC69900D0260F /* NSProcessInfo+Simplenote.swift in Sources */,
@@ -1590,6 +1613,7 @@
 				B5117999242036B1005F8936 /* NSString+Simplenote.swift in Sources */,
 				466FFEB017CC10A800399652 /* SPGradientView.m in Sources */,
 				375D293B21E033D1007AB25A /* stack.c in Sources */,
+				B57CB878244DEBCE00BA7969 /* UserDefaults+Simplenote.swift in Sources */,
 				375D294321E033D1007AB25A /* html5_blocks.c in Sources */,
 				466FFEB117CC10A800399652 /* SPBackgroundView.m in Sources */,
 				466FFEB217CC10A800399652 /* SPTableRowView.m in Sources */,
@@ -1617,6 +1641,7 @@
 				375D293321E033D1007AB25A /* buffer.c in Sources */,
 				375D294521E033D1007AB25A /* html.c in Sources */,
 				B5C92EC11B03D5E400A4FFD0 /* NSObject+Simplenote.m in Sources */,
+				B57CB875244DEBC300BA7969 /* Options.swift in Sources */,
 				3712FC8F1FE1ACAA008544AC /* Theme.swift in Sources */,
 				B532F8A820C71C1000EA3506 /* WPAuthHandler.m in Sources */,
 				466FFEC117CC10A800399652 /* NSMutableAttributedString+Styling.m in Sources */,
@@ -1651,6 +1676,7 @@
 				466FFED617CC10A800399652 /* NSString+Styling.m in Sources */,
 				466FFED717CC10A800399652 /* SPTextView.m in Sources */,
 				B501AAD32437E5600084CDA3 /* AppKitConstants.swift in Sources */,
+				B57CB87F244DED2300BA7969 /* Bundle+Simplenote.swift in Sources */,
 				3712FC831FE1ACAA008544AC /* Storage.swift in Sources */,
 				375D293521E033D1007AB25A /* autolink.c in Sources */,
 				B5CD5F7F241AC69900D0260F /* NSProcessInfo+Simplenote.swift in Sources */,

--- a/Simplenote/Bundle+Simplenote.swift
+++ b/Simplenote/Bundle+Simplenote.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+
+/// Bundle: Simplenote Methods
+///
+extension Bundle {
+
+    /// Returns the Bundle Short Version String.
+    ///
+    @objc
+    var shortVersionString: String {
+        let version = infoDictionary?["CFBundleShortVersionString"] as? String
+        return version ?? ""
+    }
+}

--- a/Simplenote/CrashLogging.swift
+++ b/Simplenote/CrashLogging.swift
@@ -21,10 +21,6 @@ class CrashLoggingShim: NSObject {
         CrashLoggingCache.emailAddress = nil
         CrashLogging.setNeedsDataRefresh()
     }
-
-    @objc static func cacheOptOutSetting(_ didOptOut: Bool) {
-        CrashLoggingCache.didOptOut = didOptOut
-    }
 }
 
 private class SNCrashLoggingDataProvider: CrashLoggingDataProvider {
@@ -78,7 +74,6 @@ private struct CrashLoggingCache {
 
     struct User: Codable {
         var emailAddress: String?
-        var didOptOut: Bool = true
 
         static var empty = User()
     }
@@ -90,17 +85,6 @@ private struct CrashLoggingCache {
         set {
             var updatedUser = cachedUser ?? User.empty
             updatedUser.emailAddress = newValue
-            cachedUser = updatedUser
-        }
-    }
-
-    static var didOptOut: Bool {
-        get {
-            return cachedUser?.didOptOut ?? true
-        }
-        set {
-            var updatedUser = cachedUser ?? User.empty
-            updatedUser.didOptOut = newValue
             cachedUser = updatedUser
         }
     }

--- a/Simplenote/CrashLogging.swift
+++ b/Simplenote/CrashLogging.swift
@@ -40,12 +40,7 @@ private class SNCrashLoggingDataProvider: CrashLoggingDataProvider {
     }
 
     var userHasOptedOut: Bool {
-
-        if let analyticsEnabledSetting = simperium.preferencesObject()?.analytics_enabled {
-            return !analyticsEnabledSetting.boolValue
-        }
-
-        return CrashLoggingCache.didOptOut
+        return !Options.shared.analyticsEnabled
     }
 
     var buildType: String {

--- a/Simplenote/MigrationsHandler.swift
+++ b/Simplenote/MigrationsHandler.swift
@@ -13,9 +13,9 @@ class MigrationsHandler: NSObject {
 
     /// Stores the last known version.
     ///
-    private var lastKnownVersion: String {
+    private var lastKnownVersion: String? {
         get {
-            UserDefaults.standard.string(forKey: .lastKnownVersion) ?? String()
+            UserDefaults.standard.string(forKey: .lastKnownVersion)
         }
         set {
             UserDefaults.standard.set(newValue, forKey: .lastKnownVersion)
@@ -29,7 +29,7 @@ class MigrationsHandler: NSObject {
             return
         }
 
-        processMigrations(from: lastKnownVersion, to: runtimeVersion)
+        processMigrations(to: runtimeVersion)
         lastKnownVersion = runtimeVersion
     }
 }
@@ -41,26 +41,18 @@ private extension MigrationsHandler {
 
     /// Handles a migration *from* a given version, *towards* a given version
     ///
-    func processMigrations(from: String, to: String) {
+    func processMigrations(to: String) {
         processPreferencesMigrations()
     }
-}
-
-
-// MARK: - Concrete migration handlers
-//
-private extension MigrationsHandler {
 
     /// Moves the Analytics flag from Simperium to UserDefaults.
     /// This must be done just once, right after upgrading. Our main goal is not to sync this flag anymore via Simperium, so that fresh installs are off by default.
     ///
     func processPreferencesMigrations() {
-        guard UserDefaults.standard.containsObject(forKey: .analyticsEnabled) == false else {
-            return
-        }
-
-        guard let simperium = SimplenoteAppDelegate.shared()?.simperium, let preferences = simperium.preferencesObject() else {
-            return
+        guard UserDefaults.standard.containsObject(forKey: .analyticsEnabled) == false,
+            let preferences = SimplenoteAppDelegate.shared()?.simperium?.preferencesObject()
+            else {
+                return
         }
 
         os_log("<> Migrating Preferences flag from Simperium")

--- a/Simplenote/MigrationsHandler.swift
+++ b/Simplenote/MigrationsHandler.swift
@@ -1,0 +1,69 @@
+import Foundation
+import os.log
+
+
+// MARK: - Simplenote's Upgrade handling flows
+//
+@objcMembers
+class MigrationsHandler: NSObject {
+
+    /// Returns the Runtime version
+    ///
+    private let runtimeVersion = Bundle.main.shortVersionString
+
+    /// Stores the last known version.
+    ///
+    private var lastKnownVersion: String {
+        get {
+            UserDefaults.standard.string(forKey: .lastKnownVersion) ?? String()
+        }
+        set {
+            UserDefaults.standard.set(newValue, forKey: .lastKnownVersion)
+        }
+    }
+
+    /// Processes any routines required to (safely) handle App Version Upgrades.
+    ///
+    func ensureUpdateIsHandled() {
+        guard runtimeVersion != lastKnownVersion else {
+            return
+        }
+
+        processMigrations(from: lastKnownVersion, to: runtimeVersion)
+        lastKnownVersion = runtimeVersion
+    }
+}
+
+
+// MARK: - Private Methods
+//
+private extension MigrationsHandler {
+
+    /// Handles a migration *from* a given version, *towards* a given version
+    ///
+    func processMigrations(from: String, to: String) {
+        processPreferencesMigrations()
+    }
+}
+
+
+// MARK: - Concrete migration handlers
+//
+private extension MigrationsHandler {
+
+    /// Moves the Analytics flag from Simperium to UserDefaults.
+    /// This must be done just once, right after upgrading. Our main goal is not to sync this flag anymore via Simperium, so that fresh installs are off by default.
+    ///
+    func processPreferencesMigrations() {
+        guard UserDefaults.standard.containsObject(forKey: .analyticsEnabled) == false else {
+            return
+        }
+
+        guard let simperium = SimplenoteAppDelegate.shared()?.simperium, let preferences = simperium.preferencesObject() else {
+            return
+        }
+
+        os_log("<> Migrating Preferences flag from Simperium")
+        Options.shared.analyticsEnabled = preferences.analytics_enabled?.boolValue ?? false
+    }
+}

--- a/Simplenote/Options.swift
+++ b/Simplenote/Options.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+
+// MARK: - Wraps access to all of the UserDefault Values
+//
+@objcMembers
+class Options: NSObject {
+
+    /// Shared Instance
+    ///
+    static let shared = Options()
+
+    /// User Defaults: Convenience
+    ///
+    private let defaults: UserDefaults
+
+
+
+    /// Designated Initializer
+    ///
+    /// - Note: Should be *private*, but for unit testing purposes, we're opening this up.
+    ///
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        super.init()
+    }
+}
+
+
+// MARK: - Actual Options!
+//
+extension Options {
+
+    /// Indicates if Analytics should be enabled
+    ///
+    var analyticsEnabled: Bool {
+        get {
+            return defaults.bool(forKey: .analyticsEnabled)
+        }
+        set {
+            defaults.set(newValue, forKey: .analyticsEnabled)
+        }
+    }
+}
+
+
+// MARK: - Public Methods
+//
+extension Options {
+
+    func reset() {
+        defaults.removeObject(forKey: .analyticsEnabled)
+    }
+}

--- a/Simplenote/Options.swift
+++ b/Simplenote/Options.swift
@@ -15,7 +15,6 @@ class Options: NSObject {
     private let defaults: UserDefaults
 
 
-
     /// Designated Initializer
     ///
     /// - Note: Should be *private*, but for unit testing purposes, we're opening this up.
@@ -23,6 +22,12 @@ class Options: NSObject {
     init(defaults: UserDefaults = .standard) {
         self.defaults = defaults
         super.init()
+    }
+
+    /// Drops all the known settings
+    ///
+    func reset() {
+        defaults.removeObject(forKey: .analyticsEnabled)
     }
 }
 
@@ -35,20 +40,10 @@ extension Options {
     ///
     var analyticsEnabled: Bool {
         get {
-            return defaults.bool(forKey: .analyticsEnabled)
+            defaults.bool(forKey: .analyticsEnabled)
         }
         set {
             defaults.set(newValue, forKey: .analyticsEnabled)
         }
-    }
-}
-
-
-// MARK: - Public Methods
-//
-extension Options {
-
-    func reset() {
-        defaults.removeObject(forKey: .analyticsEnabled)
     }
 }

--- a/Simplenote/Options.swift
+++ b/Simplenote/Options.swift
@@ -36,7 +36,7 @@ class Options: NSObject {
 //
 extension Options {
 
-    /// Indicates if Analytics should be enabled
+    /// Indicates if Analytics should be enabled. Empty value defaults to `false`
     ///
     var analyticsEnabled: Bool {
         get {

--- a/Simplenote/Preferences.m
+++ b/Simplenote/Preferences.m
@@ -16,13 +16,4 @@
     self.analytics_enabled = @(false);
 }
 
-- (void) didChangeValueForKey:(NSString *)key
-{
-    if ([key isEqualToString:@"analytics_enabled"]) {
-        [CrashLogging cacheOptOutSetting:!self.analytics_enabled.boolValue];
-    }
-
-    [super didChangeValueForKey:key];
-}
-
 @end

--- a/Simplenote/SPTracker.m
+++ b/Simplenote/SPTracker.m
@@ -258,10 +258,7 @@
 
 + (BOOL)isTrackingDisabled
 {
-    Preferences *preferences = [[[SimplenoteAppDelegate sharedDelegate] simperium] preferencesObject];
-    NSNumber *enabled = [preferences analytics_enabled];
-
-    return [enabled boolValue] == false;
+    return [[Options shared] analyticsEnabled] == false;
 }
 
 @end

--- a/Simplenote/SimplenoteAppDelegate.m
+++ b/Simplenote/SimplenoteAppDelegate.m
@@ -195,6 +195,8 @@
 
 	[self.simperium authenticateWithAppID:SPCredentials.simperiumAppID APIKey:SPCredentials.simperiumApiKey window:self.window];
 
+    [[MigrationsHandler new] ensureUpdateIsHandled];
+
     [self cleanupTags];
     [self configureWelcomeNoteIfNeeded];
 

--- a/Simplenote/SimplenoteAppDelegate.m
+++ b/Simplenote/SimplenoteAppDelegate.m
@@ -675,6 +675,9 @@
     [self.noteListViewController setWaitingForIndex:YES];
     
     [_simperium signOutAndRemoveLocalData:YES completion:^{
+        // Nuke User Settings
+        [[Options shared] reset];
+
         // Auth window won't show up until next run loop, so be careful not to close main window until then
         [self->_window performSelector:@selector(orderOut:) withObject:self afterDelay:0.1f];
         [self->_simperium authenticateIfNecessary];

--- a/Simplenote/UserDefaults+Simplenote.swift
+++ b/Simplenote/UserDefaults+Simplenote.swift
@@ -1,0 +1,81 @@
+import Foundation
+
+
+// MARK: - Simplenote UserDefaults Keys
+//
+extension UserDefaults {
+    enum Key: String {
+        case analyticsEnabled
+        case lastKnownVersion
+    }
+}
+
+
+// MARK: - Convenience Methods
+//
+extension UserDefaults {
+
+    /// Returns the Booolean associated with the specified Key.
+    ///
+    func bool(forKey key: Key) -> Bool {
+        return bool(forKey: key.rawValue)
+    }
+
+    /// Returns the Integer (if any) associated with the specified Key.
+    ///
+    func integer(forKey key: Key) -> Int {
+        return integer(forKey: key.rawValue)
+    }
+
+    /// Returns the Object (if any) associated with the specified Key.
+    ///
+    func object<T>(forKey key: Key) -> T? {
+        return value(forKey: key.rawValue) as? T
+    }
+
+    /// Returns the String (if any) associated with the specified Key.
+    ///
+    func string(forKey key: Key) -> String? {
+        return value(forKey: key.rawValue) as? String
+    }
+
+    /// Stores the Key/Value Pair.
+    ///
+    func set<T>(_ value: T?, forKey key: Key) {
+        set(value, forKey: key.rawValue)
+    }
+
+    /// Nukes any object associated with the specified Key.
+    ///
+    func removeObject(forKey key: Key) {
+        removeObject(forKey: key.rawValue)
+    }
+
+    /// Indicates if there's an entry for the specified Key.
+    ///
+    func containsObject(forKey key: Key) -> Bool {
+        return value(forKey: key.rawValue) != nil
+    }
+
+    /// Subscript Accessible via our new Key type!
+    ///
+    subscript<T>(key: Key) -> T? {
+        get {
+            return value(forKey: key.rawValue) as? T
+        }
+        set {
+            set(newValue, forKey: key.rawValue)
+        }
+    }
+
+    /// Subscript: "Type Inference Fallback". To be used whenever the type cannot be automatically inferred!
+    ///
+    subscript(key: Key) -> Any? {
+        get {
+            return value(forKey: key.rawValue)
+        }
+        set {
+            set(newValue, forKey: key.rawValue)
+        }
+    }
+}


### PR DESCRIPTION
### Details:
We're storing the `Analytics Enabled` flag in Simperium. Meaning that right after signing in, if the flag was enabled in your account, it'll be turned on by default.

In this PR we're replacing such beautiful mechanism with a local UserDefaults boolean.

**Why:** As per AAPL's guidelines, a fresh install should always be off by default.

cc @aerych  (Thank you sir!!)

### Test
0. Install `develop`
1. Log into your account
2. Click over `Privacy Settings` and enable analytics
3. Install this branch on top

- [x] Verify `Analytics` are enabled
- [x] Verify that the following snippet shows up in the console: `<> Migrating Preferences flag from Simperium`
- [x] Verify that if you disable `Analytics` and relaunch, the setting sticks disabled

### Release
These changes do not require release notes.
