### PR TITLE
SPWindow: Displaying the title bar

### DIFF
--- a/Simplenote/SPWindow.h
+++ b/Simplenote/SPWindow.h
@@ -1,18 +1,7 @@
-//
-//  SPWindow.h
-//  Simplenote
-//
-//  Created by Jorge Leandro Perez on 12/15/14.
-//  Copyright (c) 2014 Simperium. All rights reserved.
-//
-
 #import <AppKit/AppKit.h>
 
 
-
-#pragma mark ====================================================================================
-#pragma mark SPWindow
-#pragma mark ====================================================================================
+#pragma mark - SPWindow
 
 @interface SPWindow : NSWindow
 

--- a/Simplenote/SPWindow.m
+++ b/Simplenote/SPWindow.m
@@ -31,8 +31,7 @@
 
 - (void)setupTitle
 {
-    self.titleVisibility            = NSWindowTitleHidden;
-    self.titlebarAppearsTransparent = YES;
+    self.titleVisibility = NSWindowTitleHidden;
 }
 
 - (void)applyMojaveThemeOverrideIfNecessary

--- a/Simplenote/SPWindow.m
+++ b/Simplenote/SPWindow.m
@@ -1,53 +1,33 @@
-//
-//  SPWindow.m
-//  Simplenote
-//
-//  Created by Jorge Leandro Perez on 12/15/14.
-//  Copyright (c) 2014 Simperium. All rights reserved.
-//
-
 #import "SPWindow.h"
-#import "VSThemeManager.h"
+#import "Simplenote-Swift.h"
 
 
-#pragma mark ====================================================================================
-#pragma mark SPWindow
-#pragma mark ====================================================================================
+#pragma mark - SPWindow
 
 @implementation SPWindow
 
 - (instancetype)initWithContentRect:(NSRect)contentRect styleMask:(NSWindowStyleMask)styleMask backing:(NSBackingStoreType)bufferingType defer:(BOOL)flag
 {
-    styleMask = [self yosemiteMaskWithMask:styleMask];
     if (self = [super initWithContentRect:contentRect styleMask:styleMask backing:bufferingType defer:flag]) {
         [self setupTitle];
+        [self applyMojaveThemeOverrideIfNecessary];
     }
-    
-    [self applyMojaveThemeOverrideIfNecessary];
-    
+
     return self;
 }
 
 - (instancetype)initWithContentRect:(NSRect)contentRect styleMask:(NSWindowStyleMask)styleMask backing:(NSBackingStoreType)bufferingType defer:(BOOL)flag screen:(NSScreen *)screen
 {
-    styleMask = [self yosemiteMaskWithMask:styleMask];
     if ((self = [super initWithContentRect:contentRect styleMask:styleMask backing:bufferingType defer:flag screen:screen])) {
         [self setupTitle];
+        [self applyMojaveThemeOverrideIfNecessary];
     }
-    
-    [self applyMojaveThemeOverrideIfNecessary];
-    
+
     return self;
 }
 
 
 #pragma mark - Initialization Helpers
-
-- (NSUInteger)yosemiteMaskWithMask:(NSUInteger)mask
-{
-    mask |= NSWindowStyleMaskUnifiedTitleAndToolbar | NSWindowStyleMaskFullSizeContentView;
-    return mask;
-}
 
 - (void)setupTitle
 {
@@ -58,12 +38,8 @@
 - (void)applyMojaveThemeOverrideIfNecessary
 {
     if (@available(macOS 10.14, *)) {
-        NSString *themeName = [[NSUserDefaults standardUserDefaults] objectForKey:VSThemeManagerThemePrefKey];
-        if (themeName) {
-            self.appearance = [NSAppearance appearanceNamed:
-                              [themeName isEqualToString:@"dark"] ?
-                                 NSAppearanceNameVibrantDark : NSAppearanceNameVibrantLight];
-        }
+        NSAppearanceName name = [SPUserInterface isDark] ? NSAppearanceNameVibrantDark : NSAppearanceNameVibrantLight;
+        self.appearance = [NSAppearance appearanceNamed:name];
     }
 }
 


### PR DESCRIPTION
### Fix
***(Required)*** Add a concise description of what you fixed.  If this is related to an issue, add a link to it.  If applicable, add screenshots, animations, or videos to help illustrate the fix.

cc @emilylaguna Em, may I bug you with a macOS PR?
Thanks in advance!!

cc @SylvesterWilmott for the design review. JUST IN CASE you've got secound thoughts!!

Ref. #458 

### Test
- [ ] Verify Simplenote's main window now displays a titleBar
- [ ] Verify the app looks great in Dark / Light mode

### Release
These changes do not require release notes.

---

### Screenshots
<img width="300" alt="Screen Shot 2020-04-23 at 5 37 50 PM" src="https://user-images.githubusercontent.com/1195260/80147750-5c600880-858a-11ea-99c3-f325f74ddc0b.png">

<img width="300" alt="Screen Shot 2020-04-23 at 5 37 55 PM" src="https://user-images.githubusercontent.com/1195260/80147764-6124bc80-858a-11ea-8107-a61ed3c34e68.png">
