### PR TITLE
Drops NSMenuItem Outlets: Part I

### DIFF
--- a/Simplenote/NSUserInterfaceItemIdentifier+Simplenote.swift
+++ b/Simplenote/NSUserInterfaceItemIdentifier+Simplenote.swift
@@ -5,19 +5,19 @@ import Foundation
 //
 extension NSUserInterfaceItemIdentifier {
 
-    /// Identifier: Empty Trash Item
+    /// Identifier: EmptyTrash MenuItem
     ///
-    static let emptyTrashItemIdentifier = NSUserInterfaceItemIdentifier(rawValue: "emptyTrashItemIdentifier")
+    static let emptyTrashMenuItem = NSUserInterfaceItemIdentifier(rawValue: "emptyTrashMenuItem")
 
-    /// Identifier: Export Item
+    /// Identifier: Export MenuItem
     ///
-    static let exportItemIdentifier = NSUserInterfaceItemIdentifier(rawValue: "exportItemIdentifier")
+    static let exportMenuItem = NSUserInterfaceItemIdentifier(rawValue: "exportMenuItem")
 
-    /// Identifier: Focus Item
+    /// Identifier: Focus MenuItem
     ///
-    static let focusItemIdentifier = NSUserInterfaceItemIdentifier(rawValue: "focusItemIdentifier")
+    static let focusMenuItem = NSUserInterfaceItemIdentifier(rawValue: "focusMenuItem")
 
     /// Identifier: Theme Menu
     ///
-    static let themeMenuIdentifier = NSUserInterfaceItemIdentifier(rawValue: "themeMenuIdentifier")
+    static let themeMenu = NSUserInterfaceItemIdentifier(rawValue: "themeMenu")
 }

--- a/Simplenote/NSUserInterfaceItemIdentifier+Simplenote.swift
+++ b/Simplenote/NSUserInterfaceItemIdentifier+Simplenote.swift
@@ -17,7 +17,15 @@ extension NSUserInterfaceItemIdentifier {
     ///
     static let focusMenuItem = NSUserInterfaceItemIdentifier(rawValue: "focusMenuItem")
 
-    /// Identifier: Theme Menu
+    /// Identifier: Dark Theme MenuItem
     ///
-    static let themeMenu = NSUserInterfaceItemIdentifier(rawValue: "themeMenu")
+    static let themeDarkMenuItem = NSUserInterfaceItemIdentifier(rawValue: "themeDarkMenuItem")
+
+    /// Identifier: Light Theme MenuItem
+    ///
+    static let themeLightMenuItem = NSUserInterfaceItemIdentifier(rawValue: "themeLightMenuItem")
+
+    /// Identifier: System Theme MenuItem
+    ///
+    static let themeSystemMenuItem = NSUserInterfaceItemIdentifier(rawValue: "themeSystemMenuItem")
 }

--- a/Simplenote/NSUserInterfaceItemIdentifier+Simplenote.swift
+++ b/Simplenote/NSUserInterfaceItemIdentifier+Simplenote.swift
@@ -9,6 +9,10 @@ extension NSUserInterfaceItemIdentifier {
     ///
     static let emptyTrashItemIdentifier = NSUserInterfaceItemIdentifier(rawValue: "emptyTrashItemIdentifier")
 
+    /// Identifier: Export Item
+    ///
+    static let exportItemIdentifier = NSUserInterfaceItemIdentifier(rawValue: "exportItemIdentifier")
+
     /// Identifier: Focus Item
     ///
     static let focusItemIdentifier = NSUserInterfaceItemIdentifier(rawValue: "focusItemIdentifier")

--- a/Simplenote/NSUserInterfaceItemIdentifier+Simplenote.swift
+++ b/Simplenote/NSUserInterfaceItemIdentifier+Simplenote.swift
@@ -5,6 +5,14 @@ import Foundation
 //
 extension NSUserInterfaceItemIdentifier {
 
+    /// Identifier: Empty Trash Item
+    ///
+    static let emptyTrashItemIdentifier = NSUserInterfaceItemIdentifier(rawValue: "emptyTrashItemIdentifier")
+
+    /// Identifier: Focus Item
+    ///
+    static let focusItemIdentifier = NSUserInterfaceItemIdentifier(rawValue: "focusItemIdentifier")
+
     /// Identifier: Theme Menu
     ///
     static let themeMenuIdentifier = NSUserInterfaceItemIdentifier(rawValue: "themeMenuIdentifier")

--- a/Simplenote/SimplenoteAppDelegate+Swift.swift
+++ b/Simplenote/SimplenoteAppDelegate+Swift.swift
@@ -41,7 +41,7 @@ extension SimplenoteAppDelegate {
 
     @objc
     func validateFocusMenuItem(_ item: NSMenuItem) -> Bool {
-        item.state = splitViewController.isNotesListCollapsed ? .on : .off
+        item.state = noteListViewController.view.isHidden ? .on : .off
         return true
     }
 

--- a/Simplenote/SimplenoteAppDelegate+Swift.swift
+++ b/Simplenote/SimplenoteAppDelegate+Swift.swift
@@ -31,13 +31,13 @@ extension SimplenoteAppDelegate: NSMenuItemValidation {
         }
 
         switch identifier {
-        case .emptyTrashItemIdentifier:
+        case .emptyTrashMenuItem:
             return validateEmptyTrashMenuItem(menuItem)
-        case .exportItemIdentifier:
+        case .exportMenuItem:
             return validateExportMenuItem(menuItem)
-        case .focusItemIdentifier:
+        case .focusMenuItem:
             return validateFocusMenuItem(menuItem)
-        case .themeMenuIdentifier:
+        case .themeMenu:
             return validateThemeMenuItem(menuItem)
         default:
             return true

--- a/Simplenote/SimplenoteAppDelegate+Swift.swift
+++ b/Simplenote/SimplenoteAppDelegate+Swift.swift
@@ -25,8 +25,7 @@ extension SimplenoteAppDelegate {
 extension SimplenoteAppDelegate: NSMenuItemValidation {
 
     public func validateMenuItem(_ menuItem: NSMenuItem) -> Bool {
-        // Whenever a given NSMenuItem doesn't have an Identifier set, we'll check if the containing NSMenu has one
-        guard let identifier = menuItem.identifier ?? menuItem.menu?.identifier else {
+        guard let identifier = menuItem.identifier else {
             return true
         }
 
@@ -37,7 +36,7 @@ extension SimplenoteAppDelegate: NSMenuItemValidation {
             return validateExportMenuItem(menuItem)
         case .focusMenuItem:
             return validateFocusMenuItem(menuItem)
-        case .themeMenu:
+        case .themeDarkMenuItem, .themeLightMenuItem, .themeSystemMenuItem:
             return validateThemeMenuItem(menuItem)
         default:
             return true

--- a/Simplenote/SimplenoteAppDelegate+Swift.swift
+++ b/Simplenote/SimplenoteAppDelegate+Swift.swift
@@ -22,41 +22,41 @@ extension SimplenoteAppDelegate {
 
 // MARK: - MenuItem(s) Validation
 //
-extension SimplenoteAppDelegate {
+extension SimplenoteAppDelegate: NSMenuItemValidation {
 
-    @objc
-    func isEmptyTrashMenuItem(_ item: NSMenuItem) -> Bool {
-        return item.identifier == NSUserInterfaceItemIdentifier.emptyTrashItemIdentifier
+    public func validateMenuItem(_ menuItem: NSMenuItem) -> Bool {
+        guard let identifier = menuItem.identifier else {
+            return true
+        }
+
+        switch identifier {
+        case .emptyTrashItemIdentifier:
+            return validateTrashMenuItem(menuItem)
+        case .exportItemIdentifier:
+            return validateExportMenuItem(menuItem)
+        case .focusItemIdentifier:
+            return validateFocusMenuItem(menuItem)
+        case .themeMenuIdentifier:
+            return validateThemeMenuItem(menuItem)
+        default:
+            return true
+        }
     }
 
-    @objc
-    func isFocusMenuItem(_ item: NSMenuItem) -> Bool {
-        return item.identifier == NSUserInterfaceItemIdentifier.focusItemIdentifier
+    func validateTrashMenuItem(_ item: NSMenuItem) -> Bool {
+        return numDeletedNotes() > .zero
     }
 
-    @objc
-    func isThemeMenuItem(_ item: NSMenuItem) -> Bool {
-        return item.menu?.identifier == NSUserInterfaceItemIdentifier.themeMenuIdentifier
-    }
-
-    @objc
-    func isExportMenuItem(_ item: NSMenuItem) -> Bool {
-        return item.identifier == NSUserInterfaceItemIdentifier.exportItemIdentifier
-    }
-
-    @objc
     func validateExportMenuItem(_ item: NSMenuItem) -> Bool {
         item.isHidden = !exportUnlocked
         return true
     }
 
-    @objc
     func validateFocusMenuItem(_ item: NSMenuItem) -> Bool {
-        item.state = noteListViewController.view.isHidden ? .on : .off
+        item.state = splitViewController.isNotesListCollapsed ? .on : .off
         return true
     }
 
-    @objc
     func validateThemeMenuItem(_ item: NSMenuItem) -> Bool {
         guard let option = ThemeOption(rawValue: item.tag) else {
             return false

--- a/Simplenote/SimplenoteAppDelegate+Swift.swift
+++ b/Simplenote/SimplenoteAppDelegate+Swift.swift
@@ -40,6 +40,17 @@ extension SimplenoteAppDelegate {
     }
 
     @objc
+    func isExportMenuItem(_ item: NSMenuItem) -> Bool {
+        return item.identifier == NSUserInterfaceItemIdentifier.exportItemIdentifier
+    }
+
+    @objc
+    func validateExportMenuItem(_ item: NSMenuItem) -> Bool {
+        item.isHidden = !exportUnlocked
+        return true
+    }
+
+    @objc
     func validateFocusMenuItem(_ item: NSMenuItem) -> Bool {
         item.state = noteListViewController.view.isHidden ? .on : .off
         return true

--- a/Simplenote/SimplenoteAppDelegate+Swift.swift
+++ b/Simplenote/SimplenoteAppDelegate+Swift.swift
@@ -25,12 +25,24 @@ extension SimplenoteAppDelegate {
 extension SimplenoteAppDelegate {
 
     @objc
-    func isThemeMenuItem(_ item: NSMenuItem) -> Bool {
-        guard let identifier = item.menu?.identifier else {
-            return false
-        }
+    func isEmptyTrashMenuItem(_ item: NSMenuItem) -> Bool {
+        return item.identifier == NSUserInterfaceItemIdentifier.emptyTrashItemIdentifier
+    }
 
-        return identifier == .themeMenuIdentifier
+    @objc
+    func isFocusMenuItem(_ item: NSMenuItem) -> Bool {
+        return item.identifier == NSUserInterfaceItemIdentifier.focusItemIdentifier
+    }
+
+    @objc
+    func isThemeMenuItem(_ item: NSMenuItem) -> Bool {
+        return item.menu?.identifier == NSUserInterfaceItemIdentifier.themeMenuIdentifier
+    }
+
+    @objc
+    func validateFocusMenuItem(_ item: NSMenuItem) -> Bool {
+        item.state = splitViewController.isNotesListCollapsed ? .on : .off
+        return true
     }
 
     @objc

--- a/Simplenote/SimplenoteAppDelegate+Swift.swift
+++ b/Simplenote/SimplenoteAppDelegate+Swift.swift
@@ -54,8 +54,11 @@ extension SimplenoteAppDelegate: NSMenuItemValidation {
     }
 
     func validateFocusMenuItem(_ item: NSMenuItem) -> Bool {
-        item.state = noteListViewController.view.isHidden ? .on : .off
-        return true
+        let inFocusMode = noteListViewController.view.isHidden
+        item.state = inFocusMode ? .on : .off
+
+        // Prevent toggling Focus Mode whenever the editor is empty
+        return inFocusMode || noteEditorViewController.isDisplayingNote
     }
 
     func validateThemeMenuItem(_ item: NSMenuItem) -> Bool {

--- a/Simplenote/SimplenoteAppDelegate+Swift.swift
+++ b/Simplenote/SimplenoteAppDelegate+Swift.swift
@@ -25,13 +25,14 @@ extension SimplenoteAppDelegate {
 extension SimplenoteAppDelegate: NSMenuItemValidation {
 
     public func validateMenuItem(_ menuItem: NSMenuItem) -> Bool {
-        guard let identifier = menuItem.identifier else {
+        // Whenever a given NSMenuItem doesn't have an Identifier set, we'll check if the containing NSMenu has one
+        guard let identifier = menuItem.identifier ?? menuItem.menu?.identifier else {
             return true
         }
 
         switch identifier {
         case .emptyTrashItemIdentifier:
-            return validateTrashMenuItem(menuItem)
+            return validateEmptyTrashMenuItem(menuItem)
         case .exportItemIdentifier:
             return validateExportMenuItem(menuItem)
         case .focusItemIdentifier:
@@ -43,7 +44,7 @@ extension SimplenoteAppDelegate: NSMenuItemValidation {
         }
     }
 
-    func validateTrashMenuItem(_ item: NSMenuItem) -> Bool {
+    func validateEmptyTrashMenuItem(_ item: NSMenuItem) -> Bool {
         return numDeletedNotes() > .zero
     }
 

--- a/Simplenote/SimplenoteAppDelegate+Swift.swift
+++ b/Simplenote/SimplenoteAppDelegate+Swift.swift
@@ -54,7 +54,7 @@ extension SimplenoteAppDelegate: NSMenuItemValidation {
     }
 
     func validateFocusMenuItem(_ item: NSMenuItem) -> Bool {
-        item.state = splitViewController.isNotesListCollapsed ? .on : .off
+        item.state = noteListViewController.view.isHidden ? .on : .off
         return true
     }
 

--- a/Simplenote/SimplenoteAppDelegate.h
+++ b/Simplenote/SimplenoteAppDelegate.h
@@ -19,7 +19,7 @@
 #pragma mark SimplenoteAppDelegate
 #pragma mark ====================================================================================
 
-@interface SimplenoteAppDelegate : NSObject <NSApplicationDelegate, NSWindowDelegate>
+@interface SimplenoteAppDelegate : NSObject <NSApplicationDelegate, NSSplitViewDelegate, NSWindowDelegate>
 
 @property (strong, nonatomic, readonly) IBOutlet NSWindow                 *window;
 

--- a/Simplenote/SimplenoteAppDelegate.h
+++ b/Simplenote/SimplenoteAppDelegate.h
@@ -19,9 +19,7 @@
 #pragma mark SimplenoteAppDelegate
 #pragma mark ====================================================================================
 
-@interface SimplenoteAppDelegate : NSObject <NSApplicationDelegate, NSSplitViewDelegate, NSWindowDelegate> {
-    IBOutlet NSMenuItem *focusModeMenuItem;
-}
+@interface SimplenoteAppDelegate : NSObject <NSApplicationDelegate, NSWindowDelegate>
 
 @property (strong, nonatomic, readonly) IBOutlet NSWindow                 *window;
 

--- a/Simplenote/SimplenoteAppDelegate.h
+++ b/Simplenote/SimplenoteAppDelegate.h
@@ -32,6 +32,8 @@
 @property (strong, nonatomic, readonly) NSManagedObjectModel              *managedObjectModel;
 @property (strong, nonatomic, readonly) NSManagedObjectContext            *managedObjectContext;
 
+@property (assign, nonatomic, readonly) BOOL                              exportUnlocked;
+
 + (SimplenoteAppDelegate *)sharedDelegate;
 
 - (IBAction)signOutAction:(id)sender;

--- a/Simplenote/SimplenoteAppDelegate.m
+++ b/Simplenote/SimplenoteAppDelegate.m
@@ -54,7 +54,7 @@
 @property (strong, nonatomic) IBOutlet NoteEditorViewController *noteEditorViewController;
 
 @property (strong, nonatomic) IBOutlet SPSplitView              *splitView;
-@property (strong, nonatomic) IBOutlet NSMenuItem               *exportItem;
+@property (assign, nonatomic) BOOL                              exportUnlocked;
 
 @property (strong, nonatomic) NSWindowController                *aboutWindowController;
 @property (strong, nonatomic) NSWindowController                *privacyWindowController;
@@ -209,7 +209,7 @@
     }
 
     if ([SPExporter mustEnableExportAction:url]) {
-        [self.exportItem setHidden:NO];
+        self.exportUnlocked = YES;
     }
 }
 
@@ -528,6 +528,10 @@
 
     if ([self isThemeMenuItem:menuItem]) {
         return [self validateThemeMenuItem:menuItem];
+    }
+
+    if ([self isExportMenuItem:menuItem]) {
+        return [self validateExportMenuItem:menuItem];
     }
 
     return YES;

--- a/Simplenote/SimplenoteAppDelegate.m
+++ b/Simplenote/SimplenoteAppDelegate.m
@@ -514,30 +514,6 @@
 }
 
 
-#pragma mark - Menu delegate
-
-- (BOOL)validateMenuItem:(NSMenuItem *)menuItem
-{
-    if ([self isEmptyTrashMenuItem:menuItem]) {
-        return [self numDeletedNotes] > 0;
-    }
-
-    if ([self isFocusMenuItem:menuItem]) {
-        return [self validateFocusMenuItem:menuItem];
-    }
-
-    if ([self isThemeMenuItem:menuItem]) {
-        return [self validateThemeMenuItem:menuItem];
-    }
-
-    if ([self isExportMenuItem:menuItem]) {
-        return [self validateExportMenuItem:menuItem];
-    }
-
-    return YES;
-}
-
-
 #pragma mark - Static Helpers
 
 + (SimplenoteAppDelegate *)sharedDelegate

--- a/Simplenote/SimplenoteAppDelegate.m
+++ b/Simplenote/SimplenoteAppDelegate.m
@@ -55,7 +55,6 @@
 
 @property (strong, nonatomic) IBOutlet SPSplitView              *splitView;
 @property (strong, nonatomic) IBOutlet NSMenuItem               *exportItem;
-@property (strong, nonatomic) IBOutlet NSMenuItem               *emptyTrashItem;
 
 @property (strong, nonatomic) NSWindowController                *aboutWindowController;
 @property (strong, nonatomic) NSWindowController                *privacyWindowController;
@@ -519,8 +518,12 @@
 
 - (BOOL)validateMenuItem:(NSMenuItem *)menuItem
 {
-    if (menuItem == self.emptyTrashItem) {
+    if ([self isEmptyTrashMenuItem:menuItem]) {
         return [self numDeletedNotes] > 0;
+    }
+
+    if ([self isFocusMenuItem:menuItem]) {
+        return [self validateFocusMenuItem:menuItem];
     }
 
     if ([self isThemeMenuItem:menuItem]) {
@@ -637,8 +640,6 @@
     [self.noteListViewController.view setHidden:![self.noteListViewController.view isHidden]];
     
     BOOL isEnteringFocusMode = [self.noteListViewController.view isHidden];
-    // Enable/disable buttons and search bar in the toolbar
-    [focusModeMenuItem setState:isEnteringFocusMode ? NSOnState : NSOffState];
     
     if (!isEnteringFocusMode && tagsVisible) {
         // If ending focus mode and the tag view was previously visible, show it agian

--- a/Simplenote/en.lproj/MainMenu.xib
+++ b/Simplenote/en.lproj/MainMenu.xib
@@ -448,22 +448,22 @@
                             </menuItem>
                             <menuItem title="Theme" id="Jtf-4C-imn">
                                 <modifierMask key="keyEquivalentModifierMask"/>
-                                <menu key="submenu" title="Theme" systemMenu="font" identifier="themeMenu" id="SIP-Tf-W7J">
+                                <menu key="submenu" title="Theme" systemMenu="font" id="SIP-Tf-W7J">
                                     <items>
-                                        <menuItem title="Light" id="Zhe-Bb-jvT">
+                                        <menuItem title="Light" identifier="themeLightMenuItem" id="Zhe-Bb-jvT">
                                             <modifierMask key="keyEquivalentModifierMask"/>
                                             <connections>
                                                 <action selector="clickedThemeItem:" target="494" id="mgq-M0-lcf"/>
                                             </connections>
                                         </menuItem>
-                                        <menuItem title="Dark" tag="1" id="qcT-FY-eHe">
+                                        <menuItem title="Dark" tag="1" identifier="themeDarkMenuItem" id="qcT-FY-eHe">
                                             <modifierMask key="keyEquivalentModifierMask"/>
                                             <connections>
                                                 <action selector="clickedThemeItem:" target="494" id="wom-f8-fYq"/>
                                             </connections>
                                         </menuItem>
                                         <menuItem isSeparatorItem="YES" tag="1000" id="vHw-6k-QDk"/>
-                                        <menuItem title="System Appearance" tag="2" enabled="NO" id="x6g-cH-Wdm">
+                                        <menuItem title="System Appearance" tag="2" enabled="NO" identifier="themeSystemMenuItem" id="x6g-cH-Wdm">
                                             <modifierMask key="keyEquivalentModifierMask"/>
                                             <connections>
                                                 <action selector="clickedThemeItem:" target="494" id="b76-s6-4Ql"/>

--- a/Simplenote/en.lproj/MainMenu.xib
+++ b/Simplenote/en.lproj/MainMenu.xib
@@ -84,7 +84,7 @@
                                     <action selector="exportAcction:" target="494" id="0Ff-Xt-PdT"/>
                                 </connections>
                             </menuItem>
-                            <menuItem title="Empty Trash" id="1256">
+                            <menuItem title="Empty Trash" identifier="emptyTrashItemIdentifier" id="1256">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>
                                     <action selector="emptyTrashAction:" target="494" id="1688"/>
@@ -473,7 +473,7 @@
                                 </menu>
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="6I8-iX-Ptg"/>
-                            <menuItem title="Focus Mode" keyEquivalent="F" id="nrD-mL-W7Q">
+                            <menuItem title="Focus Mode" keyEquivalent="F" identifier="focusItemIdentifier" id="nrD-mL-W7Q">
                                 <connections>
                                     <action selector="focusModeAction:" target="494" id="3q6-ha-uEK"/>
                                 </connections>
@@ -1150,9 +1150,7 @@
         <customObject id="494" customClass="SimplenoteAppDelegate">
             <connections>
                 <outlet property="backgroundView" destination="372" id="C2S-D2-Vn5"/>
-                <outlet property="emptyTrashItem" destination="1256" id="1776"/>
                 <outlet property="exportItem" destination="Pwd-hR-fBt" id="fmk-th-axO"/>
-                <outlet property="focusModeMenuItem" destination="nrD-mL-W7Q" id="9KY-QY-jI5"/>
                 <outlet property="noteEditorViewController" destination="1107" id="1674"/>
                 <outlet property="noteListViewController" destination="874" id="1476"/>
                 <outlet property="splitView" destination="557" id="1477"/>

--- a/Simplenote/en.lproj/MainMenu.xib
+++ b/Simplenote/en.lproj/MainMenu.xib
@@ -78,13 +78,13 @@
                             <menuItem isSeparatorItem="YES" id="149">
                                 <modifierMask key="keyEquivalentModifierMask" command="YES"/>
                             </menuItem>
-                            <menuItem title="Export Everything" hidden="YES" identifier="exportItemIdentifier" id="Pwd-hR-fBt">
+                            <menuItem title="Export Everything" hidden="YES" identifier="exportMenuItem" id="Pwd-hR-fBt">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>
                                     <action selector="exportAcction:" target="494" id="0Ff-Xt-PdT"/>
                                 </connections>
                             </menuItem>
-                            <menuItem title="Empty Trash" identifier="emptyTrashItemIdentifier" id="1256">
+                            <menuItem title="Empty Trash" identifier="emptyTrashMenuItem" id="1256">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>
                                     <action selector="emptyTrashAction:" target="494" id="1688"/>
@@ -448,7 +448,7 @@
                             </menuItem>
                             <menuItem title="Theme" id="Jtf-4C-imn">
                                 <modifierMask key="keyEquivalentModifierMask"/>
-                                <menu key="submenu" title="Theme" systemMenu="font" identifier="themeMenuIdentifier" id="SIP-Tf-W7J">
+                                <menu key="submenu" title="Theme" systemMenu="font" identifier="themeMenu" id="SIP-Tf-W7J">
                                     <items>
                                         <menuItem title="Light" id="Zhe-Bb-jvT">
                                             <modifierMask key="keyEquivalentModifierMask"/>
@@ -473,7 +473,7 @@
                                 </menu>
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="6I8-iX-Ptg"/>
-                            <menuItem title="Focus Mode" keyEquivalent="F" identifier="focusItemIdentifier" id="nrD-mL-W7Q">
+                            <menuItem title="Focus Mode" keyEquivalent="F" identifier="focusMenuItem" id="nrD-mL-W7Q">
                                 <connections>
                                     <action selector="focusModeAction:" target="494" id="3q6-ha-uEK"/>
                                 </connections>

--- a/Simplenote/en.lproj/MainMenu.xib
+++ b/Simplenote/en.lproj/MainMenu.xib
@@ -78,7 +78,7 @@
                             <menuItem isSeparatorItem="YES" id="149">
                                 <modifierMask key="keyEquivalentModifierMask" command="YES"/>
                             </menuItem>
-                            <menuItem title="Export Everything" hidden="YES" id="Pwd-hR-fBt">
+                            <menuItem title="Export Everything" hidden="YES" identifier="exportItemIdentifier" id="Pwd-hR-fBt">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>
                                     <action selector="exportAcction:" target="494" id="0Ff-Xt-PdT"/>
@@ -1150,7 +1150,6 @@
         <customObject id="494" customClass="SimplenoteAppDelegate">
             <connections>
                 <outlet property="backgroundView" destination="372" id="C2S-D2-Vn5"/>
-                <outlet property="exportItem" destination="Pwd-hR-fBt" id="fmk-th-axO"/>
                 <outlet property="noteEditorViewController" destination="1107" id="1674"/>
                 <outlet property="noteListViewController" destination="874" id="1476"/>
                 <outlet property="splitView" destination="557" id="1477"/>


### PR DESCRIPTION
### Details:
In this PR we're addressing a bit of Tech Debt, and dropping **NSMenuItem outlets** from the AppDelegate.

We're now relying on a much cleaner mechanism, which involves the `NSMenuItemValidation` protocol, along with `NSUserInterfaceItemIdentifier` extensible enum cases.

@emilylaguna Em!! May I bug you with yet another macOS PR?
Thanks in advance!!

Ref. #458

### Scenario: Empty Trash
- [ ] Verify the Menu **Simplenote > Empty Trash** is only enabled when your trash is not empty

### Scenario: Export
1. Open `simplenote://export` in your favorite browser
2. Verify Simplenote comes to the foreground

- [ ] Verify a new Menu Item shows up: **Simplenote >> Export Everything**

### Scenario: Focus
- [ ] Verify the Menu **View > Focus Mode** is enabled whenever there's a note onscreen
- [ ] Verify that whenever there's no note onscreen (Empty Tag or Empty Trash) **View > Focus Mode** is disabled
- [ ] Verify the **Shift + CMD + F** shortcut works only when there's a note onScreen, as well

**Note:** YES Focus Mode is slightly broken. There's a separator getting stuck in some flows. Fixing that in #532, promise!!

### Scenario: Theme
- [ ] Verify the Menu **View > Theme** displays a checkmark right by the current theme
- [ ] Verify that changing the active theme correctly refreshes the **View > Theme** selected item

### Release
These changes do not require release notes.
