### PR TITLE
Visually center the About window on screen.

### DIFF
--- a/Simplenote/SimplenoteAppDelegate.m
+++ b/Simplenote/SimplenoteAppDelegate.m
@@ -321,6 +321,7 @@
     
     NSStoryboard *aboutStoryboard = [NSStoryboard storyboardWithName:@"About" bundle:nil];
     self.aboutWindowController = [aboutStoryboard instantiateControllerWithIdentifier:@"AboutWindowController"];
+    [self.aboutWindowController.window center];
     [self.aboutWindowController showWindow:self];
 }
 


### PR DESCRIPTION
### Fix

Same positioning as used for system alerts. Centered horizontally and somewhat above center vertically. Matches what you'd see from Apple's default apps.

### Test

1. Launch Simplenote
2. Select the **Simplenote > About Simplenote** menu item
3. Confirm the About window is visually centered on screen

These changes do not require release notes.