### PR TITLE
About window should respond to the ESC key.

### DIFF
--- a/Simplenote/About.storyboard
+++ b/Simplenote/About.storyboard
@@ -10,7 +10,7 @@
         <scene sceneID="o5x-cC-aBy">
             <objects>
                 <windowController storyboardIdentifier="AboutWindowController" showSeguePresentationStyle="single" id="WZ7-aT-eIa" sceneMemberID="viewController">
-                    <window key="window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="" animationBehavior="default" titleVisibility="hidden" id="2Om-mE-jCO">
+                    <window key="window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="" animationBehavior="default" titleVisibility="hidden" id="2Om-mE-jCO" customClass="NSPanel">
                         <windowStyleMask key="styleMask" titled="YES" closable="YES"/>
                         <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
                         <rect key="contentRect" x="294" y="314" width="480" height="270"/>


### PR DESCRIPTION
### Fix

Just updates the storyboard to use NSPanel instead of NSWindow. This encompasses the default behaviour for About windows.

### Test

1. Launch Simplenote
2. Select the **Simplenote > About Simplenote** menu item
3. Confirm the About window responds to the ESC key

These changes do not require release notes.