### PR TITLE
Decoupling Tags List: Mark 1

### DIFF
--- a/Simplenote/NSNotification+Simplenote.h
+++ b/Simplenote/NSNotification+Simplenote.h
@@ -8,4 +8,5 @@ extern NSString * const AppleInterfaceThemeChangedNotification;
 
 // MARK: - Simplenote Notifications: Someone forgot to bridge NSNotification.Name over to ObjC. =(
 //
+extern NSString * const TagSortModeDidChangeNotification;
 extern NSString * const ThemeDidChangeNotification;

--- a/Simplenote/NSNotification+Simplenote.m
+++ b/Simplenote/NSNotification+Simplenote.m
@@ -7,4 +7,5 @@ NSString * const AppleInterfaceThemeChangedNotification = @"AppleInterfaceThemeC
 
 // MARK: - Simplenote's Notifications
 //
+NSString * const TagSortModeDidChangeNotification = @"TagSortModeDidChangeNotification";
 NSString * const ThemeDidChangeNotification = @"ThemeDidChangeNotification";

--- a/Simplenote/NSUserInterfaceItemIdentifier+Simplenote.swift
+++ b/Simplenote/NSUserInterfaceItemIdentifier+Simplenote.swift
@@ -17,6 +17,10 @@ extension NSUserInterfaceItemIdentifier {
     ///
     static let focusMenuItem = NSUserInterfaceItemIdentifier(rawValue: "focusMenuItem")
 
+    /// Identifier: Tags Sort MenuItem
+    ///
+    static let tagSortMenuItem = NSUserInterfaceItemIdentifier(rawValue: "tagSortMenuItem")
+
     /// Identifier: Dark Theme MenuItem
     ///
     static let themeDarkMenuItem = NSUserInterfaceItemIdentifier(rawValue: "themeDarkMenuItem")

--- a/Simplenote/Options.swift
+++ b/Simplenote/Options.swift
@@ -36,6 +36,17 @@ class Options: NSObject {
 //
 extension Options {
 
+    /// Indicates if Tags must be sort Alphabetically
+    ///
+    var alphabeticallySortTags: Bool {
+        get {
+            defaults.bool(forKey: .alphabeticallySortTags)
+        }
+        set {
+            defaults.set(newValue, forKey: .alphabeticallySortTags)
+        }
+    }
+
     /// Indicates if Analytics should be enabled. Empty value defaults to `false`
     ///
     var analyticsEnabled: Bool {

--- a/Simplenote/Options.swift
+++ b/Simplenote/Options.swift
@@ -44,6 +44,7 @@ extension Options {
         }
         set {
             defaults.set(newValue, forKey: .alphabeticallySortTags)
+            NotificationCenter.default.post(name: .TagSortModeDidChange, object: nil)
         }
     }
 

--- a/Simplenote/SimplenoteAppDelegate+Swift.swift
+++ b/Simplenote/SimplenoteAppDelegate+Swift.swift
@@ -102,9 +102,7 @@ extension SimplenoteAppDelegate: NSMenuItemValidation {
     }
 
     func validateTagSortMenuItem(_ item: NSMenuItem) -> Bool {
-// TODO: FIXME
-        let alphaTagSort = UserDefaults.standard.bool(forKey: "kTagSortPreferencesKey")
-        item.state = alphaTagSort ? .on : .off
+        item.state = Options.shared.alphabeticallySortTags ? .on : .off
 
         return true
     }

--- a/Simplenote/SimplenoteAppDelegate+Swift.swift
+++ b/Simplenote/SimplenoteAppDelegate+Swift.swift
@@ -76,6 +76,8 @@ extension SimplenoteAppDelegate: NSMenuItemValidation {
             return validateExportMenuItem(menuItem)
         case .focusMenuItem:
             return validateFocusMenuItem(menuItem)
+        case .tagSortMenuItem:
+            return validateTagSortMenuItem(menuItem)
         case .themeDarkMenuItem, .themeLightMenuItem, .themeSystemMenuItem:
             return validateThemeMenuItem(menuItem)
         default:
@@ -97,6 +99,14 @@ extension SimplenoteAppDelegate: NSMenuItemValidation {
         item.state = inFocusModeEnabled ? .on : .off
 
         return inFocusModeEnabled || noteEditorViewController.isDisplayingNote
+    }
+
+    func validateTagSortMenuItem(_ item: NSMenuItem) -> Bool {
+// TODO: FIXME
+        let alphaTagSort = UserDefaults.standard.bool(forKey: "kTagSortPreferencesKey")
+        item.state = alphaTagSort ? .on : .off
+
+        return true
     }
 
     func validateThemeMenuItem(_ item: NSMenuItem) -> Bool {

--- a/Simplenote/SimplenoteAppDelegate+Swift.swift
+++ b/Simplenote/SimplenoteAppDelegate+Swift.swift
@@ -46,6 +46,12 @@ extension SimplenoteAppDelegate {
 extension SimplenoteAppDelegate {
 
     @IBAction
+    func clickedTagsSortModeItem(_ sender: Any) {
+        let options = Options.shared
+        options.alphabeticallySortTags = !options.alphabeticallySortTags
+    }
+
+    @IBAction
     func clickedThemeItem(_ sender: Any) {
         guard let item = sender as? NSMenuItem, item.state != .on else {
             return

--- a/Simplenote/TagListViewController.h
+++ b/Simplenote/TagListViewController.h
@@ -11,10 +11,7 @@
 
 @class NoteListViewController;
 
-@interface TagListViewController : NSViewController <NSTableViewDataSource, NSTableViewDelegate, NSMenuDelegate, NSTextDelegate, NSTextFieldDelegate, NSControlTextEditingDelegate, NSDraggingDestination> {
-    IBOutlet NSMenu *tagDropdownMenu;
-    IBOutlet NSMenu *trashDropdownMenu;
-}
+@interface TagListViewController : NSViewController <NSTableViewDataSource, NSTableViewDelegate, NSMenuDelegate, NSTextDelegate, NSTextFieldDelegate, NSControlTextEditingDelegate, NSDraggingDestination>
 
 @property (nonatomic, strong, readwrite) IBOutlet NSVisualEffectView    *visualEffectsView;
 @property (nonatomic, strong, readwrite) IBOutlet NSTableView           *tableView;

--- a/Simplenote/TagListViewController.h
+++ b/Simplenote/TagListViewController.h
@@ -14,7 +14,6 @@
 @interface TagListViewController : NSViewController <NSTableViewDataSource, NSTableViewDelegate, NSMenuDelegate, NSTextDelegate, NSTextFieldDelegate, NSControlTextEditingDelegate, NSDraggingDestination> {
     IBOutlet NSMenu *tagDropdownMenu;
     IBOutlet NSMenu *trashDropdownMenu;
-    IBOutlet NSMenu *findMenu;
     IBOutlet NSMenuItem *tagSortMenuItem;
 }
 

--- a/Simplenote/TagListViewController.h
+++ b/Simplenote/TagListViewController.h
@@ -31,7 +31,6 @@ extern NSString * const kDidEmptyTrash;
 - (IBAction)deleteAction:(id)sender;
 - (IBAction)renameAction:(id)sender;
 - (IBAction)emptyTrashAction:(id)sender;
-- (IBAction)sortAction:(id)sender;
 - (void)reset;
 - (void)applyStyle;
 

--- a/Simplenote/TagListViewController.h
+++ b/Simplenote/TagListViewController.h
@@ -14,7 +14,6 @@
 @interface TagListViewController : NSViewController <NSTableViewDataSource, NSTableViewDelegate, NSMenuDelegate, NSTextDelegate, NSTextFieldDelegate, NSControlTextEditingDelegate, NSDraggingDestination> {
     IBOutlet NSMenu *tagDropdownMenu;
     IBOutlet NSMenu *trashDropdownMenu;
-    IBOutlet NSMenuItem *tagSortMenuItem;
 }
 
 @property (nonatomic, strong, readwrite) IBOutlet NSVisualEffectView    *visualEffectsView;

--- a/Simplenote/TagListViewController.m
+++ b/Simplenote/TagListViewController.m
@@ -528,10 +528,6 @@ CGFloat const SPListEstimatedRowHeight = 30;
         return [appDelegate numDeletedNotes] > 0;
     }
     
-    if (menuItem.menu == findMenu) {
-        return YES;
-    }
-    
     // Disable menu items for All Notes, Trash, or if you're editing a tag (uses the NSMenuValidation informal protocol)
     return [self.tableView selectedRow] >= kStartOfTagListRow && self.tagNameBeingEdited == nil;
 }

--- a/Simplenote/TagListViewController.m
+++ b/Simplenote/TagListViewController.m
@@ -54,9 +54,6 @@ CGFloat const SPListEstimatedRowHeight = 30;
     [self.tableView setDraggingSourceOperationMask:NSDragOperationMove forLocal:YES];
     
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(tagAddedFromEditor:) name:SPTagAddedFromEditorNotificationName object:nil];
-    
-    BOOL alphaTagSort = [[NSUserDefaults standardUserDefaults] boolForKey:kTagSortPreferencesKey];
-    [tagSortMenuItem setState:alphaTagSort ? NSOnState : NSOffState];
 }
 
 - (void)viewWillAppear

--- a/Simplenote/TagListViewController.m
+++ b/Simplenote/TagListViewController.m
@@ -22,7 +22,6 @@
 #define kTrashRow 1
 #define kTagHeaderRow 2
 #define kStartOfTagListRow 3
-#define kTagSortPreferencesKey @"kTagSortPreferencesKey"
 
 
 NSString * const kTagsDidLoad = @"SPTagsDidLoad";
@@ -100,9 +99,8 @@ CGFloat const SPListEstimatedRowHeight = 30;
 
 - (void)sortTags
 {
-    BOOL sortAlphabetically = [[NSUserDefaults standardUserDefaults] boolForKey:kTagSortPreferencesKey];
     NSSortDescriptor *sortDescriptor;
-    if (sortAlphabetically) {
+    if (Options.shared.alphabeticallySortTags) {
         sortDescriptor = [[NSSortDescriptor alloc]
                           initWithKey:@"name"
                           ascending:YES
@@ -419,10 +417,9 @@ CGFloat const SPListEstimatedRowHeight = 30;
 
 - (IBAction)sortAction:(id)sender
 {
-    NSMenuItem *item = (NSMenuItem *)sender;
-    [item setState:item.state == NSOnState ? NSOffState : NSOnState];
-    [[NSUserDefaults standardUserDefaults] setBool:item.state == NSOnState forKey:kTagSortPreferencesKey];
-    
+    Options *options = [Options shared];
+    options.alphabeticallySortTags = !options.alphabeticallySortTags;
+
     [self loadTags];
 }
 
@@ -581,7 +578,7 @@ CGFloat const SPListEstimatedRowHeight = 30;
 // Much of this code is overly generalized for this use case, but it works
 - (BOOL)tableView:(NSTableView *)tableView writeRowsWithIndexes:(NSIndexSet *)rowIndexes toPasteboard:(NSPasteboard *)pboard
 {
-    BOOL isAlphaSort = [[NSUserDefaults standardUserDefaults] boolForKey:kTagSortPreferencesKey];
+    BOOL isAlphaSort = Options.shared.alphabeticallySortTags;
     if (isAlphaSort || [rowIndexes firstIndex] < kStartOfTagListRow) {
         // Alphabetical tag sorting should not allow drag and drop
         return NO;

--- a/Simplenote/TagListViewController.m
+++ b/Simplenote/TagListViewController.m
@@ -33,8 +33,10 @@ CGFloat const SPListEstimatedRowHeight = 30;
 
 @interface TagListViewController ()
 
-@property (nonatomic, assign) BOOL      menuShowing;
+@property (nonatomic, strong) NSMenu    *tagDropdownMenu;
+@property (nonatomic, strong) NSMenu    *trashDropdownMenu;
 @property (nonatomic, strong) NSString  *tagNameBeingEdited;
+@property (nonatomic, assign) BOOL      menuShowing;
 
 @end
 
@@ -68,31 +70,31 @@ CGFloat const SPListEstimatedRowHeight = 30;
 
 - (void)buildDropdownMenus
 {
-    trashDropdownMenu = [[NSMenu alloc] initWithTitle:@""];
-    trashDropdownMenu.delegate = self;
-    trashDropdownMenu.autoenablesItems = YES;
+    self.trashDropdownMenu = [[NSMenu alloc] initWithTitle:@""];
+    self.trashDropdownMenu.delegate = self;
+    self.trashDropdownMenu.autoenablesItems = YES;
 
-    [trashDropdownMenu addItemWithTitle:NSLocalizedString(@"Empty Trash", @"Empty Trash Action")
-                                 action:@selector(emptyTrashAction:)
-                          keyEquivalent:@""];
+    [self.trashDropdownMenu addItemWithTitle:NSLocalizedString(@"Empty Trash", @"Empty Trash Action")
+                                      action:@selector(emptyTrashAction:)
+                               keyEquivalent:@""];
 
-    for (NSMenuItem *item in trashDropdownMenu.itemArray) {
+    for (NSMenuItem *item in self.trashDropdownMenu.itemArray) {
         [item setTarget:self];
     }
     
-    tagDropdownMenu = [[NSMenu alloc] initWithTitle:@""];
-    tagDropdownMenu.delegate = self;
-    tagDropdownMenu.autoenablesItems = YES;
+    self.tagDropdownMenu = [[NSMenu alloc] initWithTitle:@""];
+    self.tagDropdownMenu.delegate = self;
+    self.tagDropdownMenu.autoenablesItems = YES;
 
-    [tagDropdownMenu addItemWithTitle:NSLocalizedString(@"Rename Tag", @"Rename Tag Action")
-                               action:@selector(renameAction:)
-                        keyEquivalent:@""];
+    [self.tagDropdownMenu addItemWithTitle:NSLocalizedString(@"Rename Tag", @"Rename Tag Action")
+                                    action:@selector(renameAction:)
+                             keyEquivalent:@""];
 
-    [tagDropdownMenu addItemWithTitle:NSLocalizedString(@"Delete Tag", @"Delete Tag Action")
-                               action:@selector(deleteAction:)
-                        keyEquivalent:@""];
+    [self.tagDropdownMenu addItemWithTitle:NSLocalizedString(@"Delete Tag", @"Delete Tag Action")
+                                    action:@selector(deleteAction:)
+                             keyEquivalent:@""];
 
-    for (NSMenuItem *item in tagDropdownMenu.itemArray) {
+    for (NSMenuItem *item in self.tagDropdownMenu.itemArray) {
         [item setTarget:self];
     }
 }
@@ -470,9 +472,9 @@ CGFloat const SPListEstimatedRowHeight = 30;
         case kTagHeaderRow:
             return nil;
         case kTrashRow:
-            return trashDropdownMenu;
+            return self.trashDropdownMenu;
         default:
-            return tagDropdownMenu;
+            return self.tagDropdownMenu;
     }
 }
 
@@ -512,12 +514,12 @@ CGFloat const SPListEstimatedRowHeight = 30;
 - (BOOL)validateMenuItem:(NSMenuItem *)menuItem
 {
     // Tag dropdowns are always valid
-    if (menuItem.menu == tagDropdownMenu) {
+    if (menuItem.menu == self.tagDropdownMenu) {
         return YES;
     }
     
     // For trash dropdown, check if there are deleted notes
-    if (menuItem.menu == trashDropdownMenu) {
+    if (menuItem.menu == self.trashDropdownMenu) {
 		SimplenoteAppDelegate *appDelegate = [SimplenoteAppDelegate sharedDelegate];
         return [appDelegate numDeletedNotes] > 0;
     }

--- a/Simplenote/UserDefaults+Simplenote.swift
+++ b/Simplenote/UserDefaults+Simplenote.swift
@@ -5,6 +5,7 @@ import Foundation
 //
 extension UserDefaults {
     enum Key: String {
+        case alphabeticallySortTags = "kTagSortPreferencesKey"
         case analyticsEnabled
         case lastKnownVersion
         case themeName = "VSThemeManagerThemePrefKey"

--- a/Simplenote/en.lproj/MainMenu.xib
+++ b/Simplenote/en.lproj/MainMenu.xib
@@ -437,7 +437,7 @@
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <menu key="submenu" title="Tags List" autoenablesItems="NO" id="76D-S0-1JD">
                                     <items>
-                                        <menuItem title="Sort Alphabetically" id="axW-cz-MnF">
+                                        <menuItem title="Sort Alphabetically" identifier="tagSortMenuItem" id="axW-cz-MnF">
                                             <modifierMask key="keyEquivalentModifierMask"/>
                                             <connections>
                                                 <action selector="sortAction:" target="1461" id="jQp-2i-tQh"/>
@@ -1207,7 +1207,6 @@
             <connections>
                 <outlet property="notesArrayController" destination="573" id="1672"/>
                 <outlet property="tableView" destination="1453" id="1469"/>
-                <outlet property="tagSortMenuItem" destination="axW-cz-MnF" id="vio-Yr-jb6"/>
                 <outlet property="view" destination="1436" id="yYB-xb-VWb"/>
                 <outlet property="visualEffectsView" destination="Re0-xq-32H" id="udB-MT-oME"/>
             </connections>

--- a/Simplenote/en.lproj/MainMenu.xib
+++ b/Simplenote/en.lproj/MainMenu.xib
@@ -435,12 +435,12 @@
                             </menuItem>
                             <menuItem title="Tags List" id="4QQ-5e-Vxl">
                                 <modifierMask key="keyEquivalentModifierMask"/>
-                                <menu key="submenu" title="Tags List" autoenablesItems="NO" id="76D-S0-1JD">
+                                <menu key="submenu" title="Tags List" id="76D-S0-1JD">
                                     <items>
                                         <menuItem title="Sort Alphabetically" identifier="tagSortMenuItem" id="axW-cz-MnF">
                                             <modifierMask key="keyEquivalentModifierMask"/>
                                             <connections>
-                                                <action selector="sortAction:" target="1461" id="jQp-2i-tQh"/>
+                                                <action selector="clickedTagsSortModeItem:" target="494" id="vnH-Zz-osc"/>
                                             </connections>
                                         </menuItem>
                                     </items>

--- a/Simplenote/en.lproj/MainMenu.xib
+++ b/Simplenote/en.lproj/MainMenu.xib
@@ -1205,7 +1205,6 @@
         </arrayController>
         <viewController id="1461" customClass="TagListViewController">
             <connections>
-                <outlet property="findMenu" destination="220" id="M2t-op-yAH"/>
                 <outlet property="notesArrayController" destination="573" id="1672"/>
                 <outlet property="tableView" destination="1453" id="1469"/>
                 <outlet property="tagSortMenuItem" destination="axW-cz-MnF" id="vio-Yr-jb6"/>


### PR DESCRIPTION
### Details:
- Simplenote's AppDelegate is now in charge of dealing with the Tags SortMode preference
- **TagListViewController** now listens to SortMode "Did Change" notifications
- Switched all of the ivars in TagsListViewController to properties
- **Options** now wraps up access to the SortMode UserDefaults setting

@aerych sir, may I bug you with this one?
Thanks in advance!!

Ref. #458

### Test
1. Install `develop`
2. Enable Tag Alpha Sort (**View** > **Tag List** > **Sort Alphabetically**)
3. Install this branch on top

- [x] Verify `Tag List / Sort Alphabetically` is still enabled
- [x] Verify the tags get sorted alphabetically!
- [x] Verify changing the **Tags Sort Mode** refreshes immediately the Tags List
- [x] Verify that pressing **Option + CMD + F** causes the SearchBar to acquire focus


### Release
These changes do not require release notes.
