### PR TITLE
Adjusting Selected Note Background

### DIFF
--- a/Simplenote/NSColor+Theme.swift
+++ b/Simplenote/NSColor+Theme.swift
@@ -150,7 +150,7 @@ private extension NSColor {
     }
 
     static var simplenoteSecondarySelectedBackgroundDarkColor: NSColor {
-        NSColor(red: 54.0/255.0, green: 54.0/255.0, blue: 54.0/255.0, alpha: 0.4)
+        NSColor(calibratedWhite: 1.0, alpha: 0.1)
     }
 
     static var simplenoteSecondarySelectedBackgroundLightColor: NSColor {


### PR DESCRIPTION
### Details:
In this PR we're fine tunning the Selected Note BG color.

@etoledom Eduardooo!! Can I bug you with a reaaaally simple PR?
cc @SylvesterWilmott (I owed you this one!)

Thanks in advance!!

Ref. #458

### Test
1. Launch Simplenote
2. Switch to Dark Mode

- [ ] Verify the Selected Note row looks super!

### Release
These changes do not require release notes.

### Screenshots
![Selected Color](https://user-images.githubusercontent.com/1195260/84179976-26ed7c80-aa5d-11ea-97e2-9140c783cd86.jpg)
