### PR TITLE
Editor: Adjusting Metrics

### DIFF
--- a/External/Notepad/Theme.swift
+++ b/External/Notepad/Theme.swift
@@ -63,7 +63,7 @@ private extension Theme {
 
     static var regularStyles: [Style] {
         return [
-            Style(element: .firstLine, attributes: firstLineAttributes)
+            Style(element: .firstLine, attributes: headlineAttributes)
         ]
     }
 
@@ -71,7 +71,7 @@ private extension Theme {
         return [
             Style(element: .h1, attributes: headingAttributes),
             Style(element: .h2, attributes: headingAttributes),
-            Style(element: .firstLine, attributes: firstLineAttributes),
+            Style(element: .firstLine, attributes: headlineAttributes),
             Style(element: .bold, attributes: boldAttributes),
             Style(element: .inlineCode, attributes: codeAttributes),
             Style(element: .italic, attributes: italicAttributes),
@@ -115,7 +115,7 @@ private extension Theme {
         ]
     }
 
-    static var firstLineAttributes: [NSAttributedString.Key: AnyObject] {
+    static var headlineAttributes: [NSAttributedString.Key: AnyObject] {
         return [
             .font:              NSFont.boldSystemFont(ofSize: ceil(fontSize * headlingFontMultiplier)),
             .paragraphStyle:    headlineParagraphStyle

--- a/External/Notepad/Theme.swift
+++ b/External/Notepad/Theme.swift
@@ -18,9 +18,17 @@ class Theme {
     ///
     private static let defaultFontSize = CGFloat(14)
 
+    /// Body Line Height Multiplier
+    ///
+    private static let bodyLineHeightMultiplier = CGFloat(1.43)
+
     /// Headline Font Multiplier
     ///
     private static let headlingFontMultiplier = CGFloat(1.7)
+
+    /// Headling Spacing
+    ///
+    private static let headlineSpacing = CGFloat.zero
 
     /// The body style
     ///
@@ -101,14 +109,16 @@ private extension Theme {
 
     static var bodyAttributes: [NSAttributedString.Key: AnyObject] {
         return [
-            .foregroundColor: NSColor.simplenoteTextColor,
-            .font: NSFont.systemFont(ofSize: fontSize)
+            .foregroundColor:   NSColor.simplenoteTextColor,
+            .font:              NSFont.systemFont(ofSize: fontSize),
+            .paragraphStyle:    bodyParagraphStyle
         ]
     }
 
     static var firstLineAttributes: [NSAttributedString.Key: AnyObject] {
         return [
             .font:              NSFont.boldSystemFont(ofSize: ceil(fontSize * headlingFontMultiplier)),
+            .paragraphStyle:    headlineParagraphStyle
         ]
     }
 
@@ -156,5 +166,32 @@ private extension Theme {
         return [
             .foregroundColor: NSColor.simplenoteLinkColor
         ]
+    }
+}
+
+
+// MARK: - Paragraph styles
+//
+private extension Theme {
+
+    static var bodyParagraphStyle: NSParagraphStyle {
+        let textHeight = fontSize
+        let multipliedLineHeight = floor(textHeight * bodyLineHeightMultiplier)
+        let spacing = floor((multipliedLineHeight - textHeight) * 0.5)
+
+        // We're aiming at rendering the text, in relation to the TextView's caret.
+        // For that reason, we'll adjust both, lineSpacing (bottom spacing) and lineHeight (top spacing).
+        let paragraph = NSMutableParagraphStyle()
+        paragraph.minimumLineHeight = spacing + textHeight
+        paragraph.maximumLineHeight = spacing + textHeight
+        paragraph.lineSpacing = spacing
+
+        return paragraph
+    }
+
+    static var headlineParagraphStyle: NSParagraphStyle {
+        let paragraph = NSMutableParagraphStyle()
+        paragraph.paragraphSpacing = headlineSpacing
+        return paragraph
     }
 }

--- a/External/Notepad/Theme.swift
+++ b/External/Notepad/Theme.swift
@@ -20,7 +20,7 @@ class Theme {
 
     /// Headline Font Multiplier
     ///
-    private static let firstLineFontMultiplier = CGFloat(1.25)
+    private static let headlingFontMultiplier = CGFloat(1.7)
 
     /// The body style
     ///
@@ -108,7 +108,7 @@ private extension Theme {
 
     static var firstLineAttributes: [NSAttributedString.Key: AnyObject] {
         return [
-            .font: NSFont.systemFont(ofSize: fontSize * firstLineFontMultiplier)
+            .font:              NSFont.boldSystemFont(ofSize: ceil(fontSize * headlingFontMultiplier)),
         ]
     }
 

--- a/External/Notepad/Theme.swift
+++ b/External/Notepad/Theme.swift
@@ -16,7 +16,7 @@ class Theme {
 
     /// Default Font Size
     ///
-    private static let defaultFontSize = CGFloat(15)
+    private static let defaultFontSize = CGFloat(14)
 
     /// Headline Font Multiplier
     ///

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 - Sidebar and Notes List will now be presented with a super awesome animation.
 - Your Notes List will now fit more content onscreen.
 - Updated Password Strength requirements.
+- Updated Text Metrics, for improved readability.
 
 1.10.0
 ------

--- a/Simplenote/NoteEditorViewController.h
+++ b/Simplenote/NoteEditorViewController.h
@@ -19,7 +19,7 @@
 
 typedef NS_ENUM(NSInteger, NoteFontSize) {
     NoteFontSizeMinimum = 10,
-    NoteFontSizeNormal = 15,
+    NoteFontSizeNormal = 14,
     NoteFontSizeMaximum = 30
 };
 


### PR DESCRIPTION
### Details:
In this PR we're adjusting the Editor's font size and spacing:

- **Heading:** Increased font size
- **Heading:** Switching to Bold
- **Body:** Decreased default font size by 1 point
- **Body:** Adjusted line spacing (in a hack-ish way to center the text, in relation to the cursor).

@aerych Sir, may I bug you with an Editor-Y PR?
Thanks in advance!!

**Note:** 
I've added Tech Debt tasks in the main issue, to address the constants duplication (defaultFontSize and fontSize UserDefaults key!).

Ref. #458

### Test
1. Launch Simplenote
2. Log into your account
3. Add a new note with a long title (so that it falls into two lines)
4. Add random content
5. Add a checklist with few lines

- [x] Verify the Header / Body looks great!
- [x] Verify that increasing or decreasing the font size works as expected (CMD +/-)
- [x] Verify that resetting the font size works well (CMD 0)

### Release
`RELEASE-NOTES.txt` was updated in 9c9faa4 with:
 
> Updated Text Metrics, for improved readability.

### Screenshots
<img width="300" alt="Editor Updates" src="https://user-images.githubusercontent.com/1195260/84177399-34086c80-aa59-11ea-8055-a58f9b39a65d.png">
