### PR TITLE
Disables TabBar Support

### DIFF
--- a/Simplenote/en.lproj/MainMenu.xib
+++ b/Simplenote/en.lproj/MainMenu.xib
@@ -601,7 +601,7 @@
             </connections>
             <point key="canvasLocation" x="-85" y="-270"/>
         </menu>
-        <window allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="SPWindow" animationBehavior="default" titleVisibility="hidden" id="371" customClass="SPWindow">
+        <window allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="SPWindow" animationBehavior="default" tabbingMode="disallowed" titleVisibility="hidden" id="371" customClass="SPWindow">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES" fullSizeContentView="YES"/>
             <windowCollectionBehavior key="collectionBehavior" fullScreenPrimary="YES"/>
             <rect key="contentRect" x="199" y="95" width="900" height="618"/>


### PR DESCRIPTION
### Fix
***(Required)*** Add a concise description of what you fixed.  If this is related to an issue, add a link to it.  If applicable, add screenshots, animations, or videos to help illustrate the fix.

@etoledom Eduardoooo!! May I bug you with a really small PR?
Thank you sir!!


Closes #560

### Test
1. Launch Simplenote
2. Log into your account
3. Click over `View`

- [ ] Verify the top of the System Bar's menu **does not include** the items **Show Tab Bar / Show All Tabs**

### Release
These changes do not require release notes.
