### PR TITLE
Untagged Notes Filter: Mark I

### DIFF
--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -218,6 +218,9 @@
 		B5A891A1231ECB710007EDCB /* Sparkle.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = B5A89194231ECB3C0007EDCB /* Sparkle.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		B5ACE42E24785D8C00AB02C7 /* BackgroundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5ACE42D24785D8C00AB02C7 /* BackgroundView.swift */; };
 		B5ACE42F24785D8C00AB02C7 /* BackgroundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5ACE42D24785D8C00AB02C7 /* BackgroundView.swift */; };
+		B5AF76C224A2A4F100B7D530 /* NSPredicate+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5AF76C124A2A4F100B7D530 /* NSPredicate+Simplenote.swift */; };
+		B5AF76C324A2A4F100B7D530 /* NSPredicate+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5AF76C124A2A4F100B7D530 /* NSPredicate+Simplenote.swift */; };
+		B5AF76C524A2B2EF00B7D530 /* NSPredicateSimplenoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5AF76C424A2B2EF00B7D530 /* NSPredicateSimplenoteTests.swift */; };
 		B5B17F362425641E00DD5B34 /* NSAttributedStringSimplenoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5B17F352425641E00DD5B34 /* NSAttributedStringSimplenoteTests.swift */; };
 		B5B17F382425651700DD5B34 /* TestConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5B17F372425651700DD5B34 /* TestConstants.swift */; };
 		B5B17F3A2425668400DD5B34 /* NSAttributedString+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5B17F392425668400DD5B34 /* NSAttributedString+Simplenote.swift */; };
@@ -526,6 +529,8 @@
 		B5A89191231ECB3C0007EDCB /* INSTALL.markdown */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = INSTALL.markdown; sourceTree = "<group>"; };
 		B5A89194231ECB3C0007EDCB /* Sparkle.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Sparkle.framework; sourceTree = "<group>"; };
 		B5ACE42D24785D8C00AB02C7 /* BackgroundView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundView.swift; sourceTree = "<group>"; };
+		B5AF76C124A2A4F100B7D530 /* NSPredicate+Simplenote.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSPredicate+Simplenote.swift"; sourceTree = "<group>"; };
+		B5AF76C424A2B2EF00B7D530 /* NSPredicateSimplenoteTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSPredicateSimplenoteTests.swift; sourceTree = "<group>"; };
 		B5B17F352425641E00DD5B34 /* NSAttributedStringSimplenoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSAttributedStringSimplenoteTests.swift; sourceTree = "<group>"; };
 		B5B17F372425651700DD5B34 /* TestConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestConstants.swift; sourceTree = "<group>"; };
 		B5B17F392425668400DD5B34 /* NSAttributedString+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSAttributedString+Simplenote.swift"; sourceTree = "<group>"; };
@@ -937,8 +942,9 @@
 				B5E0862E2448E58C00DEF476 /* NSImageName+Simplenote.swift */,
 				B56EA2A9244F4CC70061EAD8 /* NSImageView+Simplenote.swift */,
 				B51E9FE422E644A0004F16B4 /* NSObject+Helpers.swift */,
-				B5A2F1EF2432DE54003B29C6 /* NSRange+Simplenote.swift */,
+				B5AF76C124A2A4F100B7D530 /* NSPredicate+Simplenote.swift */,
 				B5CD5F7D241AC69900D0260F /* NSProcessInfo+Simplenote.swift */,
+				B5A2F1EF2432DE54003B29C6 /* NSRange+Simplenote.swift */,
 				B5985ACD24293E360044EDE9 /* NSRegularExpression+Simplenote.swift */,
 				B5919363245A7AD300A70C0C /* NSScreen+Simplenote.swift */,
 				B5117997242036B0005F8936 /* NSString+Simplenote.swift */,
@@ -1024,6 +1030,7 @@
 			isa = PBXGroup;
 			children = (
 				B5B17F352425641E00DD5B34 /* NSAttributedStringSimplenoteTests.swift */,
+				B5AF76C424A2B2EF00B7D530 /* NSPredicateSimplenoteTests.swift */,
 				B5985AD02429499D0044EDE9 /* NSRegularExpressionSimplenoteTests.swift */,
 				B53FF5442476EFFE0014E928 /* NSStringCondensingTests.swift */,
 				B500993E2421404F0037A431 /* NSStringSimplenoteTests.swift */,
@@ -1583,6 +1590,7 @@
 				B5E086352448EA3C00DEF476 /* TagTableCellView.swift in Sources */,
 				71233DD614DB6CD000139E61 /* NoteEditorViewController.m in Sources */,
 				B51699842480B93100ACF2F4 /* TagsField.swift in Sources */,
+				B5AF76C224A2A4F100B7D530 /* NSPredicate+Simplenote.swift in Sources */,
 				37F742EB202A382400A47D3A /* AboutViewController.swift in Sources */,
 				B5E0862C2448B69B00DEF476 /* NSTableViewCell+Simplenote.swift in Sources */,
 				B56FA7922437C672002CB9FF /* NSColor+Theme.swift in Sources */,
@@ -1705,6 +1713,7 @@
 				B51699852480B93100ACF2F4 /* TagsField.swift in Sources */,
 				B5F04FCD215949FE004B1AA0 /* Preferences.m in Sources */,
 				3700E97721C1E390004771C9 /* SPTextAttachment.swift in Sources */,
+				B5AF76C324A2A4F100B7D530 /* NSPredicate+Simplenote.swift in Sources */,
 				B5E0862D2448B69B00DEF476 /* NSTableViewCell+Simplenote.swift in Sources */,
 				B56FA7932437C672002CB9FF /* NSColor+Theme.swift in Sources */,
 				375D293321E033D1007AB25A /* buffer.c in Sources */,
@@ -1771,6 +1780,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B5AF76C524A2B2EF00B7D530 /* NSPredicateSimplenoteTests.swift in Sources */,
 				B5985AD12429499D0044EDE9 /* NSRegularExpressionSimplenoteTests.swift in Sources */,
 				B53FF5472476F9450014E928 /* Constants.swift in Sources */,
 				B50099322421218B0037A431 /* NSTextViewSimplenoteTests.swift in Sources */,

--- a/Simplenote/NSPredicate+Simplenote.swift
+++ b/Simplenote/NSPredicate+Simplenote.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+
+// MARK: - NSPredicate Methods
+//
+extension NSPredicate {
+
+    /// Returns a collection of NSPredicates that will match, as a compound, a given Search Text
+    ///
+    @objc(predicateForSearchText:)
+    static func predicateForNotes(searchText: String) -> NSPredicate {
+        let keywords = searchText.trimmingCharacters(in: .whitespacesAndNewlines).components(separatedBy: .whitespaces)
+        var output = [NSPredicate]()
+
+        for keyword in keywords where !keyword.isEmpty {
+            output.append( NSPredicate(format: "content CONTAINS[cd] %@", keyword) )
+        }
+
+        guard !output.isEmpty else {
+            return NSPredicate(value: true)
+        }
+
+        return NSCompoundPredicate(andPredicateWithSubpredicates: output)
+    }
+
+    /// Returns a NSPredicate that will match Notes with the specified `deleted` flag
+    ///
+    @objc(predicateForNotesWithDeletedStatus:)
+    static func predicateForNotes(deleted: Bool) -> NSPredicate {
+        let status = NSNumber(booleanLiteral: deleted)
+        return NSPredicate(format: "deleted == %@", status)
+    }
+
+    /// Returns a NSPredicate that will match a given Tag
+    ///
+    @objc
+    static func predicateForNotes(tag: String) -> NSPredicate {
+        return NSPredicate(format: "tags CONTAINS[c] %@", formattedTag(for: tag))
+    }
+
+    /// Returns a NSPredicate that will match:
+    ///
+    ///     A. Empty JSON Arrays (with random padding)
+    ///     B. Empty Strings
+    ///
+    @objc
+    static func predicateForUntaggedNotes() -> NSPredicate {
+        // Since the `Tags` field is a JSON Encoded Array, we'll need to look up for Untagged Notes with a RegEx:
+        // Empty String  (OR)  Spaces* + [ + Spaces* + ] + Spaces*
+        let regex = "^()|(null)|(\\s*\\[\\s*]\\s*)$"
+        return NSPredicate(format: "tags MATCHES[n] %@", regex)
+    }
+}
+
+
+// MARK: - Private Methods
+//
+private extension NSPredicate {
+
+    /// Returns the received tag, escaped and surrounded by quotes: ensures only the *exact* tag matches are hit
+    ///
+    static func formattedTag(for tag: String) -> String {
+        let filtered = tag.replacingOccurrences(of: "\\", with: "\\\\").replacingOccurrences(of: "/", with: "\\/")
+        return String(format: "\"%@\"", filtered)
+    }
+}

--- a/Simplenote/NoteListViewController.m
+++ b/Simplenote/NoteListViewController.m
@@ -507,30 +507,15 @@ NSString * const kAlphabeticalSortPref = @"kAlphabeticalSortPreferencesKey";
     NSString *searchText = [self.searchField stringValue];
     
     NSMutableArray *predicateList = [NSMutableArray new];
-    [predicateList addObject: [NSPredicate predicateWithFormat: @"deleted == %@", @(self.viewingTrash)]];
+    [predicateList addObject: [NSPredicate predicateForNotesWithDeletedStatus:self.viewingTrash]];
     
     NSString *selectedTag = [[SimplenoteAppDelegate sharedDelegate] selectedTagName];
     if (selectedTag.length > 0) {
-        // Match against "tagName" (JSON formatted)
-        NSString *tagName = selectedTag;
-        
-        tagName = [tagName stringByReplacingOccurrencesOfString:@"\\" withString:@"\\\\"];
-        tagName = [tagName stringByReplacingOccurrencesOfString:@"/" withString:@"\\/"];
-        
-        // individual tags are surrounded by quotes, thus adding quotes to the selected tag
-        // ensures only the correct notes are shown
-        NSString *match = [[NSString alloc] initWithFormat:@"\"%@\"", tagName];
-        [predicateList addObject: [NSPredicate predicateWithFormat: @"tags CONTAINS[c] %@",match]];
+        [predicateList addObject: [NSPredicate predicateForNotesWithTag:selectedTag]];
     }
     
     if (searchText.length > 0) {
-        NSArray *searchStrings = [searchText componentsSeparatedByString:@" "];
-        for (NSString *word in searchStrings) {
-            if (word.length == 0) {
-                continue;
-            }
-            [predicateList addObject: [NSPredicate predicateWithFormat:@"content CONTAINS[c] %@", word]];
-        }
+        [predicateList addObject:[NSPredicate predicateForSearchText:searchText]];
     }
     
     NSPredicate *compound = [NSCompoundPredicate andPredicateWithSubpredicates:predicateList];

--- a/Simplenote/SimplenoteAppDelegate.m
+++ b/Simplenote/SimplenoteAppDelegate.m
@@ -264,9 +264,9 @@
 - (NSInteger)numDeletedNotes
 {
     SPBucket *notesBucket = [self.simperium bucketForName:@"Note"];
-    NSInteger numDeletedNotes = [notesBucket numObjectsForPredicate:[NSPredicate predicateWithFormat:@"deleted == 1"]];
-    
-    return numDeletedNotes;
+    NSPredicate *predicate = [NSPredicate predicateForNotesWithDeletedStatus:YES];
+
+    return [notesBucket numObjectsForPredicate:predicate];
 }
 
 - (BOOL)isMainWindowVisible

--- a/Simplenote/TagListViewController.m
+++ b/Simplenote/TagListViewController.m
@@ -222,12 +222,10 @@ CGFloat const SPListEstimatedRowHeight = 30;
 
 - (NSArray *)notesWithTag:(Tag *)tag
 {
-    NSArray *predicateList = @[
-        [NSPredicate predicateWithFormat: @"deleted == %@", @(NO)],
-        [NSPredicate predicateWithFormat: @"tags CONTAINS[c] %@", tag.name]
-    ];
-    
-    NSPredicate *compound = [NSCompoundPredicate andPredicateWithSubpredicates:predicateList];
+    NSPredicate *compound = [NSCompoundPredicate andPredicateWithSubpredicates:@[
+        [NSPredicate predicateForNotesWithDeletedStatus:NO],
+        [NSPredicate predicateForNotesWithTag:tag.name]
+    ]];
     
     SimplenoteAppDelegate *appDelegate = [SimplenoteAppDelegate sharedDelegate];
     SPBucket *noteBucket = [appDelegate.simperium bucketForName:@"Note"];
@@ -434,8 +432,8 @@ CGFloat const SPListEstimatedRowHeight = 30;
     SimplenoteAppDelegate *appDelegate = [SimplenoteAppDelegate sharedDelegate];
     NSFetchRequest *fetchRequest = [[NSFetchRequest alloc] init];
     NSEntityDescription *entity = [NSEntityDescription entityForName:@"Note" inManagedObjectContext:appDelegate.managedObjectContext];
-    [fetchRequest setEntity:entity];
-    [fetchRequest setPredicate:[NSPredicate predicateWithFormat:@"deleted == YES"]];
+    fetchRequest.entity = entity;
+    fetchRequest.predicate = [NSPredicate predicateForNotesWithDeletedStatus:YES];
     
     NSError *error;
     NSArray *items = [appDelegate.managedObjectContext executeFetchRequest:fetchRequest error:&error];

--- a/SimplenoteTests/NSPredicateSimplenoteTests.swift
+++ b/SimplenoteTests/NSPredicateSimplenoteTests.swift
@@ -1,0 +1,189 @@
+import Foundation
+import XCTest
+@testable import Simplenote
+
+
+// MARK: - NSPredicate+Simplenote Unit Tests
+//
+class NSPredicateSimplenoteTests: XCTestCase {
+
+    /// Verifies that `NSPredicate.predicateForNotes(searchText:)` match entities that contain a single specified keyword
+    ///
+    func testPredicateForNotesWithSearchTextMatchesNotesContainingTheSpecifiedKeyword() {
+        let entity = MockupNote()
+        entity.content = "some content here and maybe a keyword"
+
+        let predicate = NSPredicate.predicateForNotes(searchText: "keyword")
+        XCTAssertTrue(predicate.evaluate(with: entity))
+    }
+
+    /// Verifies that `NSPredicate.predicateForNotes(searchText:)` ignores spaces between keywords
+    ///
+    func testPredicateForNotesWithSearchTextIgnoresEmptySpacesInBetweenKeywords() {
+        let entity = MockupNote()
+        entity.content = "first second"
+
+        let predicate = NSPredicate.predicateForNotes(searchText: "    first       second")
+        XCTAssertTrue(predicate.evaluate(with: entity))
+    }
+
+    /// Verifies that `NSPredicate.predicateForNotes(searchText:)` produces one subpredicate per word, and disregards newlines and spaces
+    ///
+    func testPredicateForNotesWithSearchTextProducesOnePredicatePerWordAndDisregardNewlinesAndSpaces() {
+        let keyword = "     lots of empty spaces   \n   \n  "
+        let numberOfWords = 4
+        let predicate = NSPredicate.predicateForNotes(searchText: keyword) as! NSCompoundPredicate
+
+        XCTAssertTrue(predicate.subpredicates.count == numberOfWords)
+    }
+
+    /// Verifies that `NSPredicate.predicateForNotes(searchText:)` match entities that contain multiple specified keywords
+    ///
+    func testPredicateForNotesWithSearchTextMatchesNotesContainingMultipleSpecifiedKeywords() {
+        let entity = MockupNote()
+        entity.content = "some keyword1 here and maybe another keyword2 there"
+
+        let predicate = NSPredicate.predicateForNotes(searchText: "keyword1 keyword2")
+        XCTAssertTrue(predicate.evaluate(with: entity))
+    }
+
+    /// Verifies that `NSPredicate.predicateForNotes(searchText:)` matches words with accents
+    ///
+    func testPredicateForNotesWithSearchTextMatchesKeywordsWithAccentCharacters() {
+        let entity = MockupNote()
+        entity.content = "jamás esdrújula"
+
+        let predicate = NSPredicate.predicateForNotes(searchText: "jamas esdrujula")
+        XCTAssertTrue(predicate.evaluate(with: entity))
+    }
+
+    /// Verifies that `NSPredicate.predicateForNotes(searchText:)` won't match entities that dont contain a given searchText
+    ///
+    func testPredicateForNotesWithSearchTextWontMatchNotesContainingTheSpecifiedKeywords() {
+        let entity = MockupNote()
+        entity.content = "some content here and maybe a keyword"
+
+        let predicate = NSPredicate.predicateForNotes(searchText: "missing")
+        XCTAssertFalse(predicate.evaluate(with: entity))
+    }
+
+    /// Verifies that `NSPredicate.predicateForNotes(deleted:)` matches notes with a Deleted status
+    ///
+    func testPredicateForNotesWithDeletedStatusMatchesDeletedNotes() {
+        let entity = MockupNote()
+        entity.deleted = true
+        XCTAssertTrue(NSPredicate.predicateForNotes(deleted: true).evaluate(with: entity))
+        XCTAssertFalse(NSPredicate.predicateForNotes(deleted: false).evaluate(with: entity))
+    }
+
+    /// Verifies that `NSPredicate.predicateForNotes(deleted:)` matches notes with a Not Deleted status
+    ///
+    func testPredicateForNotesWithoutDeletedStatusMatchesDeletedNotes() {
+        let entity = MockupNote()
+        entity.deleted = false
+        XCTAssertTrue(NSPredicate.predicateForNotes(deleted: false).evaluate(with: entity))
+        XCTAssertFalse(NSPredicate.predicateForNotes(deleted: true).evaluate(with: entity))
+    }
+
+    /// Verifies that `NSPredicate.predicateForNotes(tag:)` matches JSON Arrays that contain a single value, matching our target
+    ///
+    func testPredicateForNotesWithTagProperlyMatchesEntitiesThatContainSingleTags() {
+        let tag = "Yosemite"
+        let entity = MockupNote()
+        entity.tags = "[ \"" + tag + "\"]"
+        XCTAssertTrue(NSPredicate.predicateForNotes(tag: tag).evaluate(with: entity))
+    }
+
+    /// Verifies that `NSPredicate.predicateForNotes(tag:)` matches JSON Arrays that contain multiple values, one of them being our target
+    ///
+    func testPredicateForNotesWithTagProperlyMatchesEntitiesThatContainMultipleTags() {
+        let tag = "Yosemite"
+        let entity = MockupNote()
+        entity.tags = "[ \"second\", \"third\", \"" + tag + "\" ]"
+        XCTAssertTrue(NSPredicate.predicateForNotes(tag: tag).evaluate(with: entity))
+    }
+
+    /// Verifies that `NSPredicate.predicateForNotes(tag:)` properly deals with slashes
+    ///
+    func testPredicateForNotesWithTagProperlyHandlesTagsWithSlashes() {
+        let tag = "\\Yosemite"
+        let entity = MockupNote()
+        entity.tags = "[ \"\\\\Yosemite\" ]"
+        XCTAssertTrue(NSPredicate.predicateForNotes(tag: tag).evaluate(with: entity))
+    }
+
+    /// Verifies that `NSPredicate.predicateForNotes(tag:)` won't produce matches for entities that do not contain the target Tag
+    ///
+    func testPredicateForNotesWithTagTagDoesntMatchEntitiesThatDontContainTheTargetTag() {
+        let tag = "Missing"
+        let entity = MockupNote()
+        entity.tags = "[ \"Tag\" ]"
+        XCTAssertFalse(NSPredicate.predicateForNotes(tag: tag).evaluate(with: entity))
+    }
+
+    /// Verifies that `NSPredicate.predicateForUntaggedNotes` matches a perfectly formed empty JSON Array
+    ///
+    func testPredicateForUntaggedNotesMatchesEmptyJsonArrays() {
+        let entity = MockupNote()
+        entity.tags = "[]"
+        XCTAssertTrue(NSPredicate.predicateForUntaggedNotes().evaluate(with: entity))
+    }
+
+    /// Verifies that `NSPredicate.predicateForUntaggedNotes` matches a JSON Array with random spaces
+    ///
+    func testPredicateForUntaggedNotesMatchesEmptyJsonArraysWithRandomSpaces() {
+        let entity = MockupNote()
+        entity.tags = "    [ ] "
+        XCTAssertTrue(NSPredicate.predicateForUntaggedNotes().evaluate(with: entity))
+    }
+
+    /// Verifies that `NSPredicate.predicateForUntaggedNotes` matches empty strings
+    ///
+    func testPredicateForUntaggedNotesMatchesEmptyStrings() {
+        let entity = MockupNote()
+        entity.tags = ""
+        XCTAssertTrue(NSPredicate.predicateForUntaggedNotes().evaluate(with: entity))
+    }
+
+    /// Verifies that `NSPredicate.predicateForUntaggedNotes` won't match a non empty JSON Array
+    ///
+    func testPredicateForUntaggedNotesWontMatchNonEmptyJsonArrays() {
+        let entity = MockupNote()
+        entity.tags = "[\"tag\"]"
+        XCTAssertFalse(NSPredicate.predicateForUntaggedNotes().evaluate(with: entity))
+    }
+}
+
+
+// MARK: - MockupNote: Convenience class to help us test NSPredicate(s)
+//
+@objcMembers
+private class MockupNote: NSObject {
+
+    /// Entity's Contents
+    ///
+    dynamic var content: String?
+
+    /// Deletion Status
+    ///
+    dynamic var deleted = false
+
+    /// Entity's System Tags
+    ///
+    dynamic var systemTags: String?
+
+    /// Entity's Tags
+    ///
+    dynamic var tags: String?
+}
+
+
+// MARK: - MockupTag: Convenience class to help us test NSPredicate(s)
+//
+@objcMembers
+private class MockupTag: NSObject {
+
+    /// Entity's System Tags
+    ///
+    dynamic var name: String?
+}


### PR DESCRIPTION
### Details:
- Implements a **NSPredicate extension** that encapsulates all of the filtering logic
- Unit Tests all over

Ref. #458

@aerych Sir, you game for a fun one?
Thanks in advance!!

### Scenario: Tags List
- [x] Verify clicking the `Trash` row causes Trashed notes to show up in the Notes List
- [x] Verify that clicking `All Notes` casues (non trashed) notes to show up in the Notes List
- [x] Verify that clicking over any Tag causes associated Notes to show up (excluding deleted ones!)
- [x] Verify that entering a Search Keyword filters the list of notes currently visible

### Scenario: Tag Edition
- [x] Verify that renaming a Tag "moves" all of the pre-existant notes over to the new Tag
- [x] Verify that deleting a Tag causes all of the associated notes to loose such string (from the Tags Editor area!)

**Note:** Renaming a tag doesn't preserve the Notes List / Editor states. To be fixed in this release via #344

### Scenario: Empty Trash
1. Verify the Trash folder is empty (if not, empty it!)
2. Click over the `Simplenote` system menu

- [x] Verify the `Empty Trash` action is disabled
- [x] Verify that trashing (any) note causes the `Empty Trash` action to become valid

### Release
These changes do not require release notes.
