### PR TITLE
Encryption Flag

### DIFF
--- a/Simplenote/Simplenote-Info-Hockey.plist
+++ b/Simplenote/Simplenote-Info-Hockey.plist
@@ -56,5 +56,7 @@
 	<string>https://rink.hockeyapp.net/api/2/apps/ede9c49346946c51a1db1db167b49892</string>
 	<key>SUScheduledCheckInterval</key>
 	<string>3600</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 </dict>
 </plist>

--- a/Simplenote/Simplenote-Info.plist
+++ b/Simplenote/Simplenote-Info.plist
@@ -56,5 +56,7 @@
 	<string>https://rink.hockeyapp.net/api/2/apps/ede9c49346946c51a1db1db167b49892</string>
 	<key>SUScheduledCheckInterval</key>
 	<string>3600</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 </dict>
 </plist>


### PR DESCRIPTION
### Details:
In this PR we're specifying the `ITSAppUsesNonExemptEncryption` flag, so that iTunes Connect uploads go smoothly.

@aerych may I bug you with a really quick PR? Thanks in advance!!
@mokagio next build shouldn't trigger any encryption screens!


### Test
- [x] Verify the app builds correctly please!

### Release
These changes do not require release notes.
