### PR TITLE
Privacy Notice for California Users

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,7 @@
+1.11.1
+------
+- New Privacy Notice for California Users
+
 1.11.0
 ------
 - New Color Scheme for Light and Dark Modes!

--- a/Simplenote/About.storyboard
+++ b/Simplenote/About.storyboard
@@ -33,23 +33,23 @@
                 <customObject id="b5m-1i-Rei" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
                 <viewController showSeguePresentationStyle="single" id="MqH-XQ-fgw" customClass="AboutViewController" customModule="Simplenote" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" id="jNR-As-MxY">
-                        <rect key="frame" x="0.0" y="0.0" width="451" height="533"/>
+                        <rect key="frame" x="0.0" y="0.0" width="451" height="553"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <box fixedFrame="YES" boxType="custom" borderType="none" translatesAutoresizingMaskIntoConstraints="NO" id="jR0-c5-hne">
-                                <rect key="frame" x="0.0" y="0.0" width="451" height="533"/>
+                                <rect key="frame" x="0.0" y="0.0" width="451" height="553"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <view key="contentView" id="BDM-Ov-qG6">
-                                    <rect key="frame" x="0.0" y="0.0" width="451" height="533"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="451" height="553"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="O8W-lq-bJP">
-                                            <rect key="frame" x="178" y="418" width="95" height="95"/>
+                                            <rect key="frame" x="178" y="438" width="95" height="95"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" id="eup-pb-NgT"/>
                                         </imageView>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" setsMaxLayoutWidthAtFirstLayout="YES" translatesAutoresizingMaskIntoConstraints="NO" id="NgJ-g1-nEA">
-                                            <rect key="frame" x="80" y="362" width="291" height="19"/>
+                                            <rect key="frame" x="80" y="382" width="291" height="19"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" alignment="center" title="Version 42" id="TD0-Zc-GKj">
                                                 <font key="font" metaFont="controlContent"/>
@@ -58,7 +58,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" setsMaxLayoutWidthAtFirstLayout="YES" translatesAutoresizingMaskIntoConstraints="NO" id="8xe-xE-uDv">
-                                            <rect key="frame" x="80" y="382" width="291" height="29"/>
+                                            <rect key="frame" x="80" y="402" width="291" height="29"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" alignment="center" title="Simplenote" id="OVa-ev-GZS">
                                                 <font key="font" metaFont="system" size="24"/>
@@ -67,7 +67,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <box fixedFrame="YES" boxType="custom" borderType="line" translatesAutoresizingMaskIntoConstraints="NO" id="6Nc-En-R6f">
-                                            <rect key="frame" x="82" y="345" width="287" height="1"/>
+                                            <rect key="frame" x="82" y="365" width="287" height="1"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <view key="contentView" id="2Kn-8e-Uf4">
                                                 <rect key="frame" x="1" y="1" width="285" height="0.0"/>
@@ -76,7 +76,7 @@
                                             <color key="borderColor" red="0.45882352939999999" green="0.68627450980000004" blue="0.8862745098" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         </box>
                                         <box fixedFrame="YES" boxType="custom" borderType="none" title="Box" translatesAutoresizingMaskIntoConstraints="NO" id="UHw-ou-KCK">
-                                            <rect key="frame" x="82" y="280" width="287" height="66"/>
+                                            <rect key="frame" x="82" y="300" width="287" height="66"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <view key="contentView" id="ksN-Qa-WYh">
                                                 <rect key="frame" x="0.0" y="0.0" width="287" height="66"/>
@@ -119,7 +119,7 @@
                                             </view>
                                         </box>
                                         <box fixedFrame="YES" boxType="custom" borderType="none" title="Box" translatesAutoresizingMaskIntoConstraints="NO" id="MW4-bm-l4h">
-                                            <rect key="frame" x="82" y="220" width="287" height="66"/>
+                                            <rect key="frame" x="82" y="240" width="287" height="66"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <view key="contentView" id="cY1-J5-o9o">
                                                 <rect key="frame" x="0.0" y="0.0" width="287" height="66"/>
@@ -162,7 +162,7 @@
                                             </view>
                                         </box>
                                         <box fixedFrame="YES" boxType="custom" borderType="none" title="Box" translatesAutoresizingMaskIntoConstraints="NO" id="TxN-OB-oNO">
-                                            <rect key="frame" x="82" y="160" width="287" height="66"/>
+                                            <rect key="frame" x="82" y="180" width="287" height="66"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <view key="contentView" id="1qh-au-AIg">
                                                 <rect key="frame" x="0.0" y="0.0" width="287" height="66"/>
@@ -205,7 +205,7 @@
                                             </view>
                                         </box>
                                         <box fixedFrame="YES" boxType="custom" borderType="none" title="Box" translatesAutoresizingMaskIntoConstraints="NO" id="z3l-Ll-tYB">
-                                            <rect key="frame" x="82" y="100" width="287" height="66"/>
+                                            <rect key="frame" x="82" y="120" width="287" height="66"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <view key="contentView" id="K8E-BJ-rCp">
                                                 <rect key="frame" x="0.0" y="0.0" width="287" height="66"/>
@@ -239,10 +239,10 @@
                                             </view>
                                         </box>
                                         <stackView distribution="fill" orientation="vertical" alignment="centerX" spacing="4" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="drq-hU-buA">
-                                            <rect key="frame" x="0.0" y="26" width="451" height="53"/>
+                                            <rect key="frame" x="0.0" y="26" width="451" height="61"/>
                                             <subviews>
                                                 <stackView distribution="fill" orientation="horizontal" alignment="top" spacing="2" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="36G-l4-m5J">
-                                                    <rect key="frame" x="128" y="38" width="196" height="15"/>
+                                                    <rect key="frame" x="128" y="46" width="196" height="15"/>
                                                     <subviews>
                                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" setsMaxLayoutWidthAtFirstLayout="YES" translatesAutoresizingMaskIntoConstraints="NO" id="zLM-6J-YYw" customClass="SPAboutTextField" customModule="Simplenote" customModuleProvider="target">
                                                             <rect key="frame" x="-2" y="0.0" width="83" height="15"/>
@@ -281,13 +281,19 @@
                                                     </customSpacing>
                                                 </stackView>
                                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" setsMaxLayoutWidthAtFirstLayout="YES" translatesAutoresizingMaskIntoConstraints="NO" id="k4n-4L-Xn4" customClass="SPAboutTextField" customModule="Simplenote" customModuleProvider="target">
-                                                    <rect key="frame" x="-2" y="19" width="455" height="15"/>
+                                                    <rect key="frame" x="-2" y="27" width="455" height="15"/>
                                                     <textFieldCell key="cell" lineBreakMode="truncatingTail" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="center" title="Privacy Notice for California Users" id="nKa-UJ-qCZ">
                                                         <font key="font" metaFont="controlContent"/>
                                                         <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                     </textFieldCell>
                                                 </textField>
+                                                <customView translatesAutoresizingMaskIntoConstraints="NO" id="y3L-kB-cLJ">
+                                                    <rect key="frame" x="144" y="19" width="163" height="4"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="height" constant="4" id="Ad5-qn-aQP"/>
+                                                    </constraints>
+                                                </customView>
                                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" setsMaxLayoutWidthAtFirstLayout="YES" translatesAutoresizingMaskIntoConstraints="NO" id="7QO-fG-liO">
                                                     <rect key="frame" x="-2" y="0.0" width="455" height="15"/>
                                                     <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" alignment="center" title="© 2017 Automattic" id="yfA-1y-gmq">
@@ -307,8 +313,10 @@
                                                 <integer value="1000"/>
                                                 <integer value="1000"/>
                                                 <integer value="1000"/>
+                                                <integer value="1000"/>
                                             </visibilityPriorities>
                                             <customSpacing>
+                                                <real value="3.4028234663852886e+38"/>
                                                 <real value="3.4028234663852886e+38"/>
                                                 <real value="3.4028234663852886e+38"/>
                                                 <real value="3.4028234663852886e+38"/>
@@ -341,7 +349,7 @@
                     </connections>
                 </viewController>
             </objects>
-            <point key="canvasLocation" x="713.5" y="224.5"/>
+            <point key="canvasLocation" x="713.5" y="234.5"/>
         </scene>
     </scenes>
     <resources>

--- a/Simplenote/About.storyboard
+++ b/Simplenote/About.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="16096" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="16097" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="16096"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="16097"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -33,23 +33,23 @@
                 <customObject id="b5m-1i-Rei" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
                 <viewController showSeguePresentationStyle="single" id="MqH-XQ-fgw" customClass="AboutViewController" customModule="Simplenote" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" id="jNR-As-MxY">
-                        <rect key="frame" x="0.0" y="0.0" width="451" height="504"/>
+                        <rect key="frame" x="0.0" y="0.0" width="451" height="533"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <box fixedFrame="YES" boxType="custom" borderType="none" translatesAutoresizingMaskIntoConstraints="NO" id="jR0-c5-hne">
-                                <rect key="frame" x="0.0" y="0.0" width="451" height="504"/>
+                                <rect key="frame" x="0.0" y="0.0" width="451" height="533"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <view key="contentView" id="BDM-Ov-qG6">
-                                    <rect key="frame" x="0.0" y="0.0" width="451" height="504"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="451" height="533"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="O8W-lq-bJP">
-                                            <rect key="frame" x="178" y="389" width="95" height="95"/>
+                                            <rect key="frame" x="178" y="418" width="95" height="95"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" id="eup-pb-NgT"/>
                                         </imageView>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" setsMaxLayoutWidthAtFirstLayout="YES" translatesAutoresizingMaskIntoConstraints="NO" id="NgJ-g1-nEA">
-                                            <rect key="frame" x="80" y="333" width="291" height="19"/>
+                                            <rect key="frame" x="80" y="362" width="291" height="19"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" alignment="center" title="Version 42" id="TD0-Zc-GKj">
                                                 <font key="font" metaFont="controlContent"/>
@@ -58,7 +58,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" setsMaxLayoutWidthAtFirstLayout="YES" translatesAutoresizingMaskIntoConstraints="NO" id="8xe-xE-uDv">
-                                            <rect key="frame" x="80" y="353" width="291" height="29"/>
+                                            <rect key="frame" x="80" y="382" width="291" height="29"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" alignment="center" title="Simplenote" id="OVa-ev-GZS">
                                                 <font key="font" metaFont="system" size="24"/>
@@ -67,7 +67,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <box fixedFrame="YES" boxType="custom" borderType="line" translatesAutoresizingMaskIntoConstraints="NO" id="6Nc-En-R6f">
-                                            <rect key="frame" x="82" y="316" width="287" height="1"/>
+                                            <rect key="frame" x="82" y="345" width="287" height="1"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <view key="contentView" id="2Kn-8e-Uf4">
                                                 <rect key="frame" x="1" y="1" width="285" height="0.0"/>
@@ -76,7 +76,7 @@
                                             <color key="borderColor" red="0.45882352939999999" green="0.68627450980000004" blue="0.8862745098" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         </box>
                                         <box fixedFrame="YES" boxType="custom" borderType="none" title="Box" translatesAutoresizingMaskIntoConstraints="NO" id="UHw-ou-KCK">
-                                            <rect key="frame" x="82" y="251" width="287" height="66"/>
+                                            <rect key="frame" x="82" y="280" width="287" height="66"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <view key="contentView" id="ksN-Qa-WYh">
                                                 <rect key="frame" x="0.0" y="0.0" width="287" height="66"/>
@@ -119,7 +119,7 @@
                                             </view>
                                         </box>
                                         <box fixedFrame="YES" boxType="custom" borderType="none" title="Box" translatesAutoresizingMaskIntoConstraints="NO" id="MW4-bm-l4h">
-                                            <rect key="frame" x="82" y="191" width="287" height="66"/>
+                                            <rect key="frame" x="82" y="220" width="287" height="66"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <view key="contentView" id="cY1-J5-o9o">
                                                 <rect key="frame" x="0.0" y="0.0" width="287" height="66"/>
@@ -162,7 +162,7 @@
                                             </view>
                                         </box>
                                         <box fixedFrame="YES" boxType="custom" borderType="none" title="Box" translatesAutoresizingMaskIntoConstraints="NO" id="TxN-OB-oNO">
-                                            <rect key="frame" x="82" y="131" width="287" height="66"/>
+                                            <rect key="frame" x="82" y="160" width="287" height="66"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <view key="contentView" id="1qh-au-AIg">
                                                 <rect key="frame" x="0.0" y="0.0" width="287" height="66"/>
@@ -205,7 +205,7 @@
                                             </view>
                                         </box>
                                         <box fixedFrame="YES" boxType="custom" borderType="none" title="Box" translatesAutoresizingMaskIntoConstraints="NO" id="z3l-Ll-tYB">
-                                            <rect key="frame" x="82" y="71" width="287" height="66"/>
+                                            <rect key="frame" x="82" y="100" width="287" height="66"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <view key="contentView" id="K8E-BJ-rCp">
                                                 <rect key="frame" x="0.0" y="0.0" width="287" height="66"/>
@@ -238,43 +238,89 @@
                                                 </subviews>
                                             </view>
                                         </box>
-                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" setsMaxLayoutWidthAtFirstLayout="YES" translatesAutoresizingMaskIntoConstraints="NO" id="7QO-fG-liO">
-                                            <rect key="frame" x="164" y="20" width="123" height="17"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                            <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" alignment="center" title="© 2017 Automattic" id="yfA-1y-gmq">
-                                                <font key="font" metaFont="controlContent"/>
-                                                <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                            </textFieldCell>
-                                        </textField>
-                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" setsMaxLayoutWidthAtFirstLayout="YES" translatesAutoresizingMaskIntoConstraints="NO" id="7Mu-Vh-597" customClass="SPAboutTextField" customModule="Simplenote" customModuleProvider="target">
-                                            <rect key="frame" x="214" y="40" width="21" height="17"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                            <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" alignment="center" title=" • " id="qaH-P0-RWS">
-                                                <font key="font" metaFont="controlContent"/>
-                                                <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                            </textFieldCell>
-                                        </textField>
-                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" setsMaxLayoutWidthAtFirstLayout="YES" translatesAutoresizingMaskIntoConstraints="NO" id="zLM-6J-YYw" customClass="SPAboutTextField" customModule="Simplenote" customModuleProvider="target">
-                                            <rect key="frame" x="96" y="40" width="123" height="17"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                            <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" alignment="right" title="Privacy Policy" id="mtR-4c-JA4">
-                                                <font key="font" metaFont="controlContent"/>
-                                                <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                            </textFieldCell>
-                                        </textField>
-                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" setsMaxLayoutWidthAtFirstLayout="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Mvl-zm-Us5" customClass="SPAboutTextField" customModule="Simplenote" customModuleProvider="target">
-                                            <rect key="frame" x="231" y="40" width="123" height="17"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                            <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" alignment="left" title="Terms of Service" id="CPb-lj-ZNn">
-                                                <font key="font" metaFont="controlContent"/>
-                                                <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                            </textFieldCell>
-                                        </textField>
+                                        <stackView distribution="fill" orientation="vertical" alignment="centerX" spacing="4" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="drq-hU-buA">
+                                            <rect key="frame" x="0.0" y="26" width="451" height="53"/>
+                                            <subviews>
+                                                <stackView distribution="fill" orientation="horizontal" alignment="top" spacing="2" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="36G-l4-m5J">
+                                                    <rect key="frame" x="128" y="38" width="196" height="15"/>
+                                                    <subviews>
+                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" setsMaxLayoutWidthAtFirstLayout="YES" translatesAutoresizingMaskIntoConstraints="NO" id="zLM-6J-YYw" customClass="SPAboutTextField" customModule="Simplenote" customModuleProvider="target">
+                                                            <rect key="frame" x="-2" y="0.0" width="83" height="15"/>
+                                                            <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" alignment="right" title="Privacy Policy" id="mtR-4c-JA4">
+                                                                <font key="font" metaFont="controlContent"/>
+                                                                <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                            </textFieldCell>
+                                                        </textField>
+                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" setsMaxLayoutWidthAtFirstLayout="YES" translatesAutoresizingMaskIntoConstraints="NO" id="7Mu-Vh-597" customClass="SPAboutTextField" customModule="Simplenote" customModuleProvider="target">
+                                                            <rect key="frame" x="79" y="0.0" width="21" height="15"/>
+                                                            <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" alignment="center" title=" • " id="qaH-P0-RWS">
+                                                                <font key="font" metaFont="controlContent"/>
+                                                                <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                            </textFieldCell>
+                                                        </textField>
+                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" setsMaxLayoutWidthAtFirstLayout="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Mvl-zm-Us5" customClass="SPAboutTextField" customModule="Simplenote" customModuleProvider="target">
+                                                            <rect key="frame" x="98" y="0.0" width="100" height="15"/>
+                                                            <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" alignment="left" title="Terms of Service" id="CPb-lj-ZNn">
+                                                                <font key="font" metaFont="controlContent"/>
+                                                                <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                            </textFieldCell>
+                                                        </textField>
+                                                    </subviews>
+                                                    <visibilityPriorities>
+                                                        <integer value="1000"/>
+                                                        <integer value="1000"/>
+                                                        <integer value="1000"/>
+                                                    </visibilityPriorities>
+                                                    <customSpacing>
+                                                        <real value="3.4028234663852886e+38"/>
+                                                        <real value="3.4028234663852886e+38"/>
+                                                        <real value="3.4028234663852886e+38"/>
+                                                    </customSpacing>
+                                                </stackView>
+                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" setsMaxLayoutWidthAtFirstLayout="YES" translatesAutoresizingMaskIntoConstraints="NO" id="k4n-4L-Xn4" customClass="SPAboutTextField" customModule="Simplenote" customModuleProvider="target">
+                                                    <rect key="frame" x="-2" y="19" width="455" height="15"/>
+                                                    <textFieldCell key="cell" lineBreakMode="truncatingTail" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="center" title="Privacy Notice for California Users" id="nKa-UJ-qCZ">
+                                                        <font key="font" metaFont="controlContent"/>
+                                                        <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                </textField>
+                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" setsMaxLayoutWidthAtFirstLayout="YES" translatesAutoresizingMaskIntoConstraints="NO" id="7QO-fG-liO">
+                                                    <rect key="frame" x="-2" y="0.0" width="455" height="15"/>
+                                                    <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" alignment="center" title="© 2017 Automattic" id="yfA-1y-gmq">
+                                                        <font key="font" metaFont="controlContent"/>
+                                                        <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                </textField>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="k4n-4L-Xn4" firstAttribute="leading" secondItem="drq-hU-buA" secondAttribute="leading" id="65A-Gw-Umt"/>
+                                                <constraint firstAttribute="trailing" secondItem="k4n-4L-Xn4" secondAttribute="trailing" id="6pu-sJ-g8g"/>
+                                                <constraint firstItem="7QO-fG-liO" firstAttribute="leading" secondItem="drq-hU-buA" secondAttribute="leading" id="PQR-ip-iIc"/>
+                                                <constraint firstAttribute="trailing" secondItem="7QO-fG-liO" secondAttribute="trailing" id="W8s-qe-mhY"/>
+                                            </constraints>
+                                            <visibilityPriorities>
+                                                <integer value="1000"/>
+                                                <integer value="1000"/>
+                                                <integer value="1000"/>
+                                            </visibilityPriorities>
+                                            <customSpacing>
+                                                <real value="3.4028234663852886e+38"/>
+                                                <real value="3.4028234663852886e+38"/>
+                                                <real value="3.4028234663852886e+38"/>
+                                            </customSpacing>
+                                        </stackView>
                                     </subviews>
+                                    <constraints>
+                                        <constraint firstItem="drq-hU-buA" firstAttribute="leading" secondItem="BDM-Ov-qG6" secondAttribute="leading" id="2OR-nD-W9h"/>
+                                        <constraint firstAttribute="bottom" secondItem="drq-hU-buA" secondAttribute="bottom" constant="26" id="Gqh-H6-jmo"/>
+                                        <constraint firstAttribute="trailing" secondItem="drq-hU-buA" secondAttribute="trailing" id="K4t-mG-fDt"/>
+                                        <constraint firstItem="drq-hU-buA" firstAttribute="centerX" secondItem="BDM-Ov-qG6" secondAttribute="centerX" id="PJT-XP-Pgi"/>
+                                    </constraints>
                                 </view>
                                 <color key="fillColor" red="0.28235294119999998" green="0.58431372550000005" blue="0.85098039219999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             </box>
@@ -283,6 +329,7 @@
                     <connections>
                         <outlet property="backgroundBox" destination="jR0-c5-hne" id="EZe-0S-a1H"/>
                         <outlet property="blogLabel" destination="eGT-Zs-dGY" id="8qK-hu-Twv"/>
+                        <outlet property="californiaLabel" destination="k4n-4L-Xn4" id="ibY-q4-8kM"/>
                         <outlet property="copyrightLabel" destination="7QO-fG-liO" id="FLV-mx-gvF"/>
                         <outlet property="githubLabel" destination="eoo-VW-fOF" id="sT5-oi-gMy"/>
                         <outlet property="hiringLabel" destination="NvX-jo-5we" id="exi-aU-Qny"/>
@@ -294,7 +341,7 @@
                     </connections>
                 </viewController>
             </objects>
-            <point key="canvasLocation" x="713.5" y="210"/>
+            <point key="canvasLocation" x="713.5" y="224.5"/>
         </scene>
     </scenes>
     <resources>

--- a/Simplenote/AboutViewController.swift
+++ b/Simplenote/AboutViewController.swift
@@ -14,6 +14,7 @@ class AboutViewController: NSViewController {
         static let hiringUrl =     "https://automattic.com/work-with-us"
         static let privacyUrl =    "https://simplenote.com/privacy/"
         static let termsUrl =      "https://simplenote.com/terms/"
+        static let californiaUrl = "https://wp.me/Pe4R-d/#california-consumer-privacy-act-ccpa"
     }
 
     @IBOutlet var logoImageView:    NSImageView!
@@ -24,6 +25,7 @@ class AboutViewController: NSViewController {
     @IBOutlet var hiringLabel:      SPAboutTextField!
     @IBOutlet var privacyLabel:     SPAboutTextField!
     @IBOutlet var tosLabel:         SPAboutTextField!
+    @IBOutlet var californiaLabel:  SPAboutTextField!
     @IBOutlet var versionLabel:     NSTextField!
     @IBOutlet var copyrightLabel:   NSTextField!
     
@@ -50,6 +52,9 @@ class AboutViewController: NSViewController {
         
         let termsClick = NSClickGestureRecognizer(target: self, action: #selector(termsLabelClick))
         tosLabel.addGestureRecognizer(termsClick)
+
+        let californiaClick = NSClickGestureRecognizer(target: self, action: #selector(californiaLabelClick))
+        californiaLabel.addGestureRecognizer(californiaClick)
         
         // Display app version in the header
         let dictionary = Bundle.main.infoDictionary!
@@ -87,5 +92,9 @@ class AboutViewController: NSViewController {
     
     @objc func termsLabelClick() {
         NSWorkspace.shared.open(URL(string: Constants.termsUrl)!)
+    }
+
+    @objc func californiaLabelClick() {
+        NSWorkspace.shared.open(URL(string: Constants.californiaUrl)!)
     }
 }


### PR DESCRIPTION
### Fix
In this (quick!) PR we're adding a new Privacy Notice for California Users.

@aerych you game for a quick PR sir?
Thank yooou!!

### Test
1. Launch the App
2. Click `Simplenote` > `About Simplenote`

- [x] Verify there's a new link at the bottom that reads `Privacy Notice for California Users`
- [x] Verify that clicking over such link opens [this URL](https://automattic.com/privacy/#california-consumer-privacy-act-ccpa)

### Release
`RELEASE-NOTES.txt` was updated in dd0d46ec56da5194f87de18c5682a08e6e7b4388 with:
 
> New Privacy Notice for California Users

### Screenshots
<img width="459" alt="Screen Shot 2020-06-29 at 6 36 04 PM" src="https://user-images.githubusercontent.com/1195260/86058515-6b09e680-ba37-11ea-99c6-04ff2ad4a3d0.png">
