### PR TITLE
Refreshing Toolbar Actions

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 - Implements Untagged Notes Filter
 - New Note Metrics Interface
 - Relocated Editor Actions into the new More Actions Menu
+
 1.11.1
 ------
 - New Privacy Notice for California Users

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 - New Scroll Support in the Tags Editor area
 - Implements Untagged Notes Filter
 - New Note Metrics Interface
+- Relocated Editor Actions into the new More Actions Menu
 
 1.11.0
 ------

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -966,11 +966,12 @@
 				B56FA79A2437D2E0002CB9FF /* NSAppearance+Simplenote.swift */,
 				B5EB3AD92458E8430089858D /* NSApplication+Simplenote.swift */,
 				B5B17F392425668400DD5B34 /* NSAttributedString+Simplenote.swift */,
-				B5283BCF23B679C00085826F /* NSMutableAttributedString+Simplenote.swift */,
+				B5D58879244F890100345916 /* NSButton+Simplenote.swift */,
 				B5985AD4242950B40044EDE9 /* NSColor+Simplenote.swift */,
 				B5E0863A2449012700DEF476 /* NSImage+Simplenote.swift */,
 				B5E0862E2448E58C00DEF476 /* NSImageName+Simplenote.swift */,
 				B56EA2A9244F4CC70061EAD8 /* NSImageView+Simplenote.swift */,
+				B5283BCF23B679C00085826F /* NSMutableAttributedString+Simplenote.swift */,
 				B51E9FE422E644A0004F16B4 /* NSObject+Helpers.swift */,
 				B5AF76C124A2A4F100B7D530 /* NSPredicate+Simplenote.swift */,
 				B5CD5F7D241AC69900D0260F /* NSProcessInfo+Simplenote.swift */,
@@ -986,7 +987,6 @@
 				B5F807CE2481A2010048CBD7 /* Simperium+Simplenote.swift */,
 				B500993B24213B370037A431 /* String+Simplenote.swift */,
 				B5009936242130F70037A431 /* UnicodeScalar+Simplenote.swift */,
-				B5D58879244F890100345916 /* NSButton+Simplenote.swift */,
 				B57CB876244DEBCE00BA7969 /* UserDefaults+Simplenote.swift */,
 			);
 			name = Extensions;

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -252,10 +252,10 @@
 		B5C1F0AC242E9A9800A627E3 /* MockupTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5C1F0AB242E9A9800A627E3 /* MockupTextView.swift */; };
 		B5C7DD3D243E1F1900BEE354 /* VersionsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5C7DD3C243E1F1900BEE354 /* VersionsViewController.swift */; };
 		B5C7DD3E243E1F1900BEE354 /* VersionsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5C7DD3C243E1F1900BEE354 /* VersionsViewController.swift */; };
-		B5C7DD40243E4A7D00BEE354 /* ShareViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5C7DD3F243E4A7D00BEE354 /* ShareViewController.swift */; };
-		B5C7DD41243E4A7D00BEE354 /* ShareViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5C7DD3F243E4A7D00BEE354 /* ShareViewController.swift */; };
-		B5C7DD43243E4A8E00BEE354 /* ShareViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = B5C7DD42243E4A8E00BEE354 /* ShareViewController.xib */; };
-		B5C7DD44243E4A8E00BEE354 /* ShareViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = B5C7DD42243E4A8E00BEE354 /* ShareViewController.xib */; };
+		B5C7DD40243E4A7D00BEE354 /* CollaborateViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5C7DD3F243E4A7D00BEE354 /* CollaborateViewController.swift */; };
+		B5C7DD41243E4A7D00BEE354 /* CollaborateViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5C7DD3F243E4A7D00BEE354 /* CollaborateViewController.swift */; };
+		B5C7DD43243E4A8E00BEE354 /* CollaborateViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = B5C7DD42243E4A8E00BEE354 /* CollaborateViewController.xib */; };
+		B5C7DD44243E4A8E00BEE354 /* CollaborateViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = B5C7DD42243E4A8E00BEE354 /* CollaborateViewController.xib */; };
 		B5C7DD46243E51E200BEE354 /* PublishViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5C7DD45243E51E200BEE354 /* PublishViewController.swift */; };
 		B5C7DD47243E51E200BEE354 /* PublishViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5C7DD45243E51E200BEE354 /* PublishViewController.swift */; };
 		B5C7DD49243E524000BEE354 /* PublishViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = B5C7DD48243E524000BEE354 /* PublishViewController.xib */; };
@@ -570,8 +570,8 @@
 		B5C19D8A243D30690014086C /* VersionsViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = VersionsViewController.xib; sourceTree = "<group>"; };
 		B5C1F0AB242E9A9800A627E3 /* MockupTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockupTextView.swift; sourceTree = "<group>"; };
 		B5C7DD3C243E1F1900BEE354 /* VersionsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VersionsViewController.swift; sourceTree = "<group>"; };
-		B5C7DD3F243E4A7D00BEE354 /* ShareViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareViewController.swift; sourceTree = "<group>"; };
-		B5C7DD42243E4A8E00BEE354 /* ShareViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ShareViewController.xib; sourceTree = "<group>"; };
+		B5C7DD3F243E4A7D00BEE354 /* CollaborateViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollaborateViewController.swift; sourceTree = "<group>"; };
+		B5C7DD42243E4A8E00BEE354 /* CollaborateViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CollaborateViewController.xib; sourceTree = "<group>"; };
 		B5C7DD45243E51E200BEE354 /* PublishViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublishViewController.swift; sourceTree = "<group>"; };
 		B5C7DD48243E524000BEE354 /* PublishViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = PublishViewController.xib; sourceTree = "<group>"; };
 		B5C92EBE1B03D5E400A4FFD0 /* NSObject+Simplenote.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSObject+Simplenote.h"; sourceTree = "<group>"; };
@@ -1176,8 +1176,8 @@
 				B586C061245CCD35009508EC /* SplitViewController.swift */,
 				B529F7B424586D8700B168F1 /* MarkdownViewController.swift */,
 				B529F7B724586DF800B168F1 /* MarkdownViewController.xib */,
-				B5C7DD3F243E4A7D00BEE354 /* ShareViewController.swift */,
-				B5C7DD42243E4A8E00BEE354 /* ShareViewController.xib */,
+				B5C7DD3F243E4A7D00BEE354 /* CollaborateViewController.swift */,
+				B5C7DD42243E4A8E00BEE354 /* CollaborateViewController.xib */,
 				B5C7DD45243E51E200BEE354 /* PublishViewController.swift */,
 				B5C7DD48243E524000BEE354 /* PublishViewController.xib */,
 			);
@@ -1370,7 +1370,7 @@
 				B5F04FD3215964BC004B1AA0 /* Privacy.storyboard in Resources */,
 				37AE49C91FFEBB0B00FCB165 /* markdown-dark.css in Resources */,
 				B5686D0E1AEAE6D7009F9E20 /* Images.xcassets in Resources */,
-				B5C7DD43243E4A8E00BEE354 /* ShareViewController.xib in Resources */,
+				B5C7DD43243E4A8E00BEE354 /* CollaborateViewController.xib in Resources */,
 				B5A89195231ECB3C0007EDCB /* LICENSE in Resources */,
 				46F0E66717A3300B005BB4D1 /* Localizable.strings in Resources */,
 				B5438012246358B700F34B1C /* Icons.xcassets in Resources */,
@@ -1391,7 +1391,7 @@
 				466FFEE817CC10A800399652 /* MainMenu.xib in Resources */,
 				B5686D0F1AEAE6D7009F9E20 /* Images.xcassets in Resources */,
 				B5438013246358BA00F34B1C /* Icons.xcassets in Resources */,
-				B5C7DD44243E4A8E00BEE354 /* ShareViewController.xib in Resources */,
+				B5C7DD44243E4A8E00BEE354 /* CollaborateViewController.xib in Resources */,
 				37AE49CA1FFEBB0B00FCB165 /* markdown-dark.css in Resources */,
 				466FFF1717CC10A800399652 /* Localizable.strings in Resources */,
 				B529F7B924586DF800B168F1 /* MarkdownViewController.xib in Resources */,
@@ -1704,7 +1704,7 @@
 				71DCEBE7152E2ED1002744C0 /* NSMutableAttributedString+Styling.m in Sources */,
 				B529F7B524586D8700B168F1 /* MarkdownViewController.swift in Sources */,
 				B5B17F3A2425668400DD5B34 /* NSAttributedString+Simplenote.swift in Sources */,
-				B5C7DD40243E4A7D00BEE354 /* ShareViewController.swift in Sources */,
+				B5C7DD40243E4A7D00BEE354 /* CollaborateViewController.swift in Sources */,
 				B54EB1901A3F683D00D472B3 /* SPWindow.m in Sources */,
 				B5E196C1230F5F5300F5658A /* SPCredentials.swift in Sources */,
 				B51374F61AC0591900825FCC /* SPConstants.m in Sources */,
@@ -1835,7 +1835,7 @@
 				375D294921E033D1007AB25A /* html_blocks.c in Sources */,
 				B529F7B624586D8700B168F1 /* MarkdownViewController.swift in Sources */,
 				B5B17F3B2425668400DD5B34 /* NSAttributedString+Simplenote.swift in Sources */,
-				B5C7DD41243E4A7D00BEE354 /* ShareViewController.swift in Sources */,
+				B5C7DD41243E4A7D00BEE354 /* CollaborateViewController.swift in Sources */,
 				B54EB1911A3F683D00D472B3 /* SPWindow.m in Sources */,
 				B586C063245CCD35009508EC /* SplitViewController.swift in Sources */,
 				B5E196C2230F5F5300F5658A /* SPCredentials.swift in Sources */,

--- a/Simplenote/CollaborateViewController.swift
+++ b/Simplenote/CollaborateViewController.swift
@@ -1,9 +1,9 @@
 import Foundation
 
 
-// MARK: - ShareViewController
+// MARK: - CollaborateViewController
 //
-class ShareViewController: NSViewController {
+class CollaborateViewController: NSViewController {
 
     /// Share Text Legend
     ///
@@ -38,7 +38,7 @@ class ShareViewController: NSViewController {
 
 // MARK: - Private
 //
-private extension ShareViewController {
+private extension CollaborateViewController {
 
     func startListeningToNotifications() {
         NotificationCenter.default.addObserver(self, selector: #selector(refreshStyle), name: .ThemeDidChange, object: nil)
@@ -55,7 +55,7 @@ private extension ShareViewController {
 
 // MARK: - NSPopoverDelegate
 //
-extension ShareViewController: NSPopoverDelegate {
+extension CollaborateViewController: NSPopoverDelegate {
 
     public func popoverWillShow(_ notification: Notification) {
         presentingPopover = notification.object as? NSPopover

--- a/Simplenote/CollaborateViewController.xib
+++ b/Simplenote/CollaborateViewController.xib
@@ -6,7 +6,7 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
-        <customObject id="-2" userLabel="File's Owner" customClass="ShareViewController" customModule="Simplenote" customModuleProvider="target">
+        <customObject id="-2" userLabel="File's Owner" customClass="CollaborateViewController" customModule="Simplenote" customModuleProvider="target">
             <connections>
                 <outlet property="shareTextField" destination="07M-AN-65d" id="ofc-3H-Zci"/>
                 <outlet property="view" destination="3UL-37-8ha" id="1qo-2W-x9C"/>

--- a/Simplenote/NSUserInterfaceItemIdentifier+Simplenote.swift
+++ b/Simplenote/NSUserInterfaceItemIdentifier+Simplenote.swift
@@ -7,29 +7,39 @@ extension NSUserInterfaceItemIdentifier {
 
     /// Identifier: EmptyTrash MenuItem
     ///
-    static let emptyTrashMenuItem = NSUserInterfaceItemIdentifier(rawValue: "emptyTrashMenuItem")
+    static let emptyTrashMenuItem           = NSUserInterfaceItemIdentifier(rawValue: "emptyTrashMenuItem")
 
     /// Identifier: Export MenuItem
     ///
-    static let exportMenuItem = NSUserInterfaceItemIdentifier(rawValue: "exportMenuItem")
+    static let exportMenuItem               = NSUserInterfaceItemIdentifier(rawValue: "exportMenuItem")
 
     /// Identifier: Focus MenuItem
     ///
-    static let focusMenuItem = NSUserInterfaceItemIdentifier(rawValue: "focusMenuItem")
+    static let focusMenuItem                = NSUserInterfaceItemIdentifier(rawValue: "focusMenuItem")
 
     /// Identifier: Tags Sort MenuItem
     ///
-    static let tagSortMenuItem = NSUserInterfaceItemIdentifier(rawValue: "tagSortMenuItem")
+    static let tagSortMenuItem              = NSUserInterfaceItemIdentifier(rawValue: "tagSortMenuItem")
 
-    /// Identifier: Dark Theme MenuItem
+    /// Identifiers: System Menu
     ///
-    static let themeDarkMenuItem = NSUserInterfaceItemIdentifier(rawValue: "themeDarkMenuItem")
+    static let systemNewNoteMenuItem        = NSUserInterfaceItemIdentifier(rawValue: "systemNewNoteMenuItem")
+    static let systemTrashMenuItem          = NSUserInterfaceItemIdentifier(rawValue: "systemTrashMenuItem")
+    static let systemPrintMenuItem          = NSUserInterfaceItemIdentifier(rawValue: "systemPrintMenuItem")
 
-    /// Identifier: Light Theme MenuItem
+    /// Identifiers: Editor
     ///
-    static let themeLightMenuItem = NSUserInterfaceItemIdentifier(rawValue: "themeLightMenuItem")
+    static let editorPinMenuItem            = NSUserInterfaceItemIdentifier(rawValue: "editorPinMenuItem")
+    static let editorMarkdownMenuItem       = NSUserInterfaceItemIdentifier(rawValue: "editorMarkdownMenuItem")
+    static let editorShareMenuItem          = NSUserInterfaceItemIdentifier(rawValue: "editorShareMenuItem")
+    static let editorHistoryMenuItem        = NSUserInterfaceItemIdentifier(rawValue: "editorHistoryMenuItem")
+    static let editorTrashMenuItem          = NSUserInterfaceItemIdentifier(rawValue: "editorTrashMenuItem")
+    static let editorPublishMenuItem        = NSUserInterfaceItemIdentifier(rawValue: "editorPublishMenuItem")
+    static let editorCollaborateMenuItem    = NSUserInterfaceItemIdentifier(rawValue: "editorCollaborateMenuItem")
 
-    /// Identifier: System Theme MenuItem
+    /// Identifiers: Theme Menu
     ///
-    static let themeSystemMenuItem = NSUserInterfaceItemIdentifier(rawValue: "themeSystemMenuItem")
+    static let themeDarkMenuItem            = NSUserInterfaceItemIdentifier(rawValue: "themeDarkMenuItem")
+    static let themeLightMenuItem           = NSUserInterfaceItemIdentifier(rawValue: "themeLightMenuItem")
+    static let themeSystemMenuItem          = NSUserInterfaceItemIdentifier(rawValue: "themeSystemMenuItem")
 }

--- a/Simplenote/NoteEditorViewController+Swift.swift
+++ b/Simplenote/NoteEditorViewController+Swift.swift
@@ -150,6 +150,19 @@ extension NoteEditorViewController {
 }
 
 
+// MARK: - NSMenuItemValidation
+//
+extension NoteEditorViewController: NSMenuItemValidation {
+
+    public func validateMenuItem(_ menuItem: NSMenuItem) -> Bool {
+        guard let identifier = menuItem.identifier else {
+            return true
+        }
+        return true
+    }
+}
+
+
 // MARK: - Actions
 //
 extension NoteEditorViewController {

--- a/Simplenote/NoteEditorViewController+Swift.swift
+++ b/Simplenote/NoteEditorViewController+Swift.swift
@@ -62,7 +62,7 @@ extension NoteEditorViewController {
 }
 
 
-// MARK: - Private Helpers
+// MARK: - Internal State
 //
 extension NoteEditorViewController {
 
@@ -100,7 +100,12 @@ extension NoteEditorViewController {
 
         return selection.count > 1
     }
+}
 
+
+// MARK: - Refreshing Interface
+//
+extension NoteEditorViewController {
 
     /// Refreshes the Editor's Inner State
     ///
@@ -158,8 +163,52 @@ extension NoteEditorViewController: NSMenuItemValidation {
         guard let identifier = menuItem.identifier else {
             return true
         }
+
+        switch identifier {
+        case .editorPinMenuItem:
+            return validatePinMenuItem(menuItem)
+
+        case .editorMarkdownMenuItem:
+            return validateMarkdownMenuItem(menuItem)
+
+        case .editorShareMenuItem:
+            return isShareEnabled
+
+        case .editorHistoryMenuItem:
+            return isDisplayingNote && !isDisplayingMarkdown
+
+        case .editorTrashMenuItem:
+            return isDisplayingNote || isSelectingMultipleNotes
+
+        case .editorPublishMenuItem:
+            return isShareEnabled
+
+        case .editorCollaborateMenuItem:
+            return isDisplayingNote
+
+        case .systemNewNoteMenuItem:
+            return !viewingTrash
+
+        case .systemPrintMenuItem, .systemTrashMenuItem:
+            return !viewingTrash && note != nil && SimplenoteAppDelegate.shared().isMainWindowVisible()
+
+        default:
+            return true
+        }
+    }
+
+    func validatePinMenuItem(_ item: NSMenuItem) -> Bool {
+        let selectedNotesPinned = selectedNotes.allSatisfy { $0.pinned }
+        item.state = selectedNotesPinned ? .on : .off
         return true
     }
+
+    func validateMarkdownMenuItem(_ item: NSMenuItem) -> Bool {
+        let selectedNotesMarkdowned = selectedNotes.allSatisfy { $0.markdown }
+        item.state = selectedNotesMarkdowned ? .on : .off
+        return true
+    }
+
 }
 
 

--- a/Simplenote/NoteEditorViewController+Swift.swift
+++ b/Simplenote/NoteEditorViewController+Swift.swift
@@ -165,19 +165,19 @@ extension NoteEditorViewController {
     }
 
     @IBAction
-    func shareWasPressed(sender: Any) {
+    func collaborateWasPressed(sender: Any) {
         SPTracker.trackEditorCollaboratorsAccessed()
         displayCollaboratePopover(from: tagsField)
         tagsField.becomeFirstResponder()
     }
 
-    @objc
-    func publishWasPressed() {
+    @IBAction
+    func publishWasPressed(sender: Any) {
         guard let note = note else {
             return
         }
 
-        displayPublishPopover(from: toolbarView.shareButton, for: note)
+        displayPublishPopover(from: toolbarView.moreButton, for: note)
     }
 
     @IBAction
@@ -187,7 +187,7 @@ extension NoteEditorViewController {
         }
 
         SPTracker.trackEditorVersionsAccessed()
-        displayVersionsPopover(from: toolbarView.historyButton, for: note)
+        displayVersionsPopover(from: toolbarView.moreButton, for: note)
     }
 }
 

--- a/Simplenote/NoteEditorViewController+Swift.swift
+++ b/Simplenote/NoteEditorViewController+Swift.swift
@@ -122,7 +122,6 @@ extension NoteEditorViewController {
                                     isSelectingMultipleNotes: isSelectingMultipleNotes,
                                     isViewingTrash: viewingTrash)
         toolbarView.state = newState
-
     }
 
     /// Refreshes all of the TagsField properties: Tokens and allowed actions

--- a/Simplenote/NoteEditorViewController+Swift.swift
+++ b/Simplenote/NoteEditorViewController+Swift.swift
@@ -265,6 +265,15 @@ extension NoteEditorViewController {
     }
 
     @IBAction
+    func shareWasPressed(sender: Any) {
+        guard let content = note?.content else {
+            return
+        }
+
+        displaySharingPicker(from: toolbarView.moreButton, content: content)
+    }
+
+    @IBAction
     func versionsWasPressed(sender: Any) {
         guard let note = note else {
             return
@@ -276,7 +285,7 @@ extension NoteEditorViewController {
 }
 
 
-// MARK: - Popovers
+// MARK: - Popovers / Pickers
 //
 extension NoteEditorViewController {
 
@@ -294,6 +303,11 @@ extension NoteEditorViewController {
     func displayCollaboratePopover(from sourceView: NSView) {
         let viewController = CollaborateViewController()
         present(viewController, asPopoverRelativeTo: sourceView.bounds, of: sourceView, preferredEdge: .maxY, behavior: .transient)
+    }
+
+    func displaySharingPicker(from sourceView: NSView, content: String) {
+        let picker = NSSharingServicePicker(items: [content])
+        picker.show(relativeTo: sourceView.bounds, of: sourceView, preferredEdge: .minY)
     }
 
     func displayVersionsPopover(from sourceView: NSView, for note: Note) {

--- a/Simplenote/NoteEditorViewController+Swift.swift
+++ b/Simplenote/NoteEditorViewController+Swift.swift
@@ -167,7 +167,7 @@ extension NoteEditorViewController {
     @IBAction
     func shareWasPressed(sender: Any) {
         SPTracker.trackEditorCollaboratorsAccessed()
-        displaySharePopover(from: tagsField)
+        displayCollaboratePopover(from: tagsField)
         tagsField.becomeFirstResponder()
     }
 
@@ -207,8 +207,8 @@ extension NoteEditorViewController {
         present(viewController, asPopoverRelativeTo: sourceView.bounds, of: sourceView, preferredEdge: .maxY, behavior: .transient)
     }
 
-    func displaySharePopover(from sourceView: NSView) {
-        let viewController = ShareViewController()
+    func displayCollaboratePopover(from sourceView: NSView) {
+        let viewController = CollaborateViewController()
         present(viewController, asPopoverRelativeTo: sourceView.bounds, of: sourceView, preferredEdge: .maxY, behavior: .transient)
     }
 

--- a/Simplenote/NoteEditorViewController+Swift.swift
+++ b/Simplenote/NoteEditorViewController+Swift.swift
@@ -123,7 +123,6 @@ extension NoteEditorViewController {
         let newState = ToolbarState(isDisplayingNote: isDisplayingNote,
                                     isDisplayingMarkdown: isDisplayingMarkdown,
                                     isMarkdownEnabled: isMarkdownEnabled,
-                                    isShareEnabled: isShareEnabled,
                                     isSelectingMultipleNotes: isSelectingMultipleNotes,
                                     isViewingTrash: viewingTrash)
         toolbarView.state = newState

--- a/Simplenote/NoteEditorViewController+Swift.swift
+++ b/Simplenote/NoteEditorViewController+Swift.swift
@@ -72,6 +72,12 @@ extension NoteEditorViewController {
         note != nil
     }
 
+    /// Indicates if the current document is not empty
+    ///
+    var isDisplayingContent: Bool {
+        note?.content?.isEmpty == false
+    }
+
     /// Indicates if the Markdown Preview UI is active
     ///
     @objc
@@ -85,20 +91,11 @@ extension NoteEditorViewController {
         note?.markdown == true
     }
 
-    /// Indicates if the current document can be shared
-    ///
-    var isShareEnabled: Bool {
-        note?.content?.isEmpty == false
-    }
-
     /// Indicates if there are multiple selected notes
     ///
     var isSelectingMultipleNotes: Bool {
-        guard let selection = selectedNotes else {
-            return false
-        }
-
-        return selection.count > 1
+        let numberOfSelectedNotes = selectedNotes?.count ?? .zero
+        return numberOfSelectedNotes > 1
     }
 }
 
@@ -171,25 +168,25 @@ extension NoteEditorViewController: NSMenuItemValidation {
             return validateMarkdownMenuItem(menuItem)
 
         case .editorShareMenuItem:
-            return isShareEnabled
+            return validateShareMenuItem(menuItem)
 
         case .editorHistoryMenuItem:
-            return isDisplayingNote && !isDisplayingMarkdown
+            return validateHistoryMenuItem(menuItem)
 
         case .editorTrashMenuItem:
-            return isDisplayingNote || isSelectingMultipleNotes
+            return validateTrashMenuItem(menuItem)
 
         case .editorPublishMenuItem:
-            return isShareEnabled
+            return validatePublishMenuItem(menuItem)
 
         case .editorCollaborateMenuItem:
-            return isDisplayingNote
+            return validateCollaborateMenuItem(menuItem)
 
         case .systemNewNoteMenuItem:
-            return !viewingTrash
+            return validateNewNoteMenuItem(menuItem)
 
         case .systemPrintMenuItem, .systemTrashMenuItem:
-            return !viewingTrash && note != nil && SimplenoteAppDelegate.shared().isMainWindowVisible()
+            return validatePrintMenuItem(menuItem)
 
         default:
             return true
@@ -197,17 +194,44 @@ extension NoteEditorViewController: NSMenuItemValidation {
     }
 
     func validatePinMenuItem(_ item: NSMenuItem) -> Bool {
-        let selectedNotesPinned = selectedNotes.allSatisfy { $0.pinned }
-        item.state = selectedNotesPinned ? .on : .off
+        let isPinnedOn = selectedNotes.allSatisfy { $0.pinned }
+        item.state = isPinnedOn ? .on : .off
         return true
     }
 
     func validateMarkdownMenuItem(_ item: NSMenuItem) -> Bool {
-        let selectedNotesMarkdowned = selectedNotes.allSatisfy { $0.markdown }
-        item.state = selectedNotesMarkdowned ? .on : .off
+        let isMarkdownOn = selectedNotes.allSatisfy { $0.markdown }
+        item.state = isMarkdownOn ? .on : .off
         return true
     }
 
+    func validateShareMenuItem(_ item: NSMenuItem) -> Bool {
+        isDisplayingContent
+    }
+
+    func validateHistoryMenuItem(_ item: NSMenuItem) -> Bool {
+        isDisplayingNote && !isDisplayingMarkdown
+    }
+
+    func validateTrashMenuItem(_ item: NSMenuItem) -> Bool {
+        isDisplayingNote || isSelectingMultipleNotes
+    }
+
+    func validatePublishMenuItem(_ item: NSMenuItem) -> Bool {
+        isDisplayingContent
+    }
+
+    func validateCollaborateMenuItem(_ item: NSMenuItem) -> Bool {
+        isDisplayingNote
+    }
+
+    func validateNewNoteMenuItem(_ item: NSMenuItem) -> Bool {
+        !viewingTrash
+    }
+
+    func validatePrintMenuItem(_ item: NSMenuItem) -> Bool {
+        !viewingTrash && note != nil && SimplenoteAppDelegate.shared().isMainWindowVisible()
+    }
 }
 
 

--- a/Simplenote/NoteEditorViewController.h
+++ b/Simplenote/NoteEditorViewController.h
@@ -41,12 +41,6 @@ extern NSString * const SPWillAddNewNoteNotificationName;
     IBOutlet NSTableView *tableView;
     IBOutlet NSArrayController *notesArrayController;
     IBOutlet NSMenu *lineLengthMenu;
-    IBOutlet NSMenuItem *pinnedItem;
-    IBOutlet NSMenuItem *markdownItem;
-    IBOutlet NSMenuItem *newItem;
-    IBOutlet NSMenuItem *deleteItem;
-    IBOutlet NSMenuItem *printItem;
-    IBOutlet NSMenuItem *collaborateItem;
 }
 
 @property (nonatomic, strong) IBOutlet NSMenu                                   *moreActionsMenu;

--- a/Simplenote/NoteEditorViewController.m
+++ b/Simplenote/NoteEditorViewController.m
@@ -740,19 +740,6 @@ static NSString * const SPMarkdownPreferencesKey        = @"kMarkdownPreferences
 
 #pragma mark - NSButton Delegate Methods
 
-- (IBAction)shareWasPressed:(id)sender
-{
-    if (!self.note.content) {
-        return;
-    }
-
-    NSButton *sourceButton = self.toolbarView.moreButton;
-    NSMutableArray *noteShareItem = [NSMutableArray arrayWithObject:self.note.content];
-
-    NSSharingServicePicker *sharingPicker = [[NSSharingServicePicker alloc] initWithItems:noteShareItem];
-    [sharingPicker showRelativeToRect:sourceButton.bounds ofView:sourceButton preferredEdge:NSMinYEdge];
-}
-
 - (IBAction)toggleMarkdownView:(id)sender
 {
     if (self.isDisplayingMarkdown) {

--- a/Simplenote/NoteEditorViewController.m
+++ b/Simplenote/NoteEditorViewController.m
@@ -46,7 +46,6 @@ static NSString * const SPMarkdownPreferencesKey        = @"kMarkdownPreferences
 #pragma mark ====================================================================================
 
 @interface NoteEditorViewController() <NSMenuDelegate,
-                                        NSSharingServicePickerDelegate,
                                         NSTextDelegate,
                                         NSTextViewDelegate,
                                         SPBucketDelegate>
@@ -795,7 +794,6 @@ static NSString * const SPMarkdownPreferencesKey        = @"kMarkdownPreferences
     NSMutableArray *noteShareItem = [NSMutableArray arrayWithObject:self.note.content];
 
     NSSharingServicePicker *sharingPicker = [[NSSharingServicePicker alloc] initWithItems:noteShareItem];
-    sharingPicker.delegate = self;
     [sharingPicker showRelativeToRect:sourceButton.bounds ofView:sourceButton preferredEdge:NSMinYEdge];
 }
 
@@ -839,37 +837,6 @@ static NSString * const SPMarkdownPreferencesKey        = @"kMarkdownPreferences
 {
     [self.noteEditor toggleListMarkersAtSelectedRange];
     [SPTracker trackEditorChecklistInserted];
-}
-
-#pragma mark - NSSharingServicePicker delegate
-
-- (NSArray *)sharingServicePicker:(NSSharingServicePicker *)sharingServicePicker sharingServicesForItems:(NSArray *)items proposedSharingServices:(NSArray *)proposedServices
-{
-    // Add Simplenote publish to web option to the sharing services drop down
-    NSArray *services = proposedServices;
-    NSString *firstString;
-    for (id item in items) {
-        if ([item isKindOfClass:[NSString class]]) {
-            firstString = item;
-            break;
-        }
-        if ([item isKindOfClass:[NSAttributedString class]]) {
-            firstString = [(NSAttributedString *)item string];
-            break;
-        }
-    }
-    
-    if (firstString) {
-        NSImage *image = [NSImage imageNamed:@"icon_simplenote"];
-        NSString *title = NSLocalizedString(@"Publish to Web", @"Publish to Web Service");
-        NSSharingService *customService = [[NSSharingService alloc] initWithTitle:title image:image alternateImage:nil handler:^{
-            [self publishWasPressed];
-        }];
-        
-        services = [services arrayByAddingObject:customService];
-    }
-    
-    return services;
 }
 
 @end

--- a/Simplenote/NoteEditorViewController.m
+++ b/Simplenote/NoteEditorViewController.m
@@ -419,29 +419,6 @@ static NSString * const SPMarkdownPreferencesKey        = @"kMarkdownPreferences
 }
 
 
-#pragma mark - Action Menu and Popovers
-
-- (BOOL)selectedNotesPinned
-{
-    for (Note *selectedNote in self.selectedNotes) {
-        if (!selectedNote.pinned)
-            return NO;
-    }
-
-    return YES;
-}
-
-- (BOOL)selectedNotesMarkdowned
-{
-    for (Note *selectedNote in self.selectedNotes) {
-        if (!selectedNote.markdown)
-            return NO;
-    }
-    
-    return YES;
-}
-
-
 #pragma mark - Actions
 
 - (IBAction)moreWasPressed:(id)sender

--- a/Simplenote/NoteEditorViewController.m
+++ b/Simplenote/NoteEditorViewController.m
@@ -421,22 +421,6 @@ static NSString * const SPMarkdownPreferencesKey        = @"kMarkdownPreferences
 
 #pragma mark - Action Menu and Popovers
 
-- (BOOL)validateMenuItem:(NSMenuItem *)menuItem
-{
-    BOOL isMainWindowVisible = [[SimplenoteAppDelegate sharedDelegate] isMainWindowVisible];
-
-    // Note menu
-    if (menuItem == newItem) {
-        return !self.viewingTrash;
-    }
-
-    if (menuItem == deleteItem || menuItem == printItem) {
-        return !self.viewingTrash && self.note != nil && isMainWindowVisible;
-    }
-    
-    return YES;
-}
-
 - (BOOL)selectedNotesPinned
 {
     for (Note *selectedNote in self.selectedNotes) {
@@ -455,21 +439,6 @@ static NSString * const SPMarkdownPreferencesKey        = @"kMarkdownPreferences
     }
     
     return YES;
-}
-
-- (void)menuWillOpen:(NSMenu *)menu
-{
-    // Action menu
-    NSUInteger numSelectedNotes = [self.selectedNotes count];
-
-    if (self.viewingTrash || numSelectedNotes == 0) {
-        [menu cancelTrackingWithoutAnimation];
-        return;
-    }
-
-    pinnedItem.state = [self selectedNotesPinned] ? NSOnState : NSOffState;
-    markdownItem.state = [self selectedNotesMarkdowned] ? NSOnState : NSOffState;
-    [collaborateItem setEnabled:numSelectedNotes == 1];
 }
 
 

--- a/Simplenote/NoteEditorViewController.m
+++ b/Simplenote/NoteEditorViewController.m
@@ -486,9 +486,14 @@ static NSString * const SPMarkdownPreferencesKey        = @"kMarkdownPreferences
 
 - (IBAction)pinAction:(id)sender
 {
+    if (![sender isKindOfClass:[NSMenuItem class]]) {
+        return;
+    }
+
     [SPTracker trackEditorNotePinningToggled];
-    
+
     // Toggle the selected notes
+    NSMenuItem *pinnedItem = (NSMenuItem *)sender;
     BOOL isPinned = pinnedItem.state == NSOffState;
     
     for (Note *selectedNote in self.selectedNotes) {
@@ -504,7 +509,12 @@ static NSString * const SPMarkdownPreferencesKey        = @"kMarkdownPreferences
 
 - (IBAction)markdownAction:(id)sender
 {
+    if (![sender isKindOfClass:[NSMenuItem class]]) {
+        return;
+    }
+
     // Toggle the markdown state
+    NSMenuItem *markdownItem = (NSMenuItem *)sender;
     BOOL isEnabled = markdownItem.state == NSOffState;
 
     for (Note *selectedNote in self.selectedNotes) {

--- a/Simplenote/NoteEditorViewController.m
+++ b/Simplenote/NoteEditorViewController.m
@@ -785,13 +785,13 @@ static NSString * const SPMarkdownPreferencesKey        = @"kMarkdownPreferences
 
 #pragma mark - NSButton Delegate Methods
 
-- (IBAction)shareNote:(id)sender
+- (IBAction)shareWasPressed:(id)sender
 {
     if (!self.note.content) {
         return;
     }
 
-    NSButton *sourceButton = self.toolbarView.shareButton;
+    NSButton *sourceButton = self.toolbarView.moreButton;
     NSMutableArray *noteShareItem = [NSMutableArray arrayWithObject:self.note.content];
 
     NSSharingServicePicker *sharingPicker = [[NSSharingServicePicker alloc] initWithItems:noteShareItem];

--- a/Simplenote/ToolbarState.swift
+++ b/Simplenote/ToolbarState.swift
@@ -35,14 +35,6 @@ struct ToolbarState {
 //
 extension ToolbarState {
 
-    var isHistoryActionEnabled: Bool {
-        isDisplayingNote && !isDisplayingMarkdown
-    }
-
-    var isHistoryActionHidden: Bool {
-        isViewingTrash
-    }
-
     var isMetricsButtonEnabled: Bool {
         (isDisplayingNote || isSelectingMultipleNotes) && !isViewingTrash
     }
@@ -69,22 +61,6 @@ extension ToolbarState {
 
     var isRestoreActionHidden: Bool {
         !isViewingTrash
-    }
-
-    var isShareActionEnabled: Bool {
-        isShareEnabled
-    }
-
-    var isShareActionHidden: Bool {
-        isViewingTrash
-    }
-
-    var isTrashActionEnabled: Bool {
-        isDisplayingNote || isSelectingMultipleNotes
-    }
-
-    var isTrashActionHidden: Bool {
-        isViewingTrash
     }
 
     var previewActionImage: NSImage? {

--- a/Simplenote/ToolbarState.swift
+++ b/Simplenote/ToolbarState.swift
@@ -17,10 +17,6 @@ struct ToolbarState {
     ///
     let isMarkdownEnabled: Bool
 
-    /// Indicates if the current document supports Sharing
-    ///
-    let isShareEnabled: Bool
-
     /// Indicates if there are multiple selected documents
     ///
     let isSelectingMultipleNotes: Bool
@@ -78,7 +74,6 @@ extension ToolbarState {
         ToolbarState(isDisplayingNote: false,
                      isDisplayingMarkdown: false,
                      isMarkdownEnabled: false,
-                     isShareEnabled: false,
                      isSelectingMultipleNotes: false,
                      isViewingTrash: false)
     }

--- a/Simplenote/ToolbarState.swift
+++ b/Simplenote/ToolbarState.swift
@@ -36,7 +36,7 @@ struct ToolbarState {
 extension ToolbarState {
 
     var isMetricsButtonEnabled: Bool {
-        (isDisplayingNote || isSelectingMultipleNotes) && !isViewingTrash
+        (isDisplayingNote || isSelectingMultipleNotes)
     }
 
     var isMetricsButtonHidden: Bool {
@@ -44,7 +44,7 @@ extension ToolbarState {
     }
 
     var isMoreButtonEnabled: Bool {
-        (isDisplayingNote || isSelectingMultipleNotes) && !isViewingTrash
+        (isDisplayingNote || isSelectingMultipleNotes)
     }
 
     var isMoreButtonHidden: Bool {

--- a/Simplenote/ToolbarView.swift
+++ b/Simplenote/ToolbarView.swift
@@ -10,10 +10,6 @@ class ToolbarView: NSView {
     ///
     @IBOutlet private(set) var stackView: NSStackView!
 
-    /// Note History
-    ///
-    @IBOutlet private(set) var historyButton: NSButton!
-
     /// Metrics Button
     ///
     @IBOutlet private(set) var metricsButton: NSButton!
@@ -29,14 +25,6 @@ class ToolbarView: NSView {
     /// Restore Trashed Note
     ///
     @IBOutlet private(set) var restoreButton: NSButton!
-
-    /// Share Contents
-    ///
-    @IBOutlet private(set) var shareButton: NSButton!
-
-    /// Move to Trash
-    ///
-    @IBOutlet private(set) var trashButton: NSButton!
 
     /// Represents the Toolbar's State
     ///
@@ -85,9 +73,6 @@ private extension ToolbarView {
 private extension ToolbarView {
 
     func refreshInterface() {
-        historyButton.isEnabled = state.isHistoryActionEnabled
-        historyButton.isHidden = state.isHistoryActionHidden
-
         metricsButton.isEnabled = state.isMetricsButtonEnabled
         metricsButton.isHidden = state.isMetricsButtonHidden
 
@@ -100,12 +85,6 @@ private extension ToolbarView {
 
         restoreButton.isEnabled = state.isRestoreActionEnabled
         restoreButton.isHidden = state.isRestoreActionHidden
-
-        shareButton.isEnabled = state.isShareActionEnabled
-        shareButton.isHidden = state.isShareActionHidden
-
-        trashButton.isEnabled = state.isTrashActionEnabled
-        trashButton.isHidden = state.isTrashActionHidden
     }
 }
 
@@ -115,7 +94,7 @@ private extension ToolbarView {
 private extension ToolbarView {
 
     var allButtons: [NSButton] {
-        [historyButton, metricsButton, moreButton, previewButton, restoreButton, shareButton, trashButton]
+        [metricsButton, moreButton, previewButton, restoreButton]
     }
 
     @objc
@@ -126,13 +105,10 @@ private extension ToolbarView {
     }
 
     func setupSubviews() {
-        historyButton.toolTip = NSLocalizedString("History", comment: "Tooltip: History Picker")
         metricsButton.toolTip = NSLocalizedString("Metrics", comment: "Tooltip: Note Metrics")
         moreButton.toolTip = NSLocalizedString("More", comment: "Tooltip: More Actions")
         previewButton.toolTip = NSLocalizedString("Markdown Preview", comment: "Tooltip: Markdown Preview")
         restoreButton.toolTip = NSLocalizedString("Restore", comment: "Tooltip: Restore a trashed note")
-        shareButton.toolTip = NSLocalizedString("Share", comment: "Tooltip: Share a note")
-        trashButton.toolTip = NSLocalizedString("Trash", comment: "Tooltip: Trash a Note")
 
         let cells = allButtons.compactMap { $0.cell as? NSButtonCell }
         for cell in cells {

--- a/Simplenote/en.lproj/MainMenu.xib
+++ b/Simplenote/en.lproj/MainMenu.xib
@@ -21,16 +21,42 @@
                         <action selector="pinAction:" target="1107" id="ypv-Ec-ADu"/>
                     </connections>
                 </menuItem>
-                <menuItem title="Markdown Formatted" state="on" id="Ejc-Bj-rEL">
+                <menuItem title="Markdown" state="on" id="Ejc-Bj-rEL">
                     <modifierMask key="keyEquivalentModifierMask"/>
                     <connections>
                         <action selector="markdownAction:" target="1107" id="LKU-Zl-Thr"/>
                     </connections>
                 </menuItem>
-                <menuItem title="Collaborate..." id="avN-8J-w5V" userLabel="Menu Item - Share...">
+                <menuItem title="Share" id="iBw-QS-kil">
                     <modifierMask key="keyEquivalentModifierMask"/>
                     <connections>
-                        <action selector="shareWasPressedWithSender:" target="1107" id="Rw4-Kn-bOb"/>
+                        <action selector="shareWasPressed:" target="1107" id="jVE-Kl-d2g"/>
+                    </connections>
+                </menuItem>
+                <menuItem title="History" id="7Ox-IO-LLQ">
+                    <modifierMask key="keyEquivalentModifierMask"/>
+                    <connections>
+                        <action selector="versionsWasPressedWithSender:" target="1107" id="sjU-7F-7ZL"/>
+                    </connections>
+                </menuItem>
+                <menuItem title="Move to Trash" id="1z5-RU-iWI">
+                    <modifierMask key="keyEquivalentModifierMask"/>
+                    <connections>
+                        <action selector="deleteAction:" target="1107" id="JWB-Ld-JWN"/>
+                    </connections>
+                </menuItem>
+                <menuItem isSeparatorItem="YES" id="bqW-Zj-w17"/>
+                <menuItem title="Publish" id="Lhn-nd-qgk">
+                    <modifierMask key="keyEquivalentModifierMask"/>
+                    <connections>
+                        <action selector="publishWasPressedWithSender:" target="1107" id="ayi-Lv-26H"/>
+                    </connections>
+                </menuItem>
+                <menuItem isSeparatorItem="YES" id="INx-du-7dU"/>
+                <menuItem title="Collaborate" id="avN-8J-w5V" userLabel="Menu Item - Share...">
+                    <modifierMask key="keyEquivalentModifierMask"/>
+                    <connections>
+                        <action selector="collaborateWasPressedWithSender:" target="1107" id="Vov-V1-o59"/>
                     </connections>
                 </menuItem>
             </items>
@@ -1025,6 +1051,7 @@
                                                         </connections>
                                                     </button>
                                                     <button toolTip="Info" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="EXM-Do-Iy7" userLabel="Metrics">
+                                                        <rect key="frame" x="90" y="14" width="20" height="20"/>
                                                         <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="button_info" imagePosition="only" alignment="center" imageScaling="proportionallyUpOrDown" inset="2" id="1oR-T8-cRe">
                                                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                                             <font key="font" metaFont="system"/>

--- a/Simplenote/en.lproj/MainMenu.xib
+++ b/Simplenote/en.lproj/MainMenu.xib
@@ -1262,16 +1262,11 @@
             <connections>
                 <outlet property="backgroundView" destination="ktP-Hd-KgH" id="KFX-EY-NpR"/>
                 <outlet property="bottomDividerView" destination="xSv-Qg-Lo6" id="76h-Kc-UnK"/>
-                <outlet property="collaborateItem" destination="avN-8J-w5V" id="A6J-03-6wx"/>
-                <outlet property="deleteItem" destination="1655" id="1660"/>
                 <outlet property="lineLengthMenu" destination="JgX-db-Pi6" id="eVA-hS-cdT"/>
-                <outlet property="markdownItem" destination="Ejc-Bj-rEL" id="XHb-Xg-A7k"/>
                 <outlet property="moreActionsMenu" destination="nSc-s9-0oY" id="RWb-MR-Re4"/>
                 <outlet property="newItem" destination="1654" id="1658"/>
                 <outlet property="noteEditor" destination="934" id="1108"/>
                 <outlet property="notesArrayController" destination="573" id="1144"/>
-                <outlet property="pinnedItem" destination="Ryc-RD-9bh" id="6Rk-31-OHM"/>
-                <outlet property="printItem" destination="78" id="1659"/>
                 <outlet property="scrollView" destination="933" id="eqf-0S-fBY"/>
                 <outlet property="statusImageView" destination="1447" id="LVq-dS-TaS"/>
                 <outlet property="statusTextField" destination="faw-Qh-Cm9" id="gWO-rO-vyS"/>

--- a/Simplenote/en.lproj/MainMenu.xib
+++ b/Simplenote/en.lproj/MainMenu.xib
@@ -15,45 +15,45 @@
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <menu title="OtherViews" autoenablesItems="NO" id="nSc-s9-0oY" userLabel="Note More Menu">
             <items>
-                <menuItem title="Pin to Top" state="on" id="Ryc-RD-9bh">
+                <menuItem title="Pin to Top" state="on" identifier="editorPinMenuItem" id="Ryc-RD-9bh">
                     <modifierMask key="keyEquivalentModifierMask"/>
                     <connections>
                         <action selector="pinAction:" target="1107" id="ypv-Ec-ADu"/>
                     </connections>
                 </menuItem>
-                <menuItem title="Markdown" state="on" id="Ejc-Bj-rEL">
+                <menuItem title="Markdown" state="on" identifier="editorMarkdownMenuItem" id="Ejc-Bj-rEL">
                     <modifierMask key="keyEquivalentModifierMask"/>
                     <connections>
                         <action selector="markdownAction:" target="1107" id="LKU-Zl-Thr"/>
                     </connections>
                 </menuItem>
-                <menuItem title="Share" id="iBw-QS-kil">
+                <menuItem title="Share" identifier="editorShareMenuItem" id="iBw-QS-kil">
                     <modifierMask key="keyEquivalentModifierMask"/>
                     <connections>
                         <action selector="shareWasPressed:" target="1107" id="jVE-Kl-d2g"/>
                     </connections>
                 </menuItem>
-                <menuItem title="History" id="7Ox-IO-LLQ">
+                <menuItem title="History" identifier="editorHistoryMenuItem" id="7Ox-IO-LLQ">
                     <modifierMask key="keyEquivalentModifierMask"/>
                     <connections>
                         <action selector="versionsWasPressedWithSender:" target="1107" id="sjU-7F-7ZL"/>
                     </connections>
                 </menuItem>
-                <menuItem title="Move to Trash" id="1z5-RU-iWI">
+                <menuItem title="Move to Trash" identifier="editorTrashMenuItem" id="1z5-RU-iWI">
                     <modifierMask key="keyEquivalentModifierMask"/>
                     <connections>
                         <action selector="deleteAction:" target="1107" id="JWB-Ld-JWN"/>
                     </connections>
                 </menuItem>
                 <menuItem isSeparatorItem="YES" id="bqW-Zj-w17"/>
-                <menuItem title="Publish" id="Lhn-nd-qgk">
+                <menuItem title="Publish" identifier="editorPublishMenuItem" id="Lhn-nd-qgk">
                     <modifierMask key="keyEquivalentModifierMask"/>
                     <connections>
                         <action selector="publishWasPressedWithSender:" target="1107" id="ayi-Lv-26H"/>
                     </connections>
                 </menuItem>
                 <menuItem isSeparatorItem="YES" id="INx-du-7dU"/>
-                <menuItem title="Collaborate" id="avN-8J-w5V" userLabel="Menu Item - Share...">
+                <menuItem title="Collaborate" identifier="editorCollaborateMenuItem" id="avN-8J-w5V" userLabel="Menu Item - Share...">
                     <modifierMask key="keyEquivalentModifierMask"/>
                     <connections>
                         <action selector="collaborateWasPressedWithSender:" target="1107" id="Vov-V1-o59"/>
@@ -162,18 +162,18 @@
                 <menuItem title="Note" id="83">
                     <menu key="submenu" title="Note" id="81">
                         <items>
-                            <menuItem title="New" keyEquivalent="n" id="1654">
+                            <menuItem title="New" keyEquivalent="n" identifier="systemNewNoteMenuItem" id="1654">
                                 <connections>
                                     <action selector="addAction:" target="1107" id="1667"/>
                                 </connections>
                             </menuItem>
-                            <menuItem title="Move to Trash" id="1655">
+                            <menuItem title="Move to Trash" identifier="systemTrashMenuItem" id="1655">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>
                                     <action selector="deleteAction:" target="1107" id="1657"/>
                                 </connections>
                             </menuItem>
-                            <menuItem title="Print…" keyEquivalent="p" id="78">
+                            <menuItem title="Print…" keyEquivalent="p" identifier="systemPrintMenuItem" id="78">
                                 <connections>
                                     <action selector="printAction:" target="1107" id="1666"/>
                                 </connections>

--- a/Simplenote/en.lproj/MainMenu.xib
+++ b/Simplenote/en.lproj/MainMenu.xib
@@ -13,7 +13,7 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <menu title="OtherViews" autoenablesItems="NO" id="nSc-s9-0oY" userLabel="Note More Menu">
+        <menu title="OtherViews" id="nSc-s9-0oY" userLabel="Note More Menu">
             <items>
                 <menuItem title="Pin to Top" state="on" identifier="editorPinMenuItem" id="Ryc-RD-9bh">
                     <modifierMask key="keyEquivalentModifierMask"/>
@@ -1264,7 +1264,6 @@
                 <outlet property="bottomDividerView" destination="xSv-Qg-Lo6" id="76h-Kc-UnK"/>
                 <outlet property="lineLengthMenu" destination="JgX-db-Pi6" id="eVA-hS-cdT"/>
                 <outlet property="moreActionsMenu" destination="nSc-s9-0oY" id="RWb-MR-Re4"/>
-                <outlet property="newItem" destination="1654" id="1658"/>
                 <outlet property="noteEditor" destination="934" id="1108"/>
                 <outlet property="notesArrayController" destination="573" id="1144"/>
                 <outlet property="scrollView" destination="933" id="eqf-0S-fBY"/>

--- a/Simplenote/en.lproj/MainMenu.xib
+++ b/Simplenote/en.lproj/MainMenu.xib
@@ -998,7 +998,7 @@
                                         <rect key="frame" x="0.0" y="570" width="508" height="48"/>
                                         <subviews>
                                             <stackView distribution="fill" orientation="horizontal" alignment="centerY" spacing="25" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="9kE-k3-T1Z">
-                                                <rect key="frame" x="202" y="0.0" width="290" height="48"/>
+                                                <rect key="frame" x="337" y="0.0" width="155" height="48"/>
                                                 <subviews>
                                                     <button toolTip="Preview Markdown" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="OMI-hx-wfj" userLabel="Markdown">
                                                         <rect key="frame" x="0.0" y="14" width="20" height="20"/>
@@ -1014,28 +1014,8 @@
                                                             <action selector="toggleMarkdownView:" target="1107" id="Ch7-3f-k9E"/>
                                                         </connections>
                                                     </button>
-                                                    <button toolTip="History" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="7hm-UJ-0zw" userLabel="History">
-                                                        <rect key="frame" x="45" y="14" width="20" height="20"/>
-                                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="button_history" imagePosition="only" alignment="center" imageScaling="proportionallyUpOrDown" inset="2" id="KJV-0C-wVw">
-                                                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                                            <font key="font" metaFont="system"/>
-                                                        </buttonCell>
-                                                        <connections>
-                                                            <action selector="versionsWasPressedWithSender:" target="1107" id="K52-ey-bNC"/>
-                                                        </connections>
-                                                    </button>
-                                                    <button toolTip="Share" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="qmA-vO-wPh" userLabel="Share">
-                                                        <rect key="frame" x="90" y="14" width="20" height="20"/>
-                                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="button_share" imagePosition="only" alignment="center" imageScaling="proportionallyUpOrDown" inset="2" id="L1E-HD-wfM">
-                                                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                                            <font key="font" metaFont="system"/>
-                                                        </buttonCell>
-                                                        <connections>
-                                                            <action selector="shareNote:" target="1107" id="W9o-Z7-kgJ"/>
-                                                        </connections>
-                                                    </button>
                                                     <button toolTip="Restore" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="fA9-bG-luR" userLabel="Restore">
-                                                        <rect key="frame" x="135" y="14" width="20" height="20"/>
+                                                        <rect key="frame" x="45" y="14" width="20" height="20"/>
                                                         <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="button_restore" imagePosition="only" alignment="center" imageScaling="proportionallyUpOrDown" inset="2" id="X3f-rW-nRp">
                                                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                                             <font key="font" metaFont="system"/>
@@ -1044,18 +1024,7 @@
                                                             <action selector="restoreAction:" target="1107" id="Vpw-i1-WtF"/>
                                                         </connections>
                                                     </button>
-                                                    <button toolTip="Trash" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="mXz-OM-6A3" userLabel="Trash">
-                                                        <rect key="frame" x="180" y="14" width="20" height="20"/>
-                                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="button_trash" imagePosition="only" alignment="center" imageScaling="proportionallyUpOrDown" inset="2" id="ZqN-rU-FdU">
-                                                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                                            <font key="font" metaFont="system"/>
-                                                        </buttonCell>
-                                                        <connections>
-                                                            <action selector="deleteAction:" target="1107" id="OgN-ZB-bHH"/>
-                                                        </connections>
-                                                    </button>
                                                     <button toolTip="Info" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="EXM-Do-Iy7" userLabel="Metrics">
-                                                        <rect key="frame" x="225" y="14" width="20" height="20"/>
                                                         <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="button_info" imagePosition="only" alignment="center" imageScaling="proportionallyUpOrDown" inset="2" id="1oR-T8-cRe">
                                                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                                             <font key="font" metaFont="system"/>
@@ -1065,7 +1034,7 @@
                                                         </connections>
                                                     </button>
                                                     <button toolTip="Info" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="jyK-U4-rcH" userLabel="More">
-                                                        <rect key="frame" x="270" y="14" width="20" height="20"/>
+                                                        <rect key="frame" x="135" y="14" width="20" height="20"/>
                                                         <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="button_ellipsis" imagePosition="only" alignment="center" imageScaling="proportionallyUpOrDown" inset="2" id="fbf-7I-0wJ">
                                                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                                             <font key="font" metaFont="system"/>
@@ -1076,32 +1045,20 @@
                                                     </button>
                                                 </subviews>
                                                 <constraints>
-                                                    <constraint firstItem="7hm-UJ-0zw" firstAttribute="height" secondItem="OMI-hx-wfj" secondAttribute="height" id="4dz-bP-NlX"/>
                                                     <constraint firstItem="EXM-Do-Iy7" firstAttribute="height" secondItem="OMI-hx-wfj" secondAttribute="height" id="6ST-lY-Law"/>
-                                                    <constraint firstItem="mXz-OM-6A3" firstAttribute="width" secondItem="OMI-hx-wfj" secondAttribute="width" id="78W-gy-0Mk"/>
                                                     <constraint firstItem="fA9-bG-luR" firstAttribute="width" secondItem="OMI-hx-wfj" secondAttribute="width" id="F8s-23-6zM"/>
                                                     <constraint firstItem="jyK-U4-rcH" firstAttribute="height" secondItem="OMI-hx-wfj" secondAttribute="height" id="Nuo-l8-Qgs"/>
                                                     <constraint firstItem="jyK-U4-rcH" firstAttribute="width" secondItem="OMI-hx-wfj" secondAttribute="width" id="S7e-rG-avT"/>
                                                     <constraint firstItem="EXM-Do-Iy7" firstAttribute="width" secondItem="OMI-hx-wfj" secondAttribute="width" id="SzX-6c-s3o"/>
-                                                    <constraint firstItem="qmA-vO-wPh" firstAttribute="height" secondItem="OMI-hx-wfj" secondAttribute="height" id="T88-WW-K9W"/>
-                                                    <constraint firstItem="7hm-UJ-0zw" firstAttribute="width" secondItem="OMI-hx-wfj" secondAttribute="width" id="YVA-ky-JFG"/>
                                                     <constraint firstItem="fA9-bG-luR" firstAttribute="height" secondItem="OMI-hx-wfj" secondAttribute="height" id="bqG-7k-aNw"/>
-                                                    <constraint firstItem="mXz-OM-6A3" firstAttribute="height" secondItem="OMI-hx-wfj" secondAttribute="height" id="jj1-ao-yfJ"/>
-                                                    <constraint firstItem="qmA-vO-wPh" firstAttribute="width" secondItem="OMI-hx-wfj" secondAttribute="width" id="kV9-RK-Fch"/>
                                                 </constraints>
                                                 <visibilityPriorities>
                                                     <integer value="1000"/>
                                                     <integer value="1000"/>
                                                     <integer value="1000"/>
                                                     <integer value="1000"/>
-                                                    <integer value="1000"/>
-                                                    <integer value="1000"/>
-                                                    <integer value="1000"/>
                                                 </visibilityPriorities>
                                                 <customSpacing>
-                                                    <real value="3.4028234663852886e+38"/>
-                                                    <real value="3.4028234663852886e+38"/>
-                                                    <real value="3.4028234663852886e+38"/>
                                                     <real value="3.4028234663852886e+38"/>
                                                     <real value="3.4028234663852886e+38"/>
                                                     <real value="3.4028234663852886e+38"/>
@@ -1116,14 +1073,11 @@
                                             <constraint firstAttribute="trailing" secondItem="9kE-k3-T1Z" secondAttribute="trailing" constant="16" id="m9W-Sv-7fY"/>
                                         </constraints>
                                         <connections>
-                                            <outlet property="historyButton" destination="7hm-UJ-0zw" id="2dg-q8-LW8"/>
                                             <outlet property="metricsButton" destination="EXM-Do-Iy7" id="msh-O6-FFv"/>
                                             <outlet property="moreButton" destination="jyK-U4-rcH" id="0zK-dJ-ADT"/>
                                             <outlet property="previewButton" destination="OMI-hx-wfj" id="CUq-cy-7jJ"/>
                                             <outlet property="restoreButton" destination="fA9-bG-luR" id="MWN-e9-omM"/>
-                                            <outlet property="shareButton" destination="qmA-vO-wPh" id="YxO-si-thc"/>
                                             <outlet property="stackView" destination="9kE-k3-T1Z" id="Wzq-cS-z25"/>
-                                            <outlet property="trashButton" destination="mXz-OM-6A3" id="Qhb-kM-MQx"/>
                                         </connections>
                                     </customView>
                                     <scrollView borderType="none" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" horizontalScrollElasticity="none" translatesAutoresizingMaskIntoConstraints="NO" id="933">
@@ -1336,13 +1290,10 @@
     </objects>
     <resources>
         <image name="button_ellipsis" width="24" height="24"/>
-        <image name="button_history" width="24" height="24"/>
         <image name="button_info" width="24" height="24"/>
         <image name="button_new_note" width="24" height="24"/>
         <image name="button_preview_off" width="24" height="24"/>
         <image name="button_restore" width="24" height="24"/>
-        <image name="button_share" width="24" height="24"/>
-        <image name="button_trash" width="24" height="24"/>
         <image name="icon_pin" width="16" height="16"/>
         <image name="icon_shared" width="16" height="16"/>
     </resources>

--- a/Simplenote/en.lproj/MainMenu.xib
+++ b/Simplenote/en.lproj/MainMenu.xib
@@ -30,7 +30,7 @@
                 <menuItem title="Share" identifier="editorShareMenuItem" id="iBw-QS-kil">
                     <modifierMask key="keyEquivalentModifierMask"/>
                     <connections>
-                        <action selector="shareWasPressed:" target="1107" id="jVE-Kl-d2g"/>
+                        <action selector="shareWasPressedWithSender:" target="1107" id="GhA-To-o26"/>
                     </connections>
                 </menuItem>
                 <menuItem title="History" identifier="editorHistoryMenuItem" id="7Ox-IO-LLQ">


### PR DESCRIPTION
### Description:
In this PR we're refreshing the ToolbarView, and relocating several top level actions into the "More Actions" Menu.

@aerych Sir!! May I bug you with this one?
Apologies about the extensive checklists, I promise it's super quick to verify!!

**Thank you!!!**

Ref. #458 

### Details:
- Moved the following Actions from the **ToolbarView** into the **More Actions** menu (three dots button, top right corner!): **[ Share, History,  Move to Trash, Publish ]**
- Renamed **ShareViewController > CollaborateViewController**
- Dropped several **NSMenuItem** Outlets from the Note Editor
- **Upgraded the NSMenuValidation** handler, so that all of the logic relies on the NSMenuItem identifier(S)
- And of course, **wired new NSMenuItem Identifiers**!

### Scenario: Single Selection / Non Trashed
1. Click over the All Notes filter
2. Click over to **select a single note**
3. Click over the top right button `...` to reveal More Actions
4. Verify the state of the Menu Rows please!
   - [x] **Pin** is enabled
   - [x] **Pin** displays a checkmark whenever the Note is pinned
   - [x] **Markdown** is enabled
   - [x] **Markdown** displays a checkmark whenever MD is enabled for such Note
   - [x] **Share** is enabled whenever the note has content
   - [x] **History** is enabled when you're **not previewing Markdown**
   - [x] **Trash** is enabled
   - [x] **Publish** is enabled whenever the note has content
   - [ ] **Collaborate** is enabled whenever there's a note onscreen
5. Verify that clicking over each action works as expected:
   - [x] **Pin** toggles the pinned state
   - [x] **Markdown** toggles the Markdown state (a new icon should appear in the toolbar)
   - [x] **Share** reveals the macOS Share Sheet
   - [x] **History** reveals a history slider popover
   - [x] **Trash** moves the selected note to Trash
   - [x] **Publish** reveals the Publish Popover
   - [x] **Collaborate** reveals a popover in the Tags Editor area

### Scenario: Multiple Selection
1. Click over the All Notes filter
2. CMD + Click to **select multiple notes**
3. Click over the top right button `...` to reveal More Actions
4. Verify the state of the Menu Rows please!
   - [x] **Enabled Actions:** [Pin, Markdown Trash]
   - [x] **Disabled Actions:** [Share, History, Publish, Collaborate]
4. Verify that clicking over each action works as expected:
   - [x] **Pin** toggles the pinned state of the selected notes
   - [x] **Markdown** toggles the Markdown flag of the selected notes
   - [x] **Trash** moves the selected notes to Trash

### Scenario: System Menu > Note
1. Click over the All Notes filter
2. Click over the System Menu **Note**
   - [x] Verify that all of the menu items are enabled: [New, Trash, Print]
   - [x] Verify that all of these menu items are disabled when viewing Trashed Notes

### Release
`RELEASE-NOTES.txt` was updated in f247f71 with:
 
> Relocated Editor Actions into the new More Actions Menu


### Screenshots
<img width="158" alt="Screen Shot 2020-07-02 at 5 49 16 PM" src="https://user-images.githubusercontent.com/1195260/86407947-64c07800-bc8c-11ea-9b72-6e0df2df170d.png">
