### PR TITLE
Reversing Markdown Preview Icon

### DIFF
--- a/Simplenote/ToolbarState.swift
+++ b/Simplenote/ToolbarState.swift
@@ -88,7 +88,7 @@ extension ToolbarState {
     }
 
     var previewActionImage: NSImage? {
-        let name: NSImage.Name = isDisplayingMarkdown ? .previewOn : .previewOff
+        let name: NSImage.Name = isDisplayingMarkdown ? .previewOff : .previewOn
         return NSImage(named: name)
     }
 }


### PR DESCRIPTION
### Fix
In this PR we're inverting the Markdown Preview asset, so that it matches the other apps.

@etoledom Sorry, me again!!!! (thank you!!)

Closes #567

### Test
1. Open any note
2. Click over the top right icon
3. Enable Markdown Formatting

- [x] Verify that whenever you're editing, the open eye Icon shows up in the toolbar <img width="14" alt="Screen Shot 2020-07-03 at 12 14 55 PM" src="https://user-images.githubusercontent.com/1195260/86481676-d5b46e00-bd26-11ea-9302-366d1329a1cc.png">
- [x] Verify that when you click over the MD Preview button, the image gets switched to a crossed eye


### Release
These changes do not require release notes.
