### PR TITLE
RTL Support: Tags Editor

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 - Implements Untagged Notes Filter
 - New Note Metrics Interface
 - Relocated Editor Actions into the new More Actions Menu
+- Fixed Tags Editor RTL support
 
 1.11.0
 ------

--- a/Simplenote/TagAttachmentCell.swift
+++ b/Simplenote/TagAttachmentCell.swift
@@ -102,7 +102,7 @@ private extension TagAttachmentCell {
         updated.origin.x += Metrics.textInsets.left + Metrics.bgInsets.left
         updated.origin.y += Metrics.textInsets.top + Metrics.bgInsets.top
 
-        updated.size.width -= Metrics.textInsets.left + Metrics.textInsets.right
+        updated.size.width -= Metrics.textInsets.left + Metrics.textInsets.right + Metrics.bgInsets.left + Metrics.bgInsets.right
         updated.size.height -= Metrics.textInsets.top + Metrics.textInsets.bottom
 
         nsStringValue.draw(in: updated, withAttributes: attributes)

--- a/Simplenote/en.lproj/MainMenu.xib
+++ b/Simplenote/en.lproj/MainMenu.xib
@@ -1155,9 +1155,9 @@
                                                     <rect key="frame" x="0.0" y="0.0" width="462" height="25"/>
                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                     <subviews>
-                                                        <tokenField horizontalHuggingPriority="750" verticalHuggingPriority="750" placeholderIntrinsicWidth="462" placeholderIntrinsicHeight="25" translatesAutoresizingMaskIntoConstraints="NO" id="UWL-9x-FH2" customClass="TagsField" customModule="Simplenote" customModuleProvider="target">
+                                                        <tokenField horizontalHuggingPriority="750" verticalHuggingPriority="750" placeholderIntrinsicWidth="462" placeholderIntrinsicHeight="25" mirrorLayoutDirectionWhenInternationalizing="always" translatesAutoresizingMaskIntoConstraints="NO" id="UWL-9x-FH2" customClass="TagsField" customModule="Simplenote" customModuleProvider="target">
                                                             <rect key="frame" x="-2" y="0.0" width="466" height="25"/>
-                                                            <tokenFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" alignment="left" allowsEditingTextAttributes="YES" id="cU0-Np-WqS" customClass="TagsFieldCell" customModule="Simplenote" customModuleProvider="target">
+                                                            <tokenFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" baseWritingDirection="leftToRight" alignment="left" allowsEditingTextAttributes="YES" id="cU0-Np-WqS" customClass="TagsFieldCell" customModule="Simplenote" customModuleProvider="target">
                                                                 <font key="font" metaFont="label" size="12"/>
                                                                 <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                                 <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>


### PR DESCRIPTION
### Fix
In this PR we're fixing the way the Tags Editor renders in a RTL environment.

@aerych May I bug you with a really cool PR?
Thanks in advance sir!!

Ref. #458 

### Details:
1. Fixed **TagAttachmentCell**'s text frame.width, so that the text is perfectly centered
2. **TagsEditor / IB:**  forced **LTR** and enabled **Mirror when in RTL** 

### Test
1. In Xcode
  A. Click **Edit Scheme** > **Options**
  B. Set **Application Language = Right to Left**
2. Launch Simplenote + Log In

- [x] Verify the Tags Editor is pinned to the right hand side of the screen 🔥

### Release
`RELEASE-NOTES.txt` was updated in f71c7f4 with:
 
> Fixed Tags Editor RTL support


### Screenshots: Before
<img width="400" src="https://user-images.githubusercontent.com/1195260/86495658-ae729680-bd50-11ea-9538-04cd7ec46fee.jpg">

### Screenshots: After
<img width="400" src="https://user-images.githubusercontent.com/1195260/86495675-b9c5c200-bd50-11ea-9f38-e5cc0d60f031.jpg">
