### PR TITLE
Tags Editor: Tab Support

### DIFF
--- a/Simplenote/NoteEditorViewController+Swift.swift
+++ b/Simplenote/NoteEditorViewController+Swift.swift
@@ -28,6 +28,7 @@ extension NoteEditorViewController {
         tagsField.focusRingType = .none
         tagsField.font = .simplenoteSecondaryTextFont
         tagsField.placeholderText = NSLocalizedString("Add tag...", comment: "Placeholder text in the Tags View")
+        tagsField.nextKeyView = noteEditor
     }
 }
 


### PR DESCRIPTION
### Fix
In this PR we're wiring the **TagsEditor's** nextKeyView: whenever **TAB** is pressed in the tags editor area, the main Note Editor will become first responder.

cc @danielebogo Daniele! May I bug you with a really quick one? (Thank you!!)

Thank you @elibud 👏 !!

### Test
1. Click over the Tags Editor area
2. Press **TAB**

- [x] Verify the Note Editor is, now, the first responder.

### Release
These changes do not require release notes.
