### PR TITLE
Fix: Negative word count

### DIFF
--- a/Simplenote/NoteMetrics.swift
+++ b/Simplenote/NoteMetrics.swift
@@ -28,9 +28,10 @@ struct NoteMetrics {
     init(notes: [Note]) {
         let contents = notes.compactMap({ $0.content }).reduce("", +)
         let dateProviderNote = notes.count == 1 ? notes.first : nil
+        let wordCount = NSSpellChecker.shared.countWords(in: contents, language: nil)
 
         numberOfChars = contents.count
-        numberOfWords = NSSpellChecker.shared.countWords(in: contents, language: nil)
+        numberOfWords = wordCount != -1 ? wordCount : .zero
 
         creationDate = dateProviderNote?.creationDate.map {
             DateFormatter.metricsFormatter.string(from: $0)


### PR DESCRIPTION
### Fix
In this PR we're fixing a glitch that caused negative word counts to show.

@danielebogo Sir!! May I bug you with a really quick PR?
Thanks in advance!!

Closes #596

### Test
1. Add a new (and empty) Note
2. Click over the (i) icon

- [ ] Verify the word count is zero!

### Release
These changes do not require release notes.
