### PR TITLE
Prevents presenting multiple Metrics Popovers

### DIFF
--- a/Simplenote/NoteEditorViewController+Swift.swift
+++ b/Simplenote/NoteEditorViewController+Swift.swift
@@ -242,7 +242,7 @@ extension NoteEditorViewController {
 
     @IBAction
     func metricsWasPressed(sender: Any) {
-        guard isPresentingMetricsPopover == false, let notes = selectedNotes else {
+        guard !dismissMetricsPopoverIfNeeded(), let notes = selectedNotes else {
             return
         }
 
@@ -317,12 +317,16 @@ extension NoteEditorViewController {
         present(viewController, asPopoverRelativeTo: sourceView.bounds, of: sourceView, preferredEdge: .maxY, behavior: .transient)
     }
 
-    var isPresentingMetricsPopover: Bool {
-        guard let presentedViewControllers = presentedViewControllers else {
+    func dismissMetricsPopoverIfNeeded() -> Bool {
+        guard let metricsViewController = metricsViewController else {
             return false
         }
 
-        return presentedViewControllers.contains { $0 is MetricsViewController }
+        dismiss(metricsViewController)
+        return true
+    }
+    var metricsViewController: NSViewController? {
+        presentedViewControllers?.first { $0 is MetricsViewController }
     }
 }
 

--- a/Simplenote/NoteEditorViewController+Swift.swift
+++ b/Simplenote/NoteEditorViewController+Swift.swift
@@ -325,6 +325,7 @@ extension NoteEditorViewController {
         dismiss(metricsViewController)
         return true
     }
+
     var metricsViewController: NSViewController? {
         presentedViewControllers?.first { $0 is MetricsViewController }
     }

--- a/Simplenote/NoteEditorViewController+Swift.swift
+++ b/Simplenote/NoteEditorViewController+Swift.swift
@@ -242,7 +242,7 @@ extension NoteEditorViewController {
 
     @IBAction
     func metricsWasPressed(sender: Any) {
-        guard let notes = selectedNotes else {
+        guard isPresentingMetricsPopover == false, let notes = selectedNotes else {
             return
         }
 
@@ -315,6 +315,14 @@ extension NoteEditorViewController {
         let viewController = VersionsViewController(note: note)
         viewController.delegate = self
         present(viewController, asPopoverRelativeTo: sourceView.bounds, of: sourceView, preferredEdge: .maxY, behavior: .transient)
+    }
+
+    var isPresentingMetricsPopover: Bool {
+        guard let presentedViewControllers = presentedViewControllers else {
+            return false
+        }
+
+        return presentedViewControllers.contains { $0 is MetricsViewController }
     }
 }
 


### PR DESCRIPTION
### Fix
In this PR we're preventing the Note Editor from presenting multiple Metrics Popovers.

@aerych Sir!! May I trouble you with a quick fix?
Thank youuu!!

Closes #595

### Test
1. Create or open a note.
2. Double-click the (i) icon.

- [x] Verify a single Metrics Popover is animated!

### Release
These changes do not require release notes.
