### PR TITLE
Localization Script: Picking up Simperium Strings

### DIFF
--- a/Scripts/localize.py
+++ b/Scripts/localize.py
@@ -132,7 +132,7 @@ def localize_sources(path):
     old = original + '.old'
     new = original + '.new'
 
-    genstrings_cmd = 'genstrings -q -o "%s" `find ./Simplenote -name "*.m" -o -name "*.swift"`'
+    genstrings_cmd = 'genstrings -q -o "%s" `find ./Simplenote ./Pods/Simperium-OSX/*/SPAuthentication* -name "*.m" -o -name "*.swift"`'
 
     if os.path.isfile(original):
         os.rename(original, old)


### PR DESCRIPTION
### Fix
In this PR we're patching up the `Localize` script, so that Simperium Auth Strings are picked up.

@aerych sir!! May I bug you with this fun PR?
Thanks in advance!!

Ref. #8

### Test
1. Run `./Scripts/localize.py`

- [x] Verify the following file has changes `Simplenote/en.lproj/Localizable.strings`
- [x] Verify that the new strings are Auth-Y

### Release
These changes do not require release notes.
