### PR TITLE
TagListState: rowAtIndex bounds check

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 1.13.0
 ------
 - Updated Tags limit to up to 256 characters
+- Fixed a crash while handling right clicks in the Tags List
 
 1.12.0
 ------

--- a/Simplenote/TagListState.swift
+++ b/Simplenote/TagListState.swift
@@ -38,8 +38,12 @@ extension TagListState {
 
     /// Returns the `TagListRow` entity at the specified Index
     ///
-    func rowAtIndex(_ index: Int) -> TagListRow {
-        rows[index]
+    func rowAtIndex(_ index: Int) -> TagListRow? {
+        guard index > .zero && index < rows.count else {
+            return nil
+        }
+
+        return rows[index]
     }
 
     /// Returns the location of the `All Notes` row.

--- a/Simplenote/TagListViewController+Swift.swift
+++ b/Simplenote/TagListViewController+Swift.swift
@@ -68,6 +68,8 @@ extension TagListViewController: NSTableViewDataSource, SPTableViewDelegate {
             return tagTableViewCell(for: tag)
         case .untagged:
             return untaggedTableViewCell()
+        default:
+            return nil
         }
     }
 
@@ -89,7 +91,7 @@ extension TagListViewController: NSTableViewDataSource, SPTableViewDelegate {
     }
 
     public func tableView(_ tableView: NSTableView, shouldSelectRow row: Int) -> Bool {
-        state.rowAtIndex(row).isSelectable
+        state.rowAtIndex(row)?.isSelectable ?? false
     }
 
     public func tableViewSelectionDidChange(_ notification: Notification) {


### PR DESCRIPTION
### Fix
In this PR we're fixing a bounds check, responsible of a crash when dealing with right click events.

@aerych You game for an old school Out of Bounds fix?
Thank you sir!!

Closes #619

### Test
1. Log into Simplenote
2. Right click (anywhere) in the Tags List's **empty area** at the bottom
 > Yes, the trick is to right click in an empty area!

- [x] Verify Simplenote doesn't crash!

### Release
`RELEASE-NOTES.txt` was updated in d287a51 with:
 
> Fixed a crash while handling right clicks in the Tags List
