### PR TITLE
Tags List: Prevents selecting "Unselectable" cells

### DIFF
--- a/Simplenote/SPTableView.m
+++ b/Simplenote/SPTableView.m
@@ -35,7 +35,10 @@
     NSPoint mousePoint = [self convertPoint:[theEvent locationInWindow] fromView:nil];
     NSInteger row = [self rowAtPoint:mousePoint];
     NSInteger column = [self columnAtPoint:mousePoint];
-    [self selectRowIndexes:[NSIndexSet indexSetWithIndex:row] byExtendingSelection:NO];
+
+    if ([self.delegate tableView:self shouldSelectRow:row]) {
+        [self selectRowIndexes:[NSIndexSet indexSetWithIndex:row] byExtendingSelection:NO];
+    }
 
     if ([self.delegate respondsToSelector:@selector(tableView:menuForTableColumn:row:)] == false) {
         return [super menuForEvent:theEvent];


### PR DESCRIPTION
### Fix
In this PR we're fixing a bug in which "Unselectable" cells might end up highlighted.

@danielebogo Sir!! can I bug you with a really simple fix?
Thanks in advance!!

### Test
1. Launch Simplenote
2. Locate, in the left hand side panel, the `TAGS` header  (you must have at least one tag
3. Right click over the `TAGS` header

- [x] Verify the `TAGS` header does not become highlighted.

### Release
These changes do not require release notes.
