### PR TITLE
Bugfix: All Notes AWOL

### DIFF
--- a/Simplenote/TagListState.swift
+++ b/Simplenote/TagListState.swift
@@ -39,7 +39,7 @@ extension TagListState {
     /// Returns the `TagListRow` entity at the specified Index
     ///
     func rowAtIndex(_ index: Int) -> TagListRow? {
-        guard index > .zero && index < rows.count else {
+        guard index >= .zero && index < rows.count else {
             return nil
         }
 


### PR DESCRIPTION
### Fix
In this PR we're fixing a bounds check that caused the `All Notes` row to go AWOL.

This is a side effect of #623, and I totally missed the glitch!!

cc @aerych Sir, can I bug you with a quick fix?
Thank you!!

### Test
- [x] Verify the `All Notes` row is always visible
- [x] Verify you can click anywhere else, and back into `All Notes`

### Release
These changes do not require release notes.
