### PR TITLE
NoteEditorViewController: Nullability Specifiers

### DIFF
--- a/Simplenote/NoteEditorViewController+Swift.swift
+++ b/Simplenote/NoteEditorViewController+Swift.swift
@@ -58,8 +58,10 @@ extension NoteEditorViewController {
             return
         }
 
-        toolbarViewTopConstraint = toolbarView.topAnchor.constraint(equalTo: layoutGuide.topAnchor)
-        toolbarViewTopConstraint.isActive = true
+        let newTopConstraint = toolbarView.topAnchor.constraint(equalTo: layoutGuide.topAnchor)
+        newTopConstraint.isActive = true
+
+        toolbarViewTopConstraint = newTopConstraint
     }
 }
 
@@ -96,8 +98,7 @@ extension NoteEditorViewController {
     /// Indicates if there are multiple selected notes
     ///
     var isSelectingMultipleNotes: Bool {
-        let numberOfSelectedNotes = selectedNotes?.count ?? .zero
-        return numberOfSelectedNotes > 1
+        selectedNotes.count > 1
     }
 }
 
@@ -254,11 +255,11 @@ extension NoteEditorViewController {
 
     @IBAction
     func metricsWasPressed(sender: Any) {
-        guard !dismissMetricsPopoverIfNeeded(), let notes = selectedNotes else {
+        guard !dismissMetricsPopoverIfNeeded() else {
             return
         }
 
-        displayMetricsPopover(from: toolbarView.metricsButton, for: notes)
+        displayMetricsPopover(from: toolbarView.metricsButton, for: selectedNotes)
     }
 
     @IBAction
@@ -421,6 +422,10 @@ extension NoteEditorViewController {
 extension NoteEditorViewController: TagsFieldDelegate {
 
     public func tokenField(_ tokenField: NSTokenField, completionsForSubstring substring: String, indexOfToken tokenIndex: Int, indexOfSelectedItem selectedIndex: UnsafeMutablePointer<Int>?) -> [Any]? {
+        guard let note = note else {
+            return []
+        }
+
         // Disable Autocomplete:
         // We cannot control the direction of the suggestions layer. Fullscreen causes such element to be offscreen.
         guard tokenField.window?.styleMask.contains(.fullScreen) == false else {
@@ -459,12 +464,20 @@ extension NoteEditorViewController: TagsFieldDelegate {
 extension NoteEditorViewController: PublishViewControllerDelegate {
 
     func publishControllerDidClickPublish(_ controller: PublishViewController) {
+        guard let note = note else {
+            return
+        }
+
         SPTracker.trackEditorNotePublished()
         note.published = true
         save()
     }
 
     func publishControllerDidClickUnpublish(_ controller: PublishViewController) {
+        guard let note = note else {
+            return
+        }
+
         SPTracker.trackEditorNoteUnpublished()
         note.published = false
         save()
@@ -481,6 +494,10 @@ extension NoteEditorViewController: VersionsViewControllerDelegate {
     }
 
     func versionsControllerDidClickRestore(_ controller: VersionsViewController) {
+        guard let note = note else {
+            return
+        }
+
         note.content = noteEditor.plainTextContent()
         save()
 

--- a/Simplenote/NoteEditorViewController.h
+++ b/Simplenote/NoteEditorViewController.h
@@ -17,6 +17,9 @@
 @class TagsField;
 @class ToolbarView;
 
+
+NS_ASSUME_NONNULL_BEGIN
+
 typedef NS_ENUM(NSInteger, NoteFontSize) {
     NoteFontSizeMinimum = 10,
     NoteFontSizeNormal = 14,
@@ -24,17 +27,14 @@ typedef NS_ENUM(NSInteger, NoteFontSize) {
 };
 
 
-#pragma mark ====================================================================================
-#pragma mark Notifications
-#pragma mark ====================================================================================
+
+#pragma mark - Notifications
 
 extern NSString * const SPTagAddedFromEditorNotificationName;
 extern NSString * const SPWillAddNewNoteNotificationName;
 
 
-#pragma mark ====================================================================================
-#pragma mark NoteEditorViewController
-#pragma mark ====================================================================================
+#pragma mark - NoteEditorViewController
 
 @interface NoteEditorViewController : NSViewController
 {
@@ -50,19 +50,19 @@ extern NSString * const SPWillAddNewNoteNotificationName;
 @property (nonatomic, strong) IBOutlet ToolbarView                              *toolbarView;
 @property (nonatomic, strong) IBOutlet NSImageView                              *statusImageView;
 @property (nonatomic, strong) IBOutlet NSTextField                              *statusTextField;
-@property (nonatomic,   weak) IBOutlet SPTextView                               *noteEditor;
-@property (nonatomic,   weak) IBOutlet NSScrollView                             *scrollView;
-@property (nonatomic,   weak) IBOutlet TagsField                                *tagsField;
+@property (nonatomic, strong) IBOutlet SPTextView                               *noteEditor;
+@property (nonatomic, strong) IBOutlet NSScrollView                             *scrollView;
+@property (nonatomic, strong) IBOutlet TagsField                                *tagsField;
 
 @property (nonatomic, strong, readonly) MarkdownViewController                  *markdownViewController;
 @property (nonatomic, strong, readonly) NSArray<Note *>                         *selectedNotes;
 @property (nonatomic, assign, readonly) BOOL                                    viewingTrash;
-@property (nonatomic, strong) NSLayoutConstraint                                *toolbarViewTopConstraint;
+@property (nonatomic, strong, nullable) NSLayoutConstraint                      *toolbarViewTopConstraint;
 @property (nonatomic,   weak) Note                                              *note;
 
 - (void)save;
-- (void)displayNote:(Note *)selectedNote;
-- (void)displayNotes:(NSArray *)selectedNotes;
+- (void)displayNote:(nullable Note *)selectedNote;
+- (void)displayNotes:(NSArray<Note *> *)selectedNotes;
 - (void)didReceiveNewContent;
 - (void)willReceiveNewContent;
 - (void)applyStyle;
@@ -77,3 +77,6 @@ extern NSString * const SPWillAddNewNoteNotificationName;
 - (IBAction)insertChecklistAction:(id)sender;
 
 @end
+
+NS_ASSUME_NONNULL_END
+

--- a/Simplenote/NoteEditorViewController.m
+++ b/Simplenote/NoteEditorViewController.m
@@ -684,7 +684,7 @@ static NSString * const SPMarkdownPreferencesKey        = @"kMarkdownPreferences
     [self stopObservingEditorProperties:self.noteEditor];
     [self startObservingEditorProperties:editor];
 
-	_noteEditor = editor;
+    _noteEditor = editor;
 }
 
 - (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context


### PR DESCRIPTION
### Details
1. **NoteEditorViewController** gets nullability specifiers
2. Few NSArray(s) here and there got the generics treatment 😄 
3. We've also split the `setNoteEditor` setter

@aerych Sir!! Can I bug you with this one? 
Thankyooou!!!

Ref. #626

### Test
- [x] Verify the main window's layout looks super
- [x] Verify that after selecting multiple notes (CMD + Click) the menu item `Note > Move to Trash` is enabled
- [x] Verify that after selecting multiple notes (CMD + Click) you can click the `( i )` button, and the Metrics show up
- [x] Verify that Publish / Unpublish looks good
- [x] Verify the Versions picker (History) shows up as expected

### Release
These changes do not require release notes.
