### PR TITLE
Editor: Decoupling from Notes List

### DIFF
--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -252,6 +252,8 @@
 		B5B17F3A2425668400DD5B34 /* NSAttributedString+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5B17F392425668400DD5B34 /* NSAttributedString+Simplenote.swift */; };
 		B5B17F3B2425668400DD5B34 /* NSAttributedString+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5B17F392425668400DD5B34 /* NSAttributedString+Simplenote.swift */; };
 		B5B5F33D243244F100F31720 /* TextViewInputHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5B5F33C243244F100F31720 /* TextViewInputHandlerTests.swift */; };
+		B5BB8CD424DB51670024E4C5 /* NSSearchField+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5BB8CD324DB51670024E4C5 /* NSSearchField+Simplenote.swift */; };
+		B5BB8CD524DB51670024E4C5 /* NSSearchField+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5BB8CD324DB51670024E4C5 /* NSSearchField+Simplenote.swift */; };
 		B5BD016B1897552500753208 /* JSONKit+Simplenote.m in Sources */ = {isa = PBXBuildFile; fileRef = B59E812E1877C802005ADDCF /* JSONKit+Simplenote.m */; };
 		B5C19D8B243D30690014086C /* VersionsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = B5C19D8A243D30690014086C /* VersionsViewController.xib */; };
 		B5C19D8C243D30690014086C /* VersionsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = B5C19D8A243D30690014086C /* VersionsViewController.xib */; };
@@ -608,6 +610,7 @@
 		B5B17F372425651700DD5B34 /* TestConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestConstants.swift; sourceTree = "<group>"; };
 		B5B17F392425668400DD5B34 /* NSAttributedString+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSAttributedString+Simplenote.swift"; sourceTree = "<group>"; };
 		B5B5F33C243244F100F31720 /* TextViewInputHandlerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextViewInputHandlerTests.swift; sourceTree = "<group>"; };
+		B5BB8CD324DB51670024E4C5 /* NSSearchField+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSSearchField+Simplenote.swift"; sourceTree = "<group>"; };
 		B5C19D8A243D30690014086C /* VersionsViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = VersionsViewController.xib; sourceTree = "<group>"; };
 		B5C1F0AB242E9A9800A627E3 /* MockupTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockupTextView.swift; sourceTree = "<group>"; };
 		B5C7DD3C243E1F1900BEE354 /* VersionsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VersionsViewController.swift; sourceTree = "<group>"; };
@@ -1010,6 +1013,7 @@
 				B5A2F1EF2432DE54003B29C6 /* NSRange+Simplenote.swift */,
 				B5985ACD24293E360044EDE9 /* NSRegularExpression+Simplenote.swift */,
 				B5919363245A7AD300A70C0C /* NSScreen+Simplenote.swift */,
+				B5BB8CD324DB51670024E4C5 /* NSSearchField+Simplenote.swift */,
 				B5117997242036B0005F8936 /* NSString+Simplenote.swift */,
 				B5E086372448EE9D00DEF476 /* NSTableView+Simplenote.swift */,
 				B5E0862B2448B69B00DEF476 /* NSTableViewCell+Simplenote.swift */,
@@ -1750,6 +1754,7 @@
 				B5E0862F2448E58C00DEF476 /* NSImageName+Simplenote.swift in Sources */,
 				B54F9A6724D0B21D00BCF754 /* NSNotification+Simplenote.swift in Sources */,
 				3712FC8E1FE1ACAA008544AC /* Theme.swift in Sources */,
+				B5BB8CD424DB51670024E4C5 /* NSSearchField+Simplenote.swift in Sources */,
 				37D4DD6A20B3574D00C225EA /* WPAuthHandler.m in Sources */,
 				375D294821E033D1007AB25A /* html_blocks.c in Sources */,
 				71DCEBE7152E2ED1002744C0 /* NSMutableAttributedString+Styling.m in Sources */,
@@ -1883,6 +1888,7 @@
 				B54F9A6824D0B21D00BCF754 /* NSNotification+Simplenote.swift in Sources */,
 				B532F8A820C71C1000EA3506 /* WPAuthHandler.m in Sources */,
 				466FFEC117CC10A800399652 /* NSMutableAttributedString+Styling.m in Sources */,
+				B5BB8CD524DB51670024E4C5 /* NSSearchField+Simplenote.swift in Sources */,
 				375D294921E033D1007AB25A /* html_blocks.c in Sources */,
 				B529F7B624586D8700B168F1 /* MarkdownViewController.swift in Sources */,
 				B5B17F3B2425668400DD5B34 /* NSAttributedString+Simplenote.swift in Sources */,

--- a/Simplenote/Base.lproj/MainMenu.xib
+++ b/Simplenote/Base.lproj/MainMenu.xib
@@ -1467,11 +1467,9 @@
                 <outlet property="lineLengthMenu" destination="JgX-db-Pi6" id="eVA-hS-cdT"/>
                 <outlet property="moreActionsMenu" destination="nSc-s9-0oY" id="RWb-MR-Re4"/>
                 <outlet property="noteEditor" destination="934" id="1108"/>
-                <outlet property="notesArrayController" destination="573" id="1144"/>
                 <outlet property="scrollView" destination="933" id="eqf-0S-fBY"/>
                 <outlet property="statusImageView" destination="1447" id="LVq-dS-TaS"/>
                 <outlet property="statusTextField" destination="faw-Qh-Cm9" id="gWO-rO-vyS"/>
-                <outlet property="tableView" destination="561" id="1282"/>
                 <outlet property="tagsField" destination="UWL-9x-FH2" id="8o3-nm-rjz"/>
                 <outlet property="toolbarView" destination="914" id="AVi-fa-Q7n"/>
                 <outlet property="topDividerView" destination="qdg-eJ-cRo" id="ERd-6j-k2c"/>

--- a/Simplenote/NSSearchField+Simplenote.swift
+++ b/Simplenote/NSSearchField+Simplenote.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+
+// MARK: - NSSearchField Methods
+//
+extension NSSearchField {
+
+    func cancelSearch() {
+        stringValue = ""
+
+        let searchCell = cell as? NSSearchFieldCell
+        searchCell?.cancelButtonCell?.performClick(self)
+    }
+}

--- a/Simplenote/NoteEditorViewController.h
+++ b/Simplenote/NoteEditorViewController.h
@@ -31,7 +31,7 @@ typedef NS_ENUM(NSInteger, NoteFontSize) {
 
 #pragma mark - NoteEditorControllerDelegate
 
-@protocol NoteControllerEditorDelegate <NSObject>
+@protocol EditorControllerNoteActionsDelegate <NSObject>
 - (void)editorController:(NoteEditorViewController *)controller addedNoteWithSimperiumKey:(NSString *)simperiumKey;
 - (void)editorController:(NoteEditorViewController *)controller pinnedNoteWithSimperiumKey:(NSString *)simperiumKey;
 - (void)editorController:(NoteEditorViewController *)controller restoredNoteWithSimperiumKey:(NSString *)simperiumKey;
@@ -39,7 +39,7 @@ typedef NS_ENUM(NSInteger, NoteFontSize) {
 - (void)editorController:(NoteEditorViewController *)controller deletedNoteWithSimperiumKey:(NSString *)simperiumKey;
 @end
 
-@protocol NoteControllerTagsDelegate <NSObject>
+@protocol EditorControllerTagActionsDelegate <NSObject>
 - (void)editorController:(NoteEditorViewController *)controller didAddNewTag:(NSString *)tag;
 @end
 
@@ -68,8 +68,8 @@ typedef NS_ENUM(NSInteger, NoteFontSize) {
 @property (nonatomic, assign, readonly) BOOL                                    viewingTrash;
 @property (nonatomic, strong, nullable) NSLayoutConstraint                      *toolbarViewTopConstraint;
 @property (nonatomic,   weak) Note                                              *note;
-@property (nonatomic,   weak) id<NoteControllerEditorDelegate>                  delegate;
-@property (nonatomic,   weak) id<NoteControllerTagsDelegate>                    tagsDelegate;
+@property (nonatomic,   weak) id<EditorControllerNoteActionsDelegate>           noteActionsDelegate;
+@property (nonatomic,   weak) id<EditorControllerTagActionsDelegate>            tagActionsDelegate;
 
 - (void)save;
 - (void)displayNote:(nullable Note *)selectedNote;

--- a/Simplenote/NoteEditorViewController.h
+++ b/Simplenote/NoteEditorViewController.h
@@ -12,6 +12,7 @@
 @import Simperium_OSX;
 
 @class BackgroundView;
+@class NoteEditorViewController;
 @class NoteListViewController;
 @class MarkdownViewController;
 @class TagsField;
@@ -30,8 +31,6 @@ typedef NS_ENUM(NSInteger, NoteFontSize) {
 
 #pragma mark - NoteEditorControllerDelegate
 
-extern NSString * const SPTagAddedFromEditorNotificationName;
-extern NSString * const SPWillAddNewNoteNotificationName;
 @protocol NoteControllerEditorDelegate <NSObject>
 - (void)editorController:(NoteEditorViewController *)controller addedNoteWithSimperiumKey:(NSString *)simperiumKey;
 - (void)editorController:(NoteEditorViewController *)controller pinnedNoteWithSimperiumKey:(NSString *)simperiumKey;
@@ -49,8 +48,6 @@ extern NSString * const SPWillAddNewNoteNotificationName;
 
 @interface NoteEditorViewController : NSViewController
 {
-    IBOutlet NSTableView *tableView;
-    IBOutlet NSArrayController *notesArrayController;
     IBOutlet NSMenu *lineLengthMenu;
 }
 

--- a/Simplenote/NoteEditorViewController.h
+++ b/Simplenote/NoteEditorViewController.h
@@ -44,6 +44,7 @@ typedef NS_ENUM(NSInteger, NoteFontSize) {
 @end
 
 
+
 #pragma mark - NoteEditorViewController
 
 @interface NoteEditorViewController : NSViewController

--- a/Simplenote/NoteEditorViewController.h
+++ b/Simplenote/NoteEditorViewController.h
@@ -28,10 +28,21 @@ typedef NS_ENUM(NSInteger, NoteFontSize) {
 
 
 
-#pragma mark - Notifications
+#pragma mark - NoteEditorControllerDelegate
 
 extern NSString * const SPTagAddedFromEditorNotificationName;
 extern NSString * const SPWillAddNewNoteNotificationName;
+@protocol NoteControllerEditorDelegate <NSObject>
+- (void)editorController:(NoteEditorViewController *)controller addedNoteWithSimperiumKey:(NSString *)simperiumKey;
+- (void)editorController:(NoteEditorViewController *)controller pinnedNoteWithSimperiumKey:(NSString *)simperiumKey;
+- (void)editorController:(NoteEditorViewController *)controller restoredNoteWithSimperiumKey:(NSString *)simperiumKey;
+- (void)editorController:(NoteEditorViewController *)controller updatedNoteWithSimperiumKey:(NSString *)simperiumKey;
+- (void)editorController:(NoteEditorViewController *)controller deletedNoteWithSimperiumKey:(NSString *)simperiumKey;
+@end
+
+@protocol NoteControllerTagsDelegate <NSObject>
+- (void)editorController:(NoteEditorViewController *)controller didAddNewTag:(NSString *)tag;
+@end
 
 
 #pragma mark - NoteEditorViewController
@@ -59,6 +70,8 @@ extern NSString * const SPWillAddNewNoteNotificationName;
 @property (nonatomic, assign, readonly) BOOL                                    viewingTrash;
 @property (nonatomic, strong, nullable) NSLayoutConstraint                      *toolbarViewTopConstraint;
 @property (nonatomic,   weak) Note                                              *note;
+@property (nonatomic,   weak) id<NoteControllerEditorDelegate>                  delegate;
+@property (nonatomic,   weak) id<NoteControllerTagsDelegate>                    tagsDelegate;
 
 - (void)save;
 - (void)displayNote:(nullable Note *)selectedNote;

--- a/Simplenote/NoteEditorViewController.m
+++ b/Simplenote/NoteEditorViewController.m
@@ -23,7 +23,6 @@
 
 
 
-
 #pragma mark - Constants
 
 static NSString * const SPTextViewPreferencesKey        = @"kTextViewPreferencesKey";

--- a/Simplenote/NoteEditorViewController.m
+++ b/Simplenote/NoteEditorViewController.m
@@ -24,26 +24,18 @@
 
 
 
-#pragma mark ====================================================================================
-#pragma mark Notifications
-#pragma mark ====================================================================================
 
 NSString * const SPTagAddedFromEditorNotificationName   = @"SPTagAddedFromEditor";
 NSString * const SPWillAddNewNoteNotificationName       = @"SPWillAddNewNote";
-
-
-#pragma mark ====================================================================================
-#pragma mark Constants
-#pragma mark ====================================================================================
+#pragma mark - Constants
 
 static NSString * const SPTextViewPreferencesKey        = @"kTextViewPreferencesKey";
 static NSString * const SPFontSizePreferencesKey        = @"kFontSizePreferencesKey";
 static NSString * const SPMarkdownPreferencesKey        = @"kMarkdownPreferencesKey";
 
 
-#pragma mark ====================================================================================
-#pragma mark Private
-#pragma mark ====================================================================================
+
+#pragma mark - Private
 
 @interface NoteEditorViewController() <NSMenuDelegate,
                                         NSTextDelegate,
@@ -65,9 +57,8 @@ static NSString * const SPMarkdownPreferencesKey        = @"kMarkdownPreferences
 @end
 
 
-#pragma mark ====================================================================================
-#pragma mark NoteEditorViewController
-#pragma mark ====================================================================================
+
+#pragma mark - NoteEditorViewController
 
 @implementation NoteEditorViewController
 

--- a/Simplenote/NoteEditorViewController.m
+++ b/Simplenote/NoteEditorViewController.m
@@ -10,7 +10,6 @@
 #import "SimplenoteAppDelegate.h"
 #import "Note.h"
 #import "Tag.h"
-#import "NoteListViewController.h"
 #import "TagListViewController.h"
 #import "JSONKit+Simplenote.h"
 #import "NSString+Metadata.h"
@@ -25,8 +24,6 @@
 
 
 
-NSString * const SPTagAddedFromEditorNotificationName   = @"SPTagAddedFromEditor";
-NSString * const SPWillAddNewNoteNotificationName       = @"SPWillAddNewNote";
 #pragma mark - Constants
 
 static NSString * const SPTextViewPreferencesKey        = @"kTextViewPreferencesKey";

--- a/Simplenote/NoteEditorViewController.m
+++ b/Simplenote/NoteEditorViewController.m
@@ -370,7 +370,7 @@ static NSString * const SPMarkdownPreferencesKey        = @"kMarkdownPreferences
     self.saveTimer = [NSTimer scheduledTimerWithTimeInterval:2.0 target:self selector:@selector(saveAndSync:) userInfo:nil repeats:NO];
     
     // Update the note list preview
-    [self.delegate editorController:self updatedNoteWithSimperiumKey:self.note.simperiumKey];
+    [self.noteActionsDelegate editorController:self updatedNoteWithSimperiumKey:self.note.simperiumKey];
 }
 
 
@@ -431,7 +431,7 @@ static NSString * const SPMarkdownPreferencesKey        = @"kMarkdownPreferences
 	[self save];
     
     // Update the list
-    [self.delegate editorController:self pinnedNoteWithSimperiumKey:self.note.simperiumKey];
+    [self.noteActionsDelegate editorController:self pinnedNoteWithSimperiumKey:self.note.simperiumKey];
 }
 
 - (IBAction)markdownAction:(id)sender
@@ -488,7 +488,7 @@ static NSString * const SPMarkdownPreferencesKey        = @"kMarkdownPreferences
     [self displayNote:newNote];
     [self save];
 
-    [self.delegate editorController:self addedNoteWithSimperiumKey:newNote.simperiumKey];
+    [self.noteActionsDelegate editorController:self addedNoteWithSimperiumKey:newNote.simperiumKey];
 
     [self.view.window makeFirstResponder:self.noteEditor];
 }
@@ -502,7 +502,7 @@ static NSString * const SPMarkdownPreferencesKey        = @"kMarkdownPreferences
         
         [SPTracker trackEditorNoteDeleted];
         noteToDelete.deleted = YES;
-        [self.delegate editorController:self deletedNoteWithSimperiumKey:noteToDelete.simperiumKey];
+        [self.noteActionsDelegate editorController:self deletedNoteWithSimperiumKey:noteToDelete.simperiumKey];
     }
 
     [self save];
@@ -512,7 +512,7 @@ static NSString * const SPMarkdownPreferencesKey        = @"kMarkdownPreferences
 {
     self.note.deleted = NO;
     [self save];
-    [self.delegate editorController:self restoredNoteWithSimperiumKey:self.note.simperiumKey];
+    [self.noteActionsDelegate editorController:self restoredNoteWithSimperiumKey:self.note.simperiumKey];
     [self displayNote:nil];
 }
 
@@ -552,7 +552,7 @@ static NSString * const SPMarkdownPreferencesKey        = @"kMarkdownPreferences
     for (NSString *token in tokens) {
         Tag *tag = [simperium searchTagWithName:token];
         if (!tag && ![token containsEmailAddress]) {
-            [self.tagsDelegate editorController:self didAddNewTag:token];
+            [self.tagActionsDelegate editorController:self didAddNewTag:token];
         }
     }
 

--- a/Simplenote/NoteListViewController+Swift.swift
+++ b/Simplenote/NoteListViewController+Swift.swift
@@ -168,3 +168,25 @@ extension NoteListViewController {
         return noteView
     }
 }
+
+
+// MARK: - EditorControllerNoteActionsDelegate
+//
+extension NoteListViewController: EditorControllerNoteActionsDelegate {
+
+    public func editorController(_ controller: NoteEditorViewController, addedNoteWithSimperiumKey simperiumKey: String) {
+    }
+
+    public func editorController(_ controller: NoteEditorViewController, pinnedNoteWithSimperiumKey simperiumKey: String) {
+    }
+
+    public func editorController(_ controller: NoteEditorViewController, restoredNoteWithSimperiumKey simperiumKey: String) {
+    }
+
+    public func editorController(_ controller: NoteEditorViewController, updatedNoteWithSimperiumKey simperiumKey: String) {
+    }
+
+    public func editorController(_ controller: NoteEditorViewController, deletedNoteWithSimperiumKey simperiumKey: String) {
+
+    }
+}

--- a/Simplenote/NoteListViewController+Swift.swift
+++ b/Simplenote/NoteListViewController+Swift.swift
@@ -183,6 +183,8 @@ extension NoteListViewController: EditorControllerNoteActionsDelegate {
     }
 
     public func editorController(_ controller: NoteEditorViewController, deletedNoteWithSimperiumKey simperiumKey: String) {
+        // The note was just deleted, but our tableView wasn't reload yet:
+        // We'll perform a synchronous reload, while keeping the same selected index!
         performPerservingSelectedIndex {
             self.reloadSynchronously()
         }
@@ -207,6 +209,7 @@ extension NoteListViewController: EditorControllerNoteActionsDelegate {
 //
 extension NoteListViewController {
 
+    @objc
     func performPerservingSelectedIndex(block: () -> Void) {
         var previouslySelectedIndex = arrayController.selectionIndex
         block()

--- a/Simplenote/NoteListViewController+Swift.swift
+++ b/Simplenote/NoteListViewController+Swift.swift
@@ -175,18 +175,46 @@ extension NoteListViewController {
 extension NoteListViewController: EditorControllerNoteActionsDelegate {
 
     public func editorController(_ controller: NoteEditorViewController, addedNoteWithSimperiumKey simperiumKey: String) {
-    }
+        searchField.cancelSearch()
+        searchField.resignFirstResponder()
 
-    public func editorController(_ controller: NoteEditorViewController, pinnedNoteWithSimperiumKey simperiumKey: String) {
-    }
-
-    public func editorController(_ controller: NoteEditorViewController, restoredNoteWithSimperiumKey simperiumKey: String) {
-    }
-
-    public func editorController(_ controller: NoteEditorViewController, updatedNoteWithSimperiumKey simperiumKey: String) {
+        reloadSynchronously()
+        selectRow(forNoteKey: simperiumKey)
     }
 
     public func editorController(_ controller: NoteEditorViewController, deletedNoteWithSimperiumKey simperiumKey: String) {
+        performPerservingSelectedIndex {
+            self.reloadSynchronously()
+        }
+    }
 
+    public func editorController(_ controller: NoteEditorViewController, pinnedNoteWithSimperiumKey simperiumKey: String) {
+        arrayController.rearrangeObjects()
+        selectRow(forNoteKey: simperiumKey)
+    }
+
+    public func editorController(_ controller: NoteEditorViewController, restoredNoteWithSimperiumKey simperiumKey: String) {
+        arrayController.rearrangeObjects()
+    }
+
+    public func editorController(_ controller: NoteEditorViewController, updatedNoteWithSimperiumKey simperiumKey: String) {
+        reloadRow(forNoteKey: simperiumKey)
+    }
+}
+
+
+// MARK: - Helpers
+//
+extension NoteListViewController {
+
+    func performPerservingSelectedIndex(block: () -> Void) {
+        var previouslySelectedIndex = arrayController.selectionIndex
+        block()
+
+        if previouslySelectedIndex == tableView.numberOfRows {
+            previouslySelectedIndex -= 1
+        }
+
+        arrayController.setSelectionIndex(previouslySelectedIndex)
     }
 }

--- a/Simplenote/NoteListViewController.m
+++ b/Simplenote/NoteListViewController.m
@@ -79,11 +79,6 @@ NSString * const kAlphabeticalSortPref = @"kAlphabeticalSortPreferencesKey";
                                                  name: TagListDidEmptyTrashNotification
                                                object: nil];
 
-    [[NSNotificationCenter defaultCenter] addObserver: self
-                                             selector: @selector(willAddNewNote:)
-                                                 name: SPWillAddNewNoteNotificationName
-                                               object: nil];
-
     self.tableView.rowHeight = [NoteTableCellView rowHeight];
     self.tableView.selectionHighlightStyle = NSTableViewSelectionHighlightStyleRegular;
     self.tableView.backgroundColor = [NSColor clearColor];
@@ -395,13 +390,6 @@ NSString * const kAlphabeticalSortPref = @"kAlphabeticalSortPreferencesKey";
 
     [self.noteEditorViewController displayNote:nil];
     [self.statusField setHidden:NO];
-}
-
-- (void)willAddNewNote:(NSNotification *)notification
-{
-    [self.searchField setStringValue:@""];
-    [[self.searchField.cell cancelButtonCell] performClick:self];
-    [self.searchField resignFirstResponder];
 }
 
 - (void)selectedTaglistRowWasUpdated

--- a/Simplenote/NoteListViewController.m
+++ b/Simplenote/NoteListViewController.m
@@ -424,18 +424,10 @@ NSString * const kAlphabeticalSortPref = @"kAlphabeticalSortPreferencesKey";
 {
     [SPTracker trackListNoteDeleted];
     
-    SimplenoteAppDelegate *appDelegate = [SimplenoteAppDelegate sharedDelegate];
-    NSInteger currentRow = [self rowForNoteKey:note.simperiumKey];
-    
-    note.deleted = YES;
-    [appDelegate.simperium save];
-    
-    // Select the next note, and handle deleting the last row
-    if (currentRow == [self.tableView numberOfRows]) {
-        currentRow -=1;
-    }
-	
-    [self selectRow:currentRow];
+    [self performPerservingSelectedIndexWithBlock:^{
+        note.deleted = YES;
+        [[[SimplenoteAppDelegate sharedDelegate] simperium] save];
+    }];
 }
 
 - (void)deleteAction:(id)sender

--- a/Simplenote/SimplenoteAppDelegate+Swift.swift
+++ b/Simplenote/SimplenoteAppDelegate+Swift.swift
@@ -33,8 +33,14 @@ extension SimplenoteAppDelegate {
     }
 
     @objc
-    func configureSimplenoteControllers() {
+    func configureVersionsController() {
         versionsController = VersionsController(simperium: simperium)
+    }
+
+    @objc
+    func configureEditorController() {
+        noteEditorViewController.tagActionsDelegate = tagListViewController
+        noteEditorViewController.noteActionsDelegate = noteListViewController
     }
 }
 

--- a/Simplenote/SimplenoteAppDelegate.m
+++ b/Simplenote/SimplenoteAppDelegate.m
@@ -120,7 +120,8 @@
 }
 #endif
 
-- (void)applicationWillFinishLaunching:(NSNotification *)notification {
+- (void)applicationWillFinishLaunching:(NSNotification *)notification
+{
     NSAppleEventManager *eventManager = [NSAppleEventManager sharedAppleEventManager];
     [eventManager setEventHandler:self
                       andSelector:@selector(handleGetURLEvent:withReplyEvent:)
@@ -139,7 +140,8 @@
     
 	self.simperium = [self configureSimperium];
 
-    [self configureSimplenoteControllers];
+    [self configureEditorController];
+    [self configureVersionsController];
 
     [self.tagListViewController loadTags];
     [self.noteListViewController loadNotes];

--- a/Simplenote/TagListViewController.h
+++ b/Simplenote/TagListViewController.h
@@ -7,6 +7,7 @@
 //
 
 #import <Cocoa/Cocoa.h>
+#import "NoteEditorViewController.h"
 
 
 @class Tag;
@@ -23,7 +24,8 @@ extern NSString * const TagListDidEmptyTrashNotification;
                                                      NSTextDelegate,
                                                      NSTextFieldDelegate,
                                                      NSControlTextEditingDelegate,
-                                                     NSDraggingDestination>
+                                                     NSDraggingDestination,
+                                                     EditorControllerTagActionsDelegate>
 
 @property (nonatomic, strong, readwrite) IBOutlet NSVisualEffectView    *visualEffectsView;
 @property (nonatomic, strong, readwrite) IBOutlet NSClipView            *clipView;

--- a/Simplenote/TagListViewController.h
+++ b/Simplenote/TagListViewController.h
@@ -23,8 +23,7 @@ extern NSString * const TagListDidEmptyTrashNotification;
                                                      NSTextDelegate,
                                                      NSTextFieldDelegate,
                                                      NSControlTextEditingDelegate,
-                                                     NSDraggingDestination,
-                                                     NoteControllerTagsDelegate>
+                                                     NSDraggingDestination>
 
 @property (nonatomic, strong, readwrite) IBOutlet NSVisualEffectView    *visualEffectsView;
 @property (nonatomic, strong, readwrite) IBOutlet NSClipView            *clipView;

--- a/Simplenote/TagListViewController.h
+++ b/Simplenote/TagListViewController.h
@@ -19,7 +19,12 @@ extern NSString * const TagListDidBeginViewingTrashNotification;
 extern NSString * const TagListDidUpdateTagNotification;
 extern NSString * const TagListDidEmptyTrashNotification;
 
-@interface TagListViewController : NSViewController <NSMenuDelegate, NSTextDelegate, NSTextFieldDelegate, NSControlTextEditingDelegate, NSDraggingDestination>
+@interface TagListViewController : NSViewController <NSMenuDelegate,
+                                                     NSTextDelegate,
+                                                     NSTextFieldDelegate,
+                                                     NSControlTextEditingDelegate,
+                                                     NSDraggingDestination,
+                                                     NoteControllerTagsDelegate>
 
 @property (nonatomic, strong, readwrite) IBOutlet NSVisualEffectView    *visualEffectsView;
 @property (nonatomic, strong, readwrite) IBOutlet NSClipView            *clipView;

--- a/Simplenote/TagListViewController.m
+++ b/Simplenote/TagListViewController.m
@@ -25,7 +25,7 @@ NSString * const TagListDidEmptyTrashNotification           = @"TagListDidEmptyT
 CGFloat const TagListEstimatedRowHeight                     = 30;
 
 
-@interface TagListViewController () <EditorControllerTagActionsDelegate>
+@interface TagListViewController ()
 @property (nonatomic, strong) NSMenu            *tagDropdownMenu;
 @property (nonatomic, strong) NSMenu            *trashDropdownMenu;
 @property (nonatomic, strong) NSString          *tagNameBeingEdited;

--- a/Simplenote/TagListViewController.m
+++ b/Simplenote/TagListViewController.m
@@ -80,7 +80,6 @@ CGFloat const TagListEstimatedRowHeight                     = 30;
 - (void)startListeningToNotifications
 {
     NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
-    [nc addObserver:self selector:@selector(tagAddedFromEditor:) name:SPTagAddedFromEditorNotificationName object:nil];
     [nc addObserver:self selector:@selector(sortModeWasUpdated:) name:TagSortModeDidChangeNotification object:nil];
 }
 
@@ -279,9 +278,9 @@ CGFloat const TagListEstimatedRowHeight                     = 30;
     return newTag;
 }
 
-- (void)tagAddedFromEditor:(NSNotification *)notification
+- (void)editorController:(NoteEditorViewController *)controller didAddNewTag:(NSString *)tag
 {
-    [self addTagWithName:[notification.userInfo objectForKey:@"tagName"]];
+    [self addTagWithName:tag];
     [self loadTags];
 }
 

--- a/Simplenote/TagListViewController.m
+++ b/Simplenote/TagListViewController.m
@@ -24,14 +24,15 @@ NSString * const TagListDidBeginViewingTrashNotification    = @"TagListDidBeginV
 NSString * const TagListDidEmptyTrashNotification           = @"TagListDidEmptyTrashNotification";
 CGFloat const TagListEstimatedRowHeight                     = 30;
 
-@interface TagListViewController ()
+
+@interface TagListViewController () <EditorControllerTagActionsDelegate>
 @property (nonatomic, strong) NSMenu            *tagDropdownMenu;
 @property (nonatomic, strong) NSMenu            *trashDropdownMenu;
 @property (nonatomic, strong) NSString          *tagNameBeingEdited;
 @property (nonatomic, strong) NSArray<Tag *>    *tagArray;
 @property (nonatomic, assign) BOOL              menuShowing;
-
 @end
+
 
 @implementation TagListViewController
 


### PR DESCRIPTION
### Details:
Several EditorViewController improvements / tech debt tasks:

1. Encapsulation: *Note Editor* **NO LONGER** has IBOutlet(s) referencing to components owned by the Notes List 🔥
2. Delegation: New `EditorControllerNoteActionsDelegate` and `EditorControllerTagActionsDelegate` protocols
3. We've also killed direct access to NoteListViewController via the AppDelegate outlet

@aerych The codebase is gonna end up beautiful. Promise!!
Thanks in advance!!

Ref. #626

### Test
- [x] Verify that editing a document causes the Notes List to get immediately updated
- [x] Verify that Pinning a note causes the Notes List to get immediately updated
- [x] Verify that Adding a New Note causes the new entry to get selected in the Notes List
- [x] Verify that the **Search Field** is cleared out after pressing the `+` (New Note) button
- [x] Verify that deleting a note via the `... > Move to Trash` action preserves the selected row index (it shouldn't jump to the first row!) 
- [x] Verify that deleting a note via the `Delete` keyboard key preserves the selected row index (it shouldn't jump to the first row!) 
- [x] Verify that restoring a note from Trash causes the Notes List to immediately refresh
- [x] Verify that after adding a new Tag from the Notes Editor (bottom area), the new row shows up in the Tags List (left sidebar!)

### Release
These changes do not require release notes.
