### PR TITLE
Update Sparkle SUFeedURL from Hockey to App Center URL

### DIFF
--- a/Simplenote/Simplenote-Info-Hockey.plist
+++ b/Simplenote/Simplenote-Info-Hockey.plist
@@ -53,7 +53,7 @@
 	<key>NSPrincipalClass</key>
 	<string>SPApplication</string>
 	<key>SUFeedURL</key>
-	<string>https://rink.hockeyapp.net/api/2/apps/ede9c49346946c51a1db1db167b49892</string>
+	<string>https://api.appcenter.ms/v0.1/public/sparkle/apps/ede9c493-4694-6c51-a1db-1db167b49892</string>
 	<key>SUScheduledCheckInterval</key>
 	<string>3600</string>
 	<key>ITSAppUsesNonExemptEncryption</key>


### PR DESCRIPTION
### Fix
The previous URL redirects to this one. This change will save us a
redirect when checking for updates, and also bring the app up-to-date
with the App Center standards.

### Test

To test this, I changed the version to something old, like 1.0, and also enabled Sparkle for the "Simplenote" target in the Debug build configuration.

```diff
diff --git a/Simplenote.xcodeproj/project.pbxproj b/Simplenote.xcodeproj/project.pbxproj
index 4404404..b7f1530 100644
--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -2179,6 +2179,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(inherited)",
 					"COCOAPODS=1",
+					"SPARKLE_OTA=1",
 				);
 				GCC_WARN_UNDECLARED_SELECTOR = NO;
 				INFOPLIST_FILE = "Simplenote/Simplenote-Info-Hockey.plist";
diff --git a/config/Version.public.xcconfig b/config/Version.public.xcconfig
index 212df1d..179a37f 100644
--- a/config/Version.public.xcconfig
+++ b/config/Version.public.xcconfig
@@ -1,5 +1,5 @@
-VERSION_SHORT=2.0
+VERSION_SHORT=1.0

 // Public long version example: 2.0.0.1. The last 1 means the first build for
 // this version
-VERSION_LONG=2.0.0.0
+VERSION_LONG=1.0.0.0
```

Something that surprised me, though, was how the version it proposed me was 1.12.0 instead of 2.0.0.

I wonder if that is due to the different version format in the [appcast XML](https://api.appcenter.ms/v0.1/public/sparkle/apps/ede9c493-4694-6c51-a1db-1db167b49892):

```xml
<enclosure sparkle:version="2.0.0.0" sparkle:shortVersionString="2.0" url="https://appcenter-filemanagement-distrib2ede6f06e.azureedge.net/0e3db9c2-3387-4efb-bc76-a07fe805c776/Simplenote.zip?sv=2019-02-02&sr=c&sig=jC%2FRjmryhD%2BziK%2F548Nnb3RO%2BtjlNj5wc6halNNaW2Y%3D&se=2020-08-11T03%3A48%3A34Z&sp=r" length="6632120" type="application/octet-stream"/>
```

vs

```xml
<enclosure sparkle:version="11201" sparkle:shortVersionString="1.12.0" url="https://appcenter-filemanagement-distrib3ede6f06e.azureedge.net/191cd6f9-0417-4477-84ac-c4b6ecdcc56f/Simplenote-Stapled.zip?sv=2019-02-02&sr=c&sig=BApqjbD35vOb08HD9wPkk4qHWr%2BkiS0bUdikg%2Bx1FKA%3D&se=2020-08-10T22%3A35%3A03Z&sp=r" length="6505137" type="application/octet-stream"/>
```

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.