### PR TITLE
Add a testing checklist

### DIFF
--- a/TESTING-CHECKLIST.md
+++ b/TESTING-CHECKLIST.md
@@ -1,0 +1,73 @@
+## Testing
+
+### Login/Signup
+
+- [ ] Logout
+- [ ] Login with wrong password fails
+- [ ] Login with correct password succeeds
+- [ ] Login with WordPress.com succeeds
+- [ ] Signup with unique email address succeeds
+
+### Sync
+
+- [ ] Create new note appears in other device
+- [ ] Changes to new note sync to/from other device
+- [ ] New tag immediately syncs to/from other device
+- [ ] Removed tag immediately syncs to/from other device
+- [ ] Note publishes with link
+- [ ] Note unpublishes
+- [ ] Note publish change syncs _from_ other device
+- [ ] Markdown setting syncs to/from other device
+- [ ] Preview mode disappears/reappears when receiving remote changes to markdown setting
+- [ ] Note pinning syncs immediately to/from other device
+- [ ] Note pinning works regardless if selecting in list view or from note info
+- [ ] Restoring history immediately syncs note from both directions
+
+### Note editor
+
+- [ ] Can preview markdown with 👁 button
+- [ ] Can flip to edit mode with 👁 button
+- [ ] Using the Insert checklist item from the format menu inserts a checklist
+- [ ] "Undo" undoes the last edit
+- [ ] Typing `- [x]` creates a checked checklist item
+- [ ] Typing `- [ ]` created an unchecked checklist item
+- [ ] Typing `-`, `+`, or `*` creates a list
+- [ ] Typing _tab_ in a list item underneath another list item indents item
+- [ ] All list bullet types render to markdown lists
+- [ ] Added URL is linkified
+- [ ] When clicking on link it opens in new window
+- [ ] Can print note in plaintext view
+
+### Tags & search
+
+- [ ] Can filter by tag when clicking on tag in tag drawer
+- [ ] Can search by keyword, filtered instantly
+- [ ] Can search by keyword with tag selected
+- [ ] Clearing the search field immediately updates filtered notes
+- [ ] While searching, clicking on different tags or All Notes or Trash immediately updates filtered notes
+
+### Trash
+
+- [ ] Can trash note
+- [ ] Can view trashed notes by selecting `Trash`
+- [ ] Can right-click on `Trash` to empty trash
+- [ ] Can restore note from trash screen
+
+### Settings
+
+- [ ] Can toggle sidebar
+- [ ] Can change analytics sharing setting
+- [ ] With wide editor screen, toggling `Note Editor` > `Line Length` between `Narrow` and `Full` removes and adds border around note content appropriately and immediately.
+- [ ] Changing `Notes List` > `Note Display` mode immediately updates and reflects in note list
+- [ ] Changing `Notes List` > `Sort Order` immediately updates and reflects in note list for each sort type
+- [ ] For each sort type the pinned notes appear first in the note list
+- [ ] Changing `Theme` immediately updates app for desired color scheme
+
+### Keyboard shortcuts ([reference](https://simplenote.com/help/#shortcuts))
+
+- [ ] `Cmd` + `N` creates a new note
+- [ ] `Cmd` + `P` prints the selected note
+- [ ] `Cmd` + `L` moves focus to the search field
+- [ ] `Cmd` + `+` increases the font size
+- [ ] `Cmd` + `-` decreases the font size
+- [ ] `Cmd` + `0` resets the font size

--- a/TESTING-CHECKLIST.md
+++ b/TESTING-CHECKLIST.md
@@ -20,7 +20,6 @@
 - [ ] Markdown setting syncs to/from other device
 - [ ] Preview mode disappears/reappears when receiving remote changes to markdown setting
 - [ ] Note pinning syncs immediately to/from other device
-- [ ] Note pinning works regardless if selecting in list view or from note info
 - [ ] Restoring history immediately syncs note from both directions
 
 ### Note editor


### PR DESCRIPTION
### Changes

This adds a testing checklist for Simplenote macOS. The checklist is heavily based on existing checklists for the other Simplenote apps, especially the [Simplenote Electron checklist](https://github.com/Automattic/simplenote-electron/blob/develop/TESTING-CHECKLIST.md), but is adjusted to match some platform-specific expectations.

### Test

Confirm the checklist is complete and accurate for the macOS app. Let me know if I missed anything!

### Review

Only one developer is required to review these changes.

### Release

These changes do not require release notes.
