### PR TITLE
Fix: Unresponsive Tags List

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,8 +1,9 @@
-2.1
+2.1.0
 -----
- 
+- Fixed a bug in which the Tags List wouldn't accept mouse clicks
+
 2.0.0
-------
+-----
 - Updated Tags limit to up to 256 characters
 - Fixed a crash while handling right clicks in the Tags List
 

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -181,6 +181,8 @@
 		B54F9A6824D0B21D00BCF754 /* NSNotification+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54F9A6624D0B21D00BCF754 /* NSNotification+Simplenote.swift */; };
 		B54F9A6A24D0BDC100BCF754 /* TagTextFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54F9A6924D0BDC100BCF754 /* TagTextFormatter.swift */; };
 		B54F9A6B24D0BDC100BCF754 /* TagTextFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54F9A6924D0BDC100BCF754 /* TagTextFormatter.swift */; };
+		B551187224E33BC2007B11E3 /* ClipView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B551187124E33BC2007B11E3 /* ClipView.swift */; };
+		B551187324E33BC2007B11E3 /* ClipView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B551187124E33BC2007B11E3 /* ClipView.swift */; };
 		B55C312624A5117F00B23B3F /* SpacerTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55C312524A5117F00B23B3F /* SpacerTableViewCell.swift */; };
 		B55C312724A5117F00B23B3F /* SpacerTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55C312524A5117F00B23B3F /* SpacerTableViewCell.swift */; };
 		B55C312C24A530A500B23B3F /* MetricsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55C312B24A530A500B23B3F /* MetricsViewController.swift */; };
@@ -544,6 +546,7 @@
 		B54F9A6224D0AE0700BCF754 /* SimplenoteConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimplenoteConstants.swift; sourceTree = "<group>"; };
 		B54F9A6624D0B21D00BCF754 /* NSNotification+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSNotification+Simplenote.swift"; sourceTree = "<group>"; };
 		B54F9A6924D0BDC100BCF754 /* TagTextFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagTextFormatter.swift; sourceTree = "<group>"; };
+		B551187124E33BC2007B11E3 /* ClipView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipView.swift; sourceTree = "<group>"; };
 		B55C312524A5117F00B23B3F /* SpacerTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpacerTableViewCell.swift; sourceTree = "<group>"; };
 		B55C312B24A530A500B23B3F /* MetricsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetricsViewController.swift; sourceTree = "<group>"; };
 		B55C313B24A55ED800B23B3F /* NSVisualEffectView+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSVisualEffectView+Simplenote.swift"; sourceTree = "<group>"; };
@@ -939,6 +942,7 @@
 				B5946321247EF60500FC257E /* Tags */,
 				B5E8E41324575C9F0098892B /* Toolbar */,
 				B5ACE42D24785D8C00AB02C7 /* BackgroundView.swift */,
+				B551187124E33BC2007B11E3 /* ClipView.swift */,
 				B5F50914247319360042FA1D /* SplitView.swift */,
 				B535014A249D5908003837C8 /* HorizontalScrollView.swift */,
 				46F0E66117A32269005BB4D1 /* SPTableView.h */,
@@ -1688,6 +1692,7 @@
 				B500993C24213B370037A431 /* String+Simplenote.swift in Sources */,
 				3712FC8C1FE1ACAA008544AC /* Style.swift in Sources */,
 				375D294021E033D1007AB25A /* html_smartypants.c in Sources */,
+				B551187224E33BC2007B11E3 /* ClipView.swift in Sources */,
 				B5E061772450AEDA0076111A /* ToolbarView.swift in Sources */,
 				F998F3EB22853C29008C2B59 /* CrashLogging.swift in Sources */,
 				2614F1DF1405A0B10031AE94 /* Note.m in Sources */,
@@ -1822,6 +1827,7 @@
 				466FFEAB17CC10A800399652 /* Tag.m in Sources */,
 				B5A5AF7D244FA7BA0051D927 /* NoteEditorViewController+Swift.swift in Sources */,
 				B500993D24213B370037A431 /* String+Simplenote.swift in Sources */,
+				B551187324E33BC2007B11E3 /* ClipView.swift in Sources */,
 				3712FC8D1FE1ACAA008544AC /* Style.swift in Sources */,
 				375D294121E033D1007AB25A /* html_smartypants.c in Sources */,
 				B5E061782450AEDA0076111A /* ToolbarView.swift in Sources */,

--- a/Simplenote/Base.lproj/MainMenu.xib
+++ b/Simplenote/Base.lproj/MainMenu.xib
@@ -830,7 +830,7 @@
                                     </visualEffectView>
                                     <scrollView borderType="none" horizontalLineScroll="29" horizontalPageScroll="10" verticalLineScroll="29" verticalPageScroll="10" hasHorizontalScroller="NO" hasVerticalScroller="NO" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1452">
                                         <rect key="frame" x="0.0" y="0.0" width="120" height="618"/>
-                                        <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="UOf-YZ-mq1">
+                                        <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="UOf-YZ-mq1" customClass="ClipView" customModule="Simplenote" customModuleProvider="target">
                                             <rect key="frame" x="0.0" y="0.0" width="120" height="618"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>

--- a/Simplenote/Base.lproj/MainMenu.xib
+++ b/Simplenote/Base.lproj/MainMenu.xib
@@ -950,6 +950,9 @@
                                                             </prototypeCellViews>
                                                         </tableColumn>
                                                     </tableColumns>
+                                                    <userDefinedRuntimeAttributes>
+                                                        <userDefinedRuntimeAttribute type="boolean" keyPath="disableAutoscrollOnMouseDown" value="YES"/>
+                                                    </userDefinedRuntimeAttributes>
                                                     <connections>
                                                         <outlet property="dataSource" destination="1461" id="1467"/>
                                                         <outlet property="delegate" destination="1461" id="1468"/>

--- a/Simplenote/ClipView.swift
+++ b/Simplenote/ClipView.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+
+// MARK: - NSClipView
+//
+class ClipView: NSClipView {
+
+    /// ClipView's default `hitTest` implementation returns `nil` whenever a view, **although visible**, falls within the area
+    /// defined by the `contentInsets.top`.
+    ///
+    /// In this subclass we're simply forwarding the click event to the subclasses, when appropriate.
+    ///
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        if let subview = super.hitTest(point) {
+            return subview
+        }
+
+        if point.y >= contentInsets.top {
+            return nil
+        }
+
+
+        for subview in subviews {
+            let translated = convert(point, to: subview)
+            guard let result = subview.hitTest(translated) else {
+                continue
+            }
+
+            return result
+        }
+
+        return nil
+    }
+}

--- a/Simplenote/SPTableView.h
+++ b/Simplenote/SPTableView.h
@@ -17,6 +17,15 @@
 
 
 
+IB_DESIGNABLE
 @interface SPTableView : NSTableView<SPTextViewDelegate, NSTextFieldDelegate>
+
+/// AppKit will always ensure that the clicked row is visble. However, the SDK considers a row as being "not visible"
+/// whenever the clicked row falls within the `contentInsets` area.
+///
+/// Meaning that even when a given row is fully visible, NSTableView might perform a scroll anyways, leading to a jumpy UX.
+/// We're implementing a (opt-in) workaround to deal with this scenario!
+///
+@property (nonatomic, assign) IBInspectable BOOL disableAutoscrollOnMouseDown;
 
 @end

--- a/Simplenote/SPTableView.h
+++ b/Simplenote/SPTableView.h
@@ -24,7 +24,7 @@ IB_DESIGNABLE
 /// whenever the clicked row falls within the `contentInsets` area.
 ///
 /// Meaning that even when a given row is fully visible, NSTableView might perform a scroll anyways, leading to a jumpy UX.
-/// We're implementing a (opt-in) workaround to deal with this scenario!
+/// We're implementing a (opt-in) mechanism that disables Scrolling, during a mouseDown operation.
 ///
 @property (nonatomic, assign) IBInspectable BOOL disableAutoscrollOnMouseDown;
 

--- a/Simplenote/SPTableView.m
+++ b/Simplenote/SPTableView.m
@@ -29,19 +29,6 @@
     [super keyDown:theEvent];
 }
 
-- (BOOL)isRowClipped:(NSInteger)row
-{
-    if (row < 0) {
-        return NO;
-    }
-
-    NSRect rectOfRow = [self rectOfRow:row];
-    NSPoint rowInWindow = [self convertPoint:rectOfRow.origin toView:nil];
-    CGFloat windowHeight = self.window.contentLayoutRect.size.height;
-
-    return rowInWindow.y >= windowHeight;
-}
-
 - (NSInteger)rowForEvent:(NSEvent *)event
 {
     NSPoint location = [self convertPoint:event.locationInWindow fromView:nil];
@@ -56,10 +43,7 @@
 
 - (void)mouseDown:(NSEvent *)event
 {
-    NSInteger row = [self rowForEvent:event];
-    BOOL isRowClipped = [self isRowClipped:row];
-
-    self.disablesScrollToRow = self.disableAutoscrollOnMouseDown && !isRowClipped;
+    self.disablesScrollToRow = self.disableAutoscrollOnMouseDown;
 
     [super mouseDown:event];
 

--- a/Simplenote/SPTableView.m
+++ b/Simplenote/SPTableView.m
@@ -8,6 +8,11 @@
 
 #import "SPTableView.h"
 
+
+@interface SPTableView ()
+@property (nonatomic, assign) BOOL disablesScrollToRow;
+@end
+
 @implementation SPTableView
 
 - (void)keyDown:(NSEvent *)theEvent
@@ -24,24 +29,78 @@
     [super keyDown:theEvent];
 }
 
+- (BOOL)isRowClipped:(NSInteger)row
+{
+    if (row < 0) {
+        return NO;
+    }
+
+    NSRect rectOfRow = [self rectOfRow:row];
+    NSPoint rowInWindow = [self convertPoint:rectOfRow.origin toView:nil];
+    CGFloat windowHeight = self.window.contentLayoutRect.size.height;
+
+    return rowInWindow.y >= windowHeight;
+}
+
+- (NSInteger)rowForEvent:(NSEvent *)event
+{
+    NSPoint location = [self convertPoint:event.locationInWindow fromView:nil];
+    return [self rowAtPoint:location];
+}
+
+- (NSInteger)columnForEvent:(NSEvent *)event
+{
+    NSPoint mousePoint = [self convertPoint:event.locationInWindow fromView:nil];
+    return [self columnAtPoint:mousePoint];
+}
+
+- (void)mouseDown:(NSEvent *)event
+{
+    NSInteger row = [self rowForEvent:event];
+    BOOL isRowClipped = [self isRowClipped:row];
+
+    self.disablesScrollToRow = self.disableAutoscrollOnMouseDown && !isRowClipped;
+
+    [super mouseDown:event];
+
+    self.disablesScrollToRow = NO;
+}
+
+- (BOOL)autoscroll:(NSEvent *)event
+{
+    if (self.disablesScrollToRow) {
+        return NO;
+    }
+
+    return [super autoscroll:event];
+}
+
+- (void)scrollRowToVisible:(NSInteger)row
+{
+    if (self.disablesScrollToRow) {
+        return;
+    }
+
+    [super scrollRowToVisible:row];
+}
+
 - (void)didClickTextView:(id)sender
 {
     // User clicked a text view. Select its underlying row.
     [self selectRowIndexes:[NSIndexSet indexSetWithIndex:[self rowForView:sender]] byExtendingSelection:NO];
 }
 
-- (NSMenu *)menuForEvent:(NSEvent*)theEvent
+- (NSMenu *)menuForEvent:(NSEvent*)event
 {
-    NSPoint mousePoint = [self convertPoint:[theEvent locationInWindow] fromView:nil];
-    NSInteger row = [self rowAtPoint:mousePoint];
-    NSInteger column = [self columnAtPoint:mousePoint];
+    NSInteger row = [self rowForEvent:event];
+    NSInteger column = [self columnForEvent:event];
 
     if ([self.delegate tableView:self shouldSelectRow:row]) {
         [self selectRowIndexes:[NSIndexSet indexSetWithIndex:row] byExtendingSelection:NO];
     }
 
     if ([self.delegate respondsToSelector:@selector(tableView:menuForTableColumn:row:)] == false) {
-        return [super menuForEvent:theEvent];
+        return [super menuForEvent:event];
     }
 
     return [(id<SPTableViewDelegate>)self.delegate tableView:self menuForTableColumn:column row:row];


### PR DESCRIPTION
### Fix
In this PR we're fixing a bug in which the Tags List would not properly process click events.

@aerych Sir! may I bug you with yet another bugfix?

Thanks in advance!
Closes #636

### Test
1. Log into a test account with lots of tags (DM me if needed!)
2. Shrink the window so that the Tags List scrolls
3. Scroll the `All Notes` + `Trash` rows **above** the horizontal line defined by the Search Field (close to the titlebar or even below!)

- [ ] Verify that both **All Notes** and **Trash** are clickable
- [ ] If possible verify that any Tags placed in the same area (right by the Search Field) is clickable

### Release
`RELEASE-NOTES.txt` was updated in 6d05ef3 with:
 
> Fixed a bug in which the Tags List wouldn't accept mouse clicks
