### PR TITLE
Merge release 2.0 into develop

### DIFF
--- a/Simplenote/Simplenote-Info-Hockey.plist
+++ b/Simplenote/Simplenote-Info-Hockey.plist
@@ -36,7 +36,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>$VERSION_LONG</string>
+	<string>$BUILD_NUMBER</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.productivity</string>
 	<key>LSMinimumSystemVersion</key>

--- a/Simplenote/Simplenote-Info.plist
+++ b/Simplenote/Simplenote-Info.plist
@@ -36,7 +36,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>$VERSION_LONG</string>
+	<string>$BUILD_NUMBER</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.productivity</string>
 	<key>LSMinimumSystemVersion</key>

--- a/config/Version.public.xcconfig
+++ b/config/Version.public.xcconfig
@@ -2,4 +2,4 @@ VERSION_SHORT=2.0
 
 // Public long version example: 2.0.0.1. The last 1 means the first build for
 // this version
-VERSION_LONG=2.0.0.1
+VERSION_LONG=2.0.0.2

--- a/config/Version.public.xcconfig
+++ b/config/Version.public.xcconfig
@@ -3,3 +3,7 @@ VERSION_SHORT=2.0
 // Public long version example: 2.0.0.1. The last 1 means the first build for
 // this version
 VERSION_LONG=2.0.0.2
+
+// This is the value for the CFBundleVersion it should be incremented on every
+// build that gets distributed
+BUILD_NUMBER=11203


### PR DESCRIPTION
Notice 05995c, which works around the App Store Connect upload error by adding a new `BUILD_NUMBER` value in the `.xcconfig` to use for `CFBundleVersion`.