### PR TITLE
Update release-toolkit

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,11 @@
 GIT
   remote: https://github.com/wordpress-mobile/release-toolkit
-  revision: 6e94ba249c3523c3419ee2774d1a69115efb0fb6
-  tag: 0.9.12
+  revision: 6c11d29292e612ae772291c21dad89a400414f46
+  ref: 6c11d29292e612ae772291c21dad89a400414f46
   specs:
-    fastlane-plugin-wpmreleasetoolkit (0.9.11)
+    fastlane-plugin-wpmreleasetoolkit (0.9.13)
       activesupport (~> 4)
+      bigdecimal (~> 1.4)
       chroma (= 0.2.0)
       diffy (~> 3.3)
       git (~> 1.3)
@@ -45,6 +46,7 @@ GEM
     aws-sigv4 (1.2.1)
       aws-eventstream (~> 1, >= 1.0.2)
     babosa (1.0.3)
+    bigdecimal (1.4.4)
     chroma (0.2.0)
     claide (1.0.3)
     cocoapods (1.6.1)
@@ -89,7 +91,7 @@ GEM
     concurrent-ruby (1.1.6)
     declarative (0.0.20)
     declarative-option (0.1.0)
-    diffy (3.3.0)
+    diffy (3.4.0)
     digest-crc (0.6.0)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
@@ -205,7 +207,8 @@ GEM
     octokit (4.18.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
-    oj (3.10.7)
+    oj (3.10.12)
+      bigdecimal (>= 1.0, < 3)
     optimist (3.0.1)
     options (2.3.2)
     os (1.1.0)

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -2,6 +2,6 @@
 #
 # Ensure this file is checked in to source control!
 
-gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag: '0.9.12'
+gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', ref: '6c11d29292e612ae772291c21dad89a400414f46'
 gem 'fastlane-plugin-sentry'
 gem 'fastlane-plugin-appcenter', '1.6.0'


### PR DESCRIPTION
### Fix
The version scheme on Simplenote MacOS has been historically different from the one on the other apps where `CFBundleVersion` is set with a stripped string without dots.

In order to make the app compatible with our standard tooling, @mokagio added a `BUILD_NUMBER` field in `Version.public.xcconfig` and switched `CFBundleVersion` to it.

This PR updates `release-toolkit` with a version where iOSVersionHelper bumps `BUILD_NUMBER` when it is present in the `xcconfig` file (PR here: https://github.com/wordpress-mobile/release-toolkit/pull/161)

### Test
1. Checkout a new `release/x.y` branch from this one. 
2. `bundle install`
3. `export PUBLIC_CONFIG_FILE="./config/Version.Public.xcconfig" && export PROJECT_ROOT_FOLDER="./" &&bundle exec fastlane run ios_bump_version_beta`
4. Verify that `VERSION_LONG` and `BUILD_NUMBER` have been updated. 
5. Delete the `BUILD_NUMBER` field from the file and commit the change. 
6. Run `export PUBLIC_CONFIG_FILE="./config/Version.Public.xcconfig" && export PROJECT_ROOT_FOLDER="./" &&bundle exec fastlane run ios_bump_version_beta`
7. Verify that the script is successful when it can't find the `BUILD_NUMBER` field and that `VERSION_LONG` has been updated. 

Clean up:
8. Delete the test branch from GitHub (the script pushes it!)
9. Delete the test branch from your local repository. 

### Review
Only one developer is required to review these changes, but anyone can perform the review.

**Note:** After this PR is accepted, before merging it we need to merge the related `release-toolkit` PR, release a new version of the plugin and update the reference here. 

### Release
These changes do not require release notes.
