### PR TITLE
Authentication: Displaying Titlebar's Close Button

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -16,7 +16,7 @@ abstract_target 'Automattic' do
   # Automattic Shared
   #
   pod 'Automattic-Tracks-iOS', '~> 0.4'
-  pod 'Simperium-OSX', '0.8.29'
+  pod 'Simperium-OSX', '0.8.30'
 
   # Main Target
   #

--- a/Podfile
+++ b/Podfile
@@ -16,7 +16,7 @@ abstract_target 'Automattic' do
   # Automattic Shared
   #
   pod 'Automattic-Tracks-iOS', '~> 0.4'
-  pod 'Simperium-OSX', '0.8.28'
+  pod 'Simperium-OSX', '0.8.29'
 
   # Main Target
   #

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -12,22 +12,22 @@ PODS:
   - Sentry (4.5.0):
     - Sentry/Core (= 4.5.0)
   - Sentry/Core (4.5.0)
-  - Simperium-OSX (0.8.29):
-    - Simperium-OSX/DiffMatchPach (= 0.8.29)
-    - Simperium-OSX/JRSwizzle (= 0.8.29)
-    - Simperium-OSX/SocketRocket (= 0.8.29)
-    - Simperium-OSX/SPReachability (= 0.8.29)
-    - Simperium-OSX/SSKeychain (= 0.8.29)
-  - Simperium-OSX/DiffMatchPach (0.8.29)
-  - Simperium-OSX/JRSwizzle (0.8.29)
-  - Simperium-OSX/SocketRocket (0.8.29)
-  - Simperium-OSX/SPReachability (0.8.29)
-  - Simperium-OSX/SSKeychain (0.8.29)
+  - Simperium-OSX (0.8.30):
+    - Simperium-OSX/DiffMatchPach (= 0.8.30)
+    - Simperium-OSX/JRSwizzle (= 0.8.30)
+    - Simperium-OSX/SocketRocket (= 0.8.30)
+    - Simperium-OSX/SPReachability (= 0.8.30)
+    - Simperium-OSX/SSKeychain (= 0.8.30)
+  - Simperium-OSX/DiffMatchPach (0.8.30)
+  - Simperium-OSX/JRSwizzle (0.8.30)
+  - Simperium-OSX/SocketRocket (0.8.30)
+  - Simperium-OSX/SPReachability (0.8.30)
+  - Simperium-OSX/SSKeychain (0.8.30)
   - Sodium (0.8.0)
 
 DEPENDENCIES:
   - Automattic-Tracks-iOS (~> 0.4)
-  - Simperium-OSX (= 0.8.29)
+  - Simperium-OSX (= 0.8.30)
 
 SPEC REPOS:
   https://github.com/cocoapods/specs.git:
@@ -43,9 +43,9 @@ SPEC CHECKSUMS:
   CocoaLumberjack: bd155f2dd06c0e0b03f876f7a3ee55693122ec94
   Reachability: 33e18b67625424e47b6cde6d202dce689ad7af96
   Sentry: ab6c209f23700d1460691dbc90e19ed0a05d496b
-  Simperium-OSX: 80ef04a7790d32a88bf78b2f59090bfaee817d12
+  Simperium-OSX: 677949c579f96c4fd194b532bdffda86b00b3db8
   Sodium: 63c0ca312a932e6da481689537d4b35568841bdc
 
-PODFILE CHECKSUM: adc4f5ea73a1848c02e90a59e2987b836a62152e
+PODFILE CHECKSUM: 3e9e3836b359a135afd5e690bc752feda9e53e96
 
 COCOAPODS: 1.6.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,16 +1,17 @@
 PODS:
-  - Automattic-Tracks-iOS (0.4.3):
-    - CocoaLumberjack (~> 3.5.2)
-    - Reachability (~> 3.1)
+  - Automattic-Tracks-iOS (0.5.1):
+    - CocoaLumberjack (~> 3)
+    - Reachability (~> 3)
     - Sentry (~> 4)
+    - Sodium (~> 0.8.0)
     - UIDeviceIdentifier (~> 1)
-  - CocoaLumberjack (3.5.3):
-    - CocoaLumberjack/Core (= 3.5.3)
-  - CocoaLumberjack/Core (3.5.3)
+  - CocoaLumberjack (3.6.2):
+    - CocoaLumberjack/Core (= 3.6.2)
+  - CocoaLumberjack/Core (3.6.2)
   - Reachability (3.2)
-  - Sentry (4.4.3):
-    - Sentry/Core (= 4.4.3)
-  - Sentry/Core (4.4.3)
+  - Sentry (4.5.0):
+    - Sentry/Core (= 4.5.0)
+  - Sentry/Core (4.5.0)
   - Simperium-OSX (0.8.29):
     - Simperium-OSX/DiffMatchPach (= 0.8.29)
     - Simperium-OSX/JRSwizzle (= 0.8.29)
@@ -22,6 +23,7 @@ PODS:
   - Simperium-OSX/SocketRocket (0.8.29)
   - Simperium-OSX/SPReachability (0.8.29)
   - Simperium-OSX/SSKeychain (0.8.29)
+  - Sodium (0.8.0)
 
 DEPENDENCIES:
   - Automattic-Tracks-iOS (~> 0.4)
@@ -34,13 +36,15 @@ SPEC REPOS:
     - Reachability
     - Sentry
     - Simperium-OSX
+    - Sodium
 
 SPEC CHECKSUMS:
-  Automattic-Tracks-iOS: 5515b3e6a5e55183a244ca6cb013df26810fa994
-  CocoaLumberjack: 2f44e60eb91c176d471fdba43b9e3eae6a721947
+  Automattic-Tracks-iOS: ac2cf9d8332fef72cf3e6de7b14012e7a0672676
+  CocoaLumberjack: bd155f2dd06c0e0b03f876f7a3ee55693122ec94
   Reachability: 33e18b67625424e47b6cde6d202dce689ad7af96
-  Sentry: 14bdd673870e8cf64932b149fad5bbbf39a9b390
+  Sentry: ab6c209f23700d1460691dbc90e19ed0a05d496b
   Simperium-OSX: 80ef04a7790d32a88bf78b2f59090bfaee817d12
+  Sodium: 63c0ca312a932e6da481689537d4b35568841bdc
 
 PODFILE CHECKSUM: adc4f5ea73a1848c02e90a59e2987b836a62152e
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -11,21 +11,21 @@ PODS:
   - Sentry (4.4.3):
     - Sentry/Core (= 4.4.3)
   - Sentry/Core (4.4.3)
-  - Simperium-OSX (0.8.28):
-    - Simperium-OSX/DiffMatchPach (= 0.8.28)
-    - Simperium-OSX/JRSwizzle (= 0.8.28)
-    - Simperium-OSX/SocketRocket (= 0.8.28)
-    - Simperium-OSX/SPReachability (= 0.8.28)
-    - Simperium-OSX/SSKeychain (= 0.8.28)
-  - Simperium-OSX/DiffMatchPach (0.8.28)
-  - Simperium-OSX/JRSwizzle (0.8.28)
-  - Simperium-OSX/SocketRocket (0.8.28)
-  - Simperium-OSX/SPReachability (0.8.28)
-  - Simperium-OSX/SSKeychain (0.8.28)
+  - Simperium-OSX (0.8.29):
+    - Simperium-OSX/DiffMatchPach (= 0.8.29)
+    - Simperium-OSX/JRSwizzle (= 0.8.29)
+    - Simperium-OSX/SocketRocket (= 0.8.29)
+    - Simperium-OSX/SPReachability (= 0.8.29)
+    - Simperium-OSX/SSKeychain (= 0.8.29)
+  - Simperium-OSX/DiffMatchPach (0.8.29)
+  - Simperium-OSX/JRSwizzle (0.8.29)
+  - Simperium-OSX/SocketRocket (0.8.29)
+  - Simperium-OSX/SPReachability (0.8.29)
+  - Simperium-OSX/SSKeychain (0.8.29)
 
 DEPENDENCIES:
   - Automattic-Tracks-iOS (~> 0.4)
-  - Simperium-OSX (= 0.8.28)
+  - Simperium-OSX (= 0.8.29)
 
 SPEC REPOS:
   https://github.com/cocoapods/specs.git:
@@ -40,8 +40,8 @@ SPEC CHECKSUMS:
   CocoaLumberjack: 2f44e60eb91c176d471fdba43b9e3eae6a721947
   Reachability: 33e18b67625424e47b6cde6d202dce689ad7af96
   Sentry: 14bdd673870e8cf64932b149fad5bbbf39a9b390
-  Simperium-OSX: aaa21852e3d5348e3d25bb25d6c1dfbec3b91429
+  Simperium-OSX: 80ef04a7790d32a88bf78b2f59090bfaee817d12
 
-PODFILE CHECKSUM: 78bf76028858af587c14629c496341ab7f2fb75f
+PODFILE CHECKSUM: adc4f5ea73a1848c02e90a59e2987b836a62152e
 
 COCOAPODS: 1.6.1

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -190,12 +190,12 @@
 		B55C313C24A55ED800B23B3F /* NSVisualEffectView+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55C313B24A55ED800B23B3F /* NSVisualEffectView+Simplenote.swift */; };
 		B55C313D24A55ED800B23B3F /* NSVisualEffectView+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55C313B24A55ED800B23B3F /* NSVisualEffectView+Simplenote.swift */; };
 		B55E98FD1BE03E3F0087CA48 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B55E98FB1BE03E3F0087CA48 /* Security.framework */; };
-		B5609AE824EEC9860097777A /* SimplenoteSearch in Frameworks */ = {isa = PBXBuildFile; productRef = B5609AE724EEC9860097777A /* SimplenoteSearch */; };
-		B5609AEA24EEC9910097777A /* SimplenoteSearch in Frameworks */ = {isa = PBXBuildFile; productRef = B5609AE924EEC9910097777A /* SimplenoteSearch */; };
+		B5609AE824EEC9860097777A /* BuildFile in Frameworks */ = {isa = PBXBuildFile; productRef = B5609AE724EEC9860097777A /* SwiftPackageProductDependency */; };
+		B5609AEA24EEC9910097777A /* BuildFile in Frameworks */ = {isa = PBXBuildFile; productRef = B5609AE924EEC9910097777A /* SwiftPackageProductDependency */; };
 		B5609AEC24EEE7200097777A /* SPBucket+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5609AEB24EEE7200097777A /* SPBucket+Simplenote.swift */; };
 		B5609AED24EEE7200097777A /* SPBucket+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5609AEB24EEE7200097777A /* SPBucket+Simplenote.swift */; };
-		B5609AF024EF171D0097777A /* SimplenoteFoundation in Frameworks */ = {isa = PBXBuildFile; productRef = B5609AEF24EF171D0097777A /* SimplenoteFoundation */; };
-		B5609AF224EF17270097777A /* SimplenoteFoundation in Frameworks */ = {isa = PBXBuildFile; productRef = B5609AF124EF17270097777A /* SimplenoteFoundation */; };
+		B5609AF024EF171D0097777A /* BuildFile in Frameworks */ = {isa = PBXBuildFile; productRef = B5609AEF24EF171D0097777A /* SwiftPackageProductDependency */; };
+		B5609AF224EF17270097777A /* BuildFile in Frameworks */ = {isa = PBXBuildFile; productRef = B5609AF124EF17270097777A /* SwiftPackageProductDependency */; };
 		B5686D0E1AEAE6D7009F9E20 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B5686D0D1AEAE6D7009F9E20 /* Images.xcassets */; };
 		B5686D0F1AEAE6D7009F9E20 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B5686D0D1AEAE6D7009F9E20 /* Images.xcassets */; };
 		B56EA2AA244F4CC70061EAD8 /* NSImageView+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B56EA2A9244F4CC70061EAD8 /* NSImageView+Simplenote.swift */; };
@@ -659,8 +659,8 @@
 				2614F1E91405A1150031AE94 /* CoreServices.framework in Frameworks */,
 				B5A8919C231ECB3D0007EDCB /* Sparkle.framework in Frameworks */,
 				26F72A8D14032D2A00A7935E /* Cocoa.framework in Frameworks */,
-				B5609AEA24EEC9910097777A /* SimplenoteSearch in Frameworks */,
-				B5609AF224EF17270097777A /* SimplenoteFoundation in Frameworks */,
+				B5609AEA24EEC9910097777A /* BuildFile in Frameworks */,
+				B5609AF224EF17270097777A /* BuildFile in Frameworks */,
 				D0A1D693931CD24A56140DF7 /* Pods_Automattic_Simplenote.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -675,8 +675,8 @@
 				466FFEE017CC10A800399652 /* CoreServices.framework in Frameworks */,
 				466FFEE117CC10A800399652 /* Cocoa.framework in Frameworks */,
 				B55E98FD1BE03E3F0087CA48 /* Security.framework in Frameworks */,
-				B5609AE824EEC9860097777A /* SimplenoteSearch in Frameworks */,
-				B5609AF024EF171D0097777A /* SimplenoteFoundation in Frameworks */,
+				B5609AE824EEC9860097777A /* BuildFile in Frameworks */,
+				B5609AF024EF171D0097777A /* BuildFile in Frameworks */,
 				1E077730C2108B885911E3B5 /* Pods_Automattic_Simplenote_AppStore.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1286,8 +1286,8 @@
 			);
 			name = Simplenote;
 			packageProductDependencies = (
-				B5609AE924EEC9910097777A /* SimplenoteSearch */,
-				B5609AF124EF17270097777A /* SimplenoteFoundation */,
+				B5609AE924EEC9910097777A /* SwiftPackageProductDependency */,
+				B5609AF124EF17270097777A /* SwiftPackageProductDependency */,
 			);
 			productName = Simplenote;
 			productReference = 26F72A8814032D2A00A7935E /* Simplenote.app */;
@@ -1311,8 +1311,8 @@
 			);
 			name = "Simplenote-AppStore";
 			packageProductDependencies = (
-				B5609AE724EEC9860097777A /* SimplenoteSearch */,
-				B5609AEF24EF171D0097777A /* SimplenoteFoundation */,
+				B5609AE724EEC9860097777A /* SwiftPackageProductDependency */,
+				B5609AEF24EF171D0097777A /* SwiftPackageProductDependency */,
 			);
 			productName = Simplenote;
 			productReference = 466FFF2F17CC10A800399652 /* Simplenote.app */;
@@ -1399,8 +1399,8 @@
 			);
 			mainGroup = 26F72A7D14032D2900A7935E;
 			packageReferences = (
-				B5609AE624EEC9860097777A /* XCRemoteSwiftPackageReference "SimplenoteSearch-Swift" */,
-				B5609AEE24EF171D0097777A /* XCRemoteSwiftPackageReference "SimplenoteFoundation-Swift" */,
+				B5609AE624EEC9860097777A /* RemoteSwiftPackageReference */,
+				B5609AEE24EF171D0097777A /* RemoteSwiftPackageReference */,
 			);
 			productRefGroup = 26F72A8914032D2A00A7935E /* Products */;
 			projectDirPath = "";
@@ -1483,6 +1483,7 @@
 				"${BUILT_PRODUCTS_DIR}/Reachability/Reachability.framework",
 				"${BUILT_PRODUCTS_DIR}/Sentry/Sentry.framework",
 				"${BUILT_PRODUCTS_DIR}/Simperium-OSX/Simperium_OSX.framework",
+				"${BUILT_PRODUCTS_DIR}/Sodium/Sodium.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
@@ -1493,6 +1494,7 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Reachability.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Sentry.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Simperium_OSX.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Sodium.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -1557,6 +1559,7 @@
 				"${BUILT_PRODUCTS_DIR}/Reachability/Reachability.framework",
 				"${BUILT_PRODUCTS_DIR}/Sentry/Sentry.framework",
 				"${BUILT_PRODUCTS_DIR}/Simperium-OSX/Simperium_OSX.framework",
+				"${BUILT_PRODUCTS_DIR}/Sodium/Sodium.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
@@ -1567,6 +1570,7 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Reachability.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Sentry.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Simperium_OSX.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Sodium.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -1654,6 +1658,7 @@
 				"${BUILT_PRODUCTS_DIR}/Reachability/Reachability.framework",
 				"${BUILT_PRODUCTS_DIR}/Sentry/Sentry.framework",
 				"${BUILT_PRODUCTS_DIR}/Simperium-OSX/Simperium_OSX.framework",
+				"${BUILT_PRODUCTS_DIR}/Sodium/Sodium.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
@@ -1664,6 +1669,7 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Reachability.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Sentry.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Simperium_OSX.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Sodium.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -2528,7 +2534,7 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		B5609AE624EEC9860097777A /* XCRemoteSwiftPackageReference "SimplenoteSearch-Swift" */ = {
+		B5609AE624EEC9860097777A /* RemoteSwiftPackageReference */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "git@github.com:Automattic/SimplenoteSearch-Swift.git";
 			requirement = {
@@ -2536,7 +2542,7 @@
 				minimumVersion = 1.0.0;
 			};
 		};
-		B5609AEE24EF171D0097777A /* XCRemoteSwiftPackageReference "SimplenoteFoundation-Swift" */ = {
+		B5609AEE24EF171D0097777A /* RemoteSwiftPackageReference */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "git@github.com:Automattic/SimplenoteFoundation-Swift.git";
 			requirement = {
@@ -2547,24 +2553,24 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		B5609AE724EEC9860097777A /* SimplenoteSearch */ = {
+		B5609AE724EEC9860097777A /* SwiftPackageProductDependency */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = B5609AE624EEC9860097777A /* XCRemoteSwiftPackageReference "SimplenoteSearch-Swift" */;
+			package = B5609AE624EEC9860097777A /* RemoteSwiftPackageReference */;
 			productName = SimplenoteSearch;
 		};
-		B5609AE924EEC9910097777A /* SimplenoteSearch */ = {
+		B5609AE924EEC9910097777A /* SwiftPackageProductDependency */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = B5609AE624EEC9860097777A /* XCRemoteSwiftPackageReference "SimplenoteSearch-Swift" */;
+			package = B5609AE624EEC9860097777A /* RemoteSwiftPackageReference */;
 			productName = SimplenoteSearch;
 		};
-		B5609AEF24EF171D0097777A /* SimplenoteFoundation */ = {
+		B5609AEF24EF171D0097777A /* SwiftPackageProductDependency */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = B5609AEE24EF171D0097777A /* XCRemoteSwiftPackageReference "SimplenoteFoundation-Swift" */;
+			package = B5609AEE24EF171D0097777A /* RemoteSwiftPackageReference */;
 			productName = SimplenoteFoundation;
 		};
-		B5609AF124EF17270097777A /* SimplenoteFoundation */ = {
+		B5609AF124EF17270097777A /* SwiftPackageProductDependency */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = B5609AEE24EF171D0097777A /* XCRemoteSwiftPackageReference "SimplenoteFoundation-Swift" */;
+			package = B5609AEE24EF171D0097777A /* RemoteSwiftPackageReference */;
 			productName = SimplenoteFoundation;
 		};
 /* End XCSwiftPackageProductDependency section */

--- a/Simplenote/SimplenoteAppDelegate.m
+++ b/Simplenote/SimplenoteAppDelegate.m
@@ -534,10 +534,17 @@
 
 - (BOOL)applicationShouldHandleReopen:(NSApplication *)sender hasVisibleWindows:(BOOL)hasVisibleWindows
 {
-    if (!hasVisibleWindows) {
-        [self.window setIsVisible:YES];
-        [self.window makeKeyAndOrderFront:self];
+    if (hasVisibleWindows) {
+        return YES;
     }
+
+    if (!self.simperium.user.authenticated) {
+        [self.simperium authenticateIfNecessary];
+        return YES;
+    }
+
+    [self.window setIsVisible:YES];
+    [self.window makeKeyAndOrderFront:self];
     
     return YES;
 }


### PR DESCRIPTION
### Fix
In this PR we're adjusting the Authentication Window, so that the standard buttons are displayed. Note that only Close is allowed

cc @aerych Sir, you game for a quick PR?
Thanks in advance!

Closes #658

### Test
- [x] Verify that the Login Window now displays the close button (top left corner)
- [x] Verify that clicking over the Close button effectively dismisses the Login Window
- [x] Verify that (when not authenticated) clicking over the Simplenote (Dock) Icon reopens the Authentication window
- [x] Verify that (when authenticated) clicking over the Simplenote (Dock) Icon reopens the main window

### Release
These changes do not require release notes.

### Screenshot
<img width="300" alt="Screen Shot 2020-08-25 at 20 03 16" src="https://user-images.githubusercontent.com/1195260/91236333-081e8e00-e70e-11ea-98e1-315098ea075b.png">

