### PR TITLE
Update release-toolkit to latest version, 0.9.14

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,11 @@
 GIT
   remote: https://github.com/wordpress-mobile/release-toolkit
-  revision: 6e94ba249c3523c3419ee2774d1a69115efb0fb6
-  tag: 0.9.12
+  revision: dd4dd1b1af753f7369f08715343d031be09a2c27
+  tag: 0.9.14
   specs:
-    fastlane-plugin-wpmreleasetoolkit (0.9.11)
+    fastlane-plugin-wpmreleasetoolkit (0.9.14)
       activesupport (~> 4)
+      bigdecimal (~> 1.4)
       chroma (= 0.2.0)
       diffy (~> 3.3)
       git (~> 1.3)
@@ -45,6 +46,7 @@ GEM
     aws-sigv4 (1.2.1)
       aws-eventstream (~> 1, >= 1.0.2)
     babosa (1.0.3)
+    bigdecimal (1.4.4)
     chroma (0.2.0)
     claide (1.0.3)
     cocoapods (1.6.1)
@@ -86,10 +88,10 @@ GEM
     colored2 (3.1.2)
     commander-fastlane (4.4.6)
       highline (~> 1.7.2)
-    concurrent-ruby (1.1.6)
+    concurrent-ruby (1.1.7)
     declarative (0.0.20)
     declarative-option (0.1.0)
-    diffy (3.3.0)
+    diffy (3.4.0)
     digest-crc (0.6.0)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
@@ -192,7 +194,7 @@ GEM
     mini_magick (4.10.1)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
-    minitest (5.14.1)
+    minitest (5.14.2)
     molinillo (0.6.6)
     multi_json (1.15.0)
     multipart-post (2.0.0)
@@ -205,7 +207,7 @@ GEM
     octokit (4.18.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
-    oj (3.10.7)
+    oj (3.10.14)
     optimist (3.0.1)
     options (2.3.2)
     os (1.1.0)
@@ -214,7 +216,7 @@ GEM
     progress_bar (1.3.1)
       highline (>= 1.6, < 3)
       options (~> 2.3.0)
-    public_suffix (4.0.5)
+    public_suffix (4.0.6)
     rake (12.3.3)
     rake-compiler (1.1.1)
       rake
@@ -283,4 +285,4 @@ DEPENDENCIES
   xcpretty-travis-formatter!
 
 BUNDLED WITH
-   2.0.2
+   2.1.4

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -2,6 +2,6 @@
 #
 # Ensure this file is checked in to source control!
 
-gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag: '0.9.12'
+gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag: '0.9.14'
 gem 'fastlane-plugin-sentry'
 gem 'fastlane-plugin-appcenter', '1.6.0'


### PR DESCRIPTION
### Test
You can smoke test this by running any of the lanes. For example, one that doesn't try to change the state of the remote is `update_appstore_strings`.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release

These changes do not require release notes.