### PR TITLE
Linkifying on Paste ©

### DIFF
--- a/Simplenote/NSTextView+Simplenote.swift
+++ b/Simplenote/NSTextView+Simplenote.swift
@@ -128,6 +128,39 @@ extension NSTextView {
 }
 
 
+// MARK: - Linkification
+//
+extension NSTextView {
+
+    /// Asynchronously Processess Links in the Document
+    ///
+    @objc
+    func processLinksInDocumentAsynchronously() {
+        DispatchQueue.main.async(execute: processLinksInDocument)
+    }
+
+    /// Processess Links in the document
+    ///
+    /// - Important: This API temporarily disables the `delegate`.
+    /// - Note: Invoking `checkTextInDocument` results in a call to`delegate.textDidChange`.
+    ///         This causes the Editor to update the Note's Modification Date, and may affect the List Sort Order (!)
+    ///
+    func processLinksInDocument() {
+        /// Disable the Delegate:
+        let theDelegate = delegate
+        delegate = nil
+
+        /// Issue #472: Linkification should not be undoable
+        undoManager?.disableUndoRegistration()
+        checkTextInDocument(nil)
+        undoManager?.enableUndoRegistration()
+
+        /// Restore the Delegate
+        delegate = theDelegate
+    }
+}
+
+
 // MARK: - Processing Special Characters
 //
 extension NSTextView {

--- a/Simplenote/NSTextView+Simplenote.swift
+++ b/Simplenote/NSTextView+Simplenote.swift
@@ -111,12 +111,14 @@ extension NSTextView {
     ///     -   List Markers will be replaced by Text Attachments
     ///     -   Our UndoManager will be reset right after processing the Lists. Otherwise CTRL + Z would
     ///         result in Attachments replacee by `-[]`!
+    ///     -   Links will be processed asynchronously
     ///
     @objc
     func displayNote(content: String) {
         string = content
         textStorage?.processChecklists(with: .simplenoteTextColor)
         undoManager?.removeAllActions()
+        processLinksInDocumentAsynchronously()
     }
 
     /// Returns the content represented as Plain Text

--- a/Simplenote/NoteEditorViewController.m
+++ b/Simplenote/NoteEditorViewController.m
@@ -228,8 +228,6 @@ static NSString * const SPMarkdownPreferencesKey        = @"kMarkdownPreferences
         // Otherwise we'll scroll to the top!
         [[self.scrollView documentView] scrollPoint:NSMakePoint(0, 0)];
     }
-    
-    [self checkTextInDocument];
 }
 
 - (void)displayNotes:(NSArray *)notes
@@ -460,8 +458,7 @@ static NSString * const SPMarkdownPreferencesKey        = @"kMarkdownPreferences
     
     // Update editor to apply markdown styles
     [self.storage refreshStyleWithMarkdownEnabled:self.note.markdown];
-    [self checkTextInDocument];
-    
+
     [[NSUserDefaults standardUserDefaults] setBool:(BOOL)isEnabled forKey:SPMarkdownPreferencesKey];
 }
 
@@ -611,7 +608,6 @@ static NSString * const SPMarkdownPreferencesKey        = @"kMarkdownPreferences
     // Update font size preference and reset fonts
     [[NSUserDefaults standardUserDefaults] setInteger:currentFontSize forKey:SPFontSizePreferencesKey];
     [self applyStyle];
-    [self checkTextInDocument];
 }
 
 #pragma mark - NoteEditor Preferences Helpers

--- a/Simplenote/NoteEditorViewController.m
+++ b/Simplenote/NoteEditorViewController.m
@@ -244,25 +244,6 @@ static NSString * const SPMarkdownPreferencesKey        = @"kMarkdownPreferences
     [self showStatusText:status];
 }
 
-// Linkifies text in the editor
-- (void)checkTextInDocument
-{
-    dispatch_async(dispatch_get_main_queue(), ^() {
-        // Temporarily remove the editor delegate because `checkTextInDocument`
-        // fires `textDidChange` which will erroneously modify the note's modification
-        // date and unintentionally change the sort order of the note in the list as a result
-        [self.noteEditor setDelegate:nil];
-
-        // Issue #472: Linkification should not be undoable
-        [self.noteEditor.undoManager disableUndoRegistration];
-        [self.noteEditor checkTextInDocument:nil];
-        [self.noteEditor.undoManager enableUndoRegistration];
-
-        [self.noteEditor setNeedsDisplay:YES];
-        [self.noteEditor setDelegate:self];
-    });
-}
-
 - (void)showStatusText:(NSString *)text
 {
     BOOL shouldHideImage = text == nil || text.length == 0;

--- a/Simplenote/SPTableView.h
+++ b/Simplenote/SPTableView.h
@@ -18,7 +18,7 @@
 
 
 IB_DESIGNABLE
-@interface SPTableView : NSTableView<SPTextViewDelegate, NSTextFieldDelegate>
+@interface SPTableView : NSTableView<NSTextFieldDelegate>
 
 /// AppKit will always ensure that the clicked row is visble. However, the SDK considers a row as being "not visible"
 /// whenever the clicked row falls within the `contentInsets` area.

--- a/Simplenote/SPTableView.m
+++ b/Simplenote/SPTableView.m
@@ -68,12 +68,6 @@
     [super scrollRowToVisible:row];
 }
 
-- (void)didClickTextView:(id)sender
-{
-    // User clicked a text view. Select its underlying row.
-    [self selectRowIndexes:[NSIndexSet indexSetWithIndex:[self rowForView:sender]] byExtendingSelection:NO];
-}
-
 - (NSMenu *)menuForEvent:(NSEvent*)event
 {
     NSInteger row = [self rowForEvent:event];

--- a/Simplenote/SPTextView.h
+++ b/Simplenote/SPTextView.h
@@ -10,11 +10,6 @@
 
 #define kMinEditorPadding 20
 
-
-@protocol SPTextViewDelegate <NSTextViewDelegate>
-- (void)didClickTextView:(id)sender;
-@end
-
 @interface SPTextView : NSTextView
 
 @end

--- a/Simplenote/SPTextView.m
+++ b/Simplenote/SPTextView.m
@@ -26,6 +26,7 @@
 - (void)paste:(id)sender
 {
     [super paste:sender];
+    [self processLinksInDocumentAsynchronously];
 }
 
 - (void)drawRect:(NSRect)dirtyRect {

--- a/Simplenote/SPTextView.m
+++ b/Simplenote/SPTextView.m
@@ -29,9 +29,9 @@
     [super mouseDown:theEvent];
 }
 
-- (id<SPTextViewDelegate>)textViewDelegate
+- (void)paste:(id)sender
 {
-    return [self.delegate conformsToProtocol:@protocol(SPTextViewDelegate)] ? (id<SPTextViewDelegate>)self.delegate : nil;
+    [super paste:sender];
 }
 
 - (void)drawRect:(NSRect)dirtyRect {

--- a/Simplenote/SPTextView.m
+++ b/Simplenote/SPTextView.m
@@ -14,14 +14,8 @@
 
 @implementation SPTextView
 
-// Workaround NSTextView not allowing clicks
-// http://stackoverflow.com/a/10308359/1379066
 - (void)mouseDown:(NSEvent *)theEvent
 {
-    // Notify delegate that this text view was clicked and then
-    // handled the click natively as well.
-    [[self textViewDelegate] didClickTextView:self];
-    
     if ([self checkForChecklistClick:theEvent]) {
         return;
     }


### PR DESCRIPTION
### Description:
In this PR we're explicitly linkifying the document, whenever the user performs a **Paste** OP.

Plus, since we were in the neighborhood, few tech debt notes:

- Linkification is now handled by the **NSTextView.displayNote** API
- All of the Editor explicit Linkification / **checkTextInDocument** invocations have been dropped.

Ref. #663 

### Details:
Few months ago, [Storage would remove all of the NSAttributedString Styles](https://github.com/Automattic/simplenote-macos/blob/1.8/External/Notepad/Storage.swift#L37) whenever the **Storage.Theme** property was set.

[This "reset" process was overhauled](https://github.com/Automattic/simplenote-macos/blob/release/2.1/External/Notepad/Storage.swift#L180) so that only `.font, .foreground, .paragraphStyle` attributes are removed, leaving intact any `.link` attributes.

Because of the above, it's safe to drop explicit Linkification Invocations whenever the "Font / Markdown" flags are toggled.

### Test
[TBD]

### Release
These changes do not require release notes.
