### PR TITLE
Markdown: Dark Mode Highlight

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,7 @@
+2.2.0
+-----
+- Fixed Markdown Preview's Highlight Color, when in Dark Mode #673
+
 2.1.0
 -----
 - Fixed a bug in which the Tags List wouldn't accept mouse clicks

--- a/Simplenote/CSS/markdown-dark.css
+++ b/Simplenote/CSS/markdown-dark.css
@@ -22,6 +22,10 @@ html {
     text-rendering: optimizeLegibility;
 }
 
+::selection {
+    background-color: rgba(70, 70, 70, 0.75);
+}
+
 ::-webkit-scrollbar {
     width: 6px;
 }


### PR DESCRIPTION
### Fix
In this PR we're updating the Highlight Color of the Markdown Preview, when in Dark Mode.

@SylvesterWilmott Sir!! what do you think about this one?
Thanks in advance!!

Ref. #663

### Test
1. Add a new note with random content
2. Enable Markdown
3. Switch to Dark Mode
4. Switch to Markdown Preview

- [ ] Verify that the Text Selection is visible!

### Release
`RELEASE-NOTES.txt` was updated in 409718d with:
 
> Fixed Markdown Preview's Highlight Color, when in Dark Mode #673

### Screenshot: Before
<img width="300" alt="Screen Shot 2020-09-10 at 11 54 10" src="https://user-images.githubusercontent.com/1195260/92750282-4d250000-f35d-11ea-9bf7-819a76136ef0.png">

### Screenshot: Now!
<img width="300" alt="Screen Shot 2020-09-10 at 11 53 27" src="https://user-images.githubusercontent.com/1195260/92750299-50b88700-f35d-11ea-9c77-4b95ba7f7b2b.png">

