### PR TITLE
LoginWindowController: Resetting Frame Origin

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 2.3
 -----
- 
+- Fixed a bug that randomly caused the login screen to cut off #664
+
 2.2.0
 -----
 - Editor's Actions now lets you copy a Note's Internal Link #667

--- a/Simplenote/LoginWindowController.m
+++ b/Simplenote/LoginWindowController.m
@@ -42,6 +42,10 @@ static NSString *SPAuthSessionKey                   = @"SPAuthSessionKey";
     CGRect frame = self.window.frame;
     frame.size.height += SPLoginAdditionalHeight;
     [self.window setFrame:frame display:YES animate:NO];
+
+    // Make sure the rootView's origin is always zero.
+    // Ref. https://github.com/Automattic/simplenote-macos/issues/664
+    frame.origin = CGPointZero;
     [rootView setFrame:frame];
     
     // Move up all subviews (Frame origin.y is at the bottom on macOS?)


### PR DESCRIPTION
### Fix
This PR fixes a (really random / unpredictable) layout issue in the Authentication UI.

I'm afraid I couldn't find any direct way to trigger the original issue. I did reproduce the glitch in a Virtual Machine, absolutely by chance, after relaunch.

@guarani Sir!! Can I bug you with a really small PR?
Thanks in advance!!

Closes #664

### Test
- [ ] Verify the Login Window looks as expected!

### Release
`RELEASE-NOTES.txt` was updated in 14140a5 with:
 
> Fixed a bug that randomly caused the login screen to cut off
