### PR TITLE
Interlinks Autocomplete UI: Mark III

### DIFF
--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -2650,8 +2650,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "git@github.com:Automattic/SimplenoteInterlinks-Swift.git";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 1.0.0;
+				kind = revision;
+				revision = af8a85e149da029e114158cd930cfc8ea0f4e814;
 			};
 		};
 		B5609AE624EEC9860097777A /* XCRemoteSwiftPackageReference "SimplenoteSearch-Swift" */ = {

--- a/Simplenote.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Simplenote.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "git@github.com:Automattic/SimplenoteInterlinks-Swift.git",
         "state": {
           "branch": null,
-          "revision": "d49f8ccece40d16f4baae1577cce1452e28b2463",
-          "version": "1.0.0"
+          "revision": "af8a85e149da029e114158cd930cfc8ea0f4e814",
+          "version": null
         }
       },
       {

--- a/Simplenote/Interlink.storyboard
+++ b/Simplenote/Interlink.storyboard
@@ -45,7 +45,7 @@
                                     <rect key="frame" x="0.0" y="0.0" width="230" height="57"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
-                                        <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnReordering="NO" columnSelection="YES" columnResizing="NO" multipleSelection="NO" emptySelection="NO" autosaveColumns="NO" rowHeight="19" viewBased="YES" id="3Me-kR-MCE">
+                                        <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnReordering="NO" columnSelection="YES" columnResizing="NO" multipleSelection="NO" emptySelection="NO" autosaveColumns="NO" rowHeight="19" viewBased="YES" id="3Me-kR-MCE" customClass="SPTableView">
                                             <rect key="frame" x="0.0" y="0.0" width="230" height="57"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="calibratedRGB"/>

--- a/Simplenote/InterlinkViewController.swift
+++ b/Simplenote/InterlinkViewController.swift
@@ -72,7 +72,7 @@ extension InterlinkViewController {
 
     /// Refreshes the UI so that Interlinks for the specified Keyword are rendered
     ///
-    func displayInterlinks(for keyword: String) {
+    func refreshInterlinks(for keyword: String) {
         refreshResultsPredicate(for: keyword)
         tableView.reloadDataAndResetSelection()
     }

--- a/Simplenote/InterlinkViewController.swift
+++ b/Simplenote/InterlinkViewController.swift
@@ -45,7 +45,9 @@ class InterlinkViewController: NSViewController {
         refreshStyle()
         setupResultsController()
         setupRoundedCorners()
+        setupTableView()
         setupTrackingAreas()
+
     }
 
     override func mouseEntered(with event: NSEvent) {
@@ -86,6 +88,12 @@ private extension InterlinkViewController {
         backgroundView.layer?.cornerRadius = Settings.cornerRadius
     }
 
+    func setupTableView() {
+        tableView.becomeFirstResponder()
+        tableView.target = self
+        tableView.doubleAction = #selector(noteWasSelected)
+    }
+
     func setupTrackingAreas() {
         view.addTrackingArea(trackingArea)
     }
@@ -104,6 +112,18 @@ private extension InterlinkViewController {
         ])
 
         try? resultsController.performFetch()
+    }
+}
+
+
+// MARK: - Action Handlers
+//
+extension InterlinkViewController {
+
+    @objc
+    func noteWasSelected() {
+        // TODO: Perform Interlink Insertion!!
+        NSLog("Here")
     }
 }
 
@@ -160,7 +180,16 @@ extension InterlinkViewController: NSTableViewDataSource {
 
 // MARK: - NSTableViewDelegate
 //
-extension InterlinkViewController: NSTableViewDelegate {
+extension InterlinkViewController: SPTableViewDelegate {
+
+    public func tableView(_ tableView: NSTableView, didReceiveKeyDownEvent event: NSEvent) -> Bool {
+        guard case NSEvent.SpecialKey.carriageReturn = event.specialKey else {
+            return false
+        }
+
+        noteWasSelected()
+        return true
+    }
 
     public func tableView(_ tableView: NSTableView, shouldSelectRow row: Int) -> Bool {
         true

--- a/Simplenote/InterlinkViewController.swift
+++ b/Simplenote/InterlinkViewController.swift
@@ -32,6 +32,10 @@ class InterlinkViewController: NSViewController {
         return ResultsController(viewContext: mainContext, sortedBy: [sortDescriptor])
     }()
 
+    /// Closure to be executed whenever a Note is selected
+    ///
+    var onInsertInterlink: ((Note) -> Void)?
+
 
     // MARK: - Overridden Methods
 
@@ -91,7 +95,7 @@ private extension InterlinkViewController {
     func setupTableView() {
         tableView.becomeFirstResponder()
         tableView.target = self
-        tableView.doubleAction = #selector(noteWasSelected)
+        tableView.doubleAction = #selector(performInterlinkInsert)
     }
 
     func setupTrackingAreas() {
@@ -121,9 +125,13 @@ private extension InterlinkViewController {
 extension InterlinkViewController {
 
     @objc
-    func noteWasSelected() {
-        // TODO: Perform Interlink Insertion!!
-        NSLog("Here")
+    func performInterlinkInsert() {
+        guard let note = noteAtRow(tableView.selectedRow) else {
+            return
+        }
+
+        onInsertInterlink?(note)
+        onInsertInterlink = nil
     }
 }
 
@@ -187,7 +195,7 @@ extension InterlinkViewController: SPTableViewDelegate {
             return false
         }
 
-        noteWasSelected()
+        performInterlinkInsert()
         return true
     }
 

--- a/Simplenote/NoteEditorViewController+Swift.swift
+++ b/Simplenote/NoteEditorViewController+Swift.swift
@@ -581,9 +581,9 @@ extension NoteEditorViewController {
         }
     }
 
-    func insertInterlink(_ linkText: String, in range: Range<String.Index>) {
+    func insertInterlink(_ text: String, in range: Range<String.Index>) {
         let range = noteEditor.string.utf16NSRange(from: range)
-        noteEditor.replaceCharacters(in: range, with: linkText)
+        noteEditor.replaceCharacters(in: range, with: text)
     }
 
     func dismissInterlinkWindow() {

--- a/Simplenote/SPTableView.h
+++ b/Simplenote/SPTableView.h
@@ -11,7 +11,13 @@
 
 @protocol SPTableViewDelegate <NSTableViewDelegate>
 
+@optional
 - (nullable NSMenu *)tableView:(nonnull NSTableView *)tableView menuForTableColumn:(NSInteger)column row:(NSInteger)row;
+
+/// Invoked whenever the TableView received a KeyDown event.
+/// - Note: When this API returns `true`, further Event forwarding will be halted
+///
+- (BOOL)tableView:(nonnull NSTableView *)tableView didReceiveKeyDownEvent:(nonnull NSEvent *)event;
 
 @end
 
@@ -26,6 +32,7 @@ IB_DESIGNABLE
 /// Meaning that even when a given row is fully visible, NSTableView might perform a scroll anyways, leading to a jumpy UX.
 /// We're implementing a (opt-in) mechanism that disables Scrolling, during a mouseDown operation.
 ///
-@property (nonatomic, assign) IBInspectable BOOL disableAutoscrollOnMouseDown;
+@property (nonatomic, assign, readwrite) IBInspectable BOOL disableAutoscrollOnMouseDown;
+@property (nonatomic, assign, nullable) SEL returnAction;
 
 @end

--- a/Simplenote/SPTableView.m
+++ b/Simplenote/SPTableView.m
@@ -25,6 +25,14 @@
             return;
         }
     }
+
+    // Nü Event Handling Mechanism
+    id<SPTableViewDelegate> extendedDelegate = (id<SPTableViewDelegate>)self.delegate;
+    if ([extendedDelegate respondsToSelector:@selector(tableView:didReceiveKeyDownEvent:)]) {
+        if ([extendedDelegate tableView:self didReceiveKeyDownEvent:theEvent]) {
+            return;
+        }
+    }
     
     [super keyDown:theEvent];
 }


### PR DESCRIPTION
### Details:
In this PR we're enhancing the Interlink Autocomplete Window so that **return** or **double click** inserts the selected note's Interlink.

Ref. #663

### Test
[TBD]

### Release
> `RELEASE-NOTES.txt` was updated in d3adb3ef with:
> 
> > Typing `[` will now allow you to pick Interlinking Notes right from the editor
