### PR TITLE
Update Tracks to version with support for non-sandboxed apps

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -15,7 +15,7 @@ abstract_target 'Automattic' do
 
   # Automattic Shared
   #
-  pod 'Automattic-Tracks-iOS', '~> 0.4'
+  pod 'Automattic-Tracks-iOS', git: 'https://github.com/Automattic/Automattic-Tracks-iOS', branch: 'store-data-in-application-support'
   pod 'Simperium-OSX', '0.8.30'
 
   # Main Target

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -26,26 +26,35 @@ PODS:
   - Sodium (0.8.0)
 
 DEPENDENCIES:
-  - Automattic-Tracks-iOS (~> 0.4)
+  - Automattic-Tracks-iOS (from `https://github.com/Automattic/Automattic-Tracks-iOS`, branch `store-data-in-application-support`)
   - Simperium-OSX (= 0.8.30)
 
 SPEC REPOS:
   https://github.com/cocoapods/specs.git:
-    - Automattic-Tracks-iOS
     - CocoaLumberjack
     - Reachability
     - Sentry
     - Simperium-OSX
     - Sodium
 
+EXTERNAL SOURCES:
+  Automattic-Tracks-iOS:
+    :branch: store-data-in-application-support
+    :git: https://github.com/Automattic/Automattic-Tracks-iOS
+
+CHECKOUT OPTIONS:
+  Automattic-Tracks-iOS:
+    :commit: 90cc2ab6f9038a2f79e4bd89cae882abaffc5bd9
+    :git: https://github.com/Automattic/Automattic-Tracks-iOS
+
 SPEC CHECKSUMS:
-  Automattic-Tracks-iOS: ac2cf9d8332fef72cf3e6de7b14012e7a0672676
+  Automattic-Tracks-iOS: b0f5d0cde00e4a0ff423d0139d84e2819af91c6a
   CocoaLumberjack: bd155f2dd06c0e0b03f876f7a3ee55693122ec94
   Reachability: 33e18b67625424e47b6cde6d202dce689ad7af96
   Sentry: ab6c209f23700d1460691dbc90e19ed0a05d496b
   Simperium-OSX: 677949c579f96c4fd194b532bdffda86b00b3db8
   Sodium: 63c0ca312a932e6da481689537d4b35568841bdc
 
-PODFILE CHECKSUM: 3e9e3836b359a135afd5e690bc752feda9e53e96
+PODFILE CHECKSUM: b6ce3bf0aa9a39ad9dfd426878722575e7ac1f1e
 
 COCOAPODS: 1.6.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -3,11 +3,11 @@ PODS:
     - CocoaLumberjack (~> 3)
     - Reachability (~> 3)
     - Sentry (~> 4)
-    - Sodium (~> 0.8.0)
+    - Sodium-Fork (= 0.8.2)
     - UIDeviceIdentifier (~> 1)
-  - CocoaLumberjack (3.6.2):
-    - CocoaLumberjack/Core (= 3.6.2)
-  - CocoaLumberjack/Core (3.6.2)
+  - CocoaLumberjack (3.7.0):
+    - CocoaLumberjack/Core (= 3.7.0)
+  - CocoaLumberjack/Core (3.7.0)
   - Reachability (3.2)
   - Sentry (4.5.0):
     - Sentry/Core (= 4.5.0)
@@ -23,7 +23,7 @@ PODS:
   - Simperium-OSX/SocketRocket (0.8.30)
   - Simperium-OSX/SPReachability (0.8.30)
   - Simperium-OSX/SSKeychain (0.8.30)
-  - Sodium (0.8.0)
+  - Sodium-Fork (0.8.2)
 
 DEPENDENCIES:
   - Automattic-Tracks-iOS (from `https://github.com/Automattic/Automattic-Tracks-iOS`, branch `store-data-in-application-support`)
@@ -35,7 +35,7 @@ SPEC REPOS:
     - Reachability
     - Sentry
     - Simperium-OSX
-    - Sodium
+    - Sodium-Fork
 
 EXTERNAL SOURCES:
   Automattic-Tracks-iOS:
@@ -44,16 +44,16 @@ EXTERNAL SOURCES:
 
 CHECKOUT OPTIONS:
   Automattic-Tracks-iOS:
-    :commit: 90cc2ab6f9038a2f79e4bd89cae882abaffc5bd9
+    :commit: 61a05f6229b334b317b20dc2392c120d2f4a25cc
     :git: https://github.com/Automattic/Automattic-Tracks-iOS
 
 SPEC CHECKSUMS:
-  Automattic-Tracks-iOS: b0f5d0cde00e4a0ff423d0139d84e2819af91c6a
-  CocoaLumberjack: bd155f2dd06c0e0b03f876f7a3ee55693122ec94
+  Automattic-Tracks-iOS: c0f2377e508400e8bba8b6772cf6356e44a9bf2e
+  CocoaLumberjack: e8955b9d337ac307103b0a34fd141c32f27e53c5
   Reachability: 33e18b67625424e47b6cde6d202dce689ad7af96
   Sentry: ab6c209f23700d1460691dbc90e19ed0a05d496b
   Simperium-OSX: 677949c579f96c4fd194b532bdffda86b00b3db8
-  Sodium: 63c0ca312a932e6da481689537d4b35568841bdc
+  Sodium-Fork: 45fe3a7c675898ca0635af4eadcb34985477e868
 
 PODFILE CHECKSUM: b6ce3bf0aa9a39ad9dfd426878722575e7ac1f1e
 

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -1508,7 +1508,7 @@
 				"${BUILT_PRODUCTS_DIR}/Reachability/Reachability.framework",
 				"${BUILT_PRODUCTS_DIR}/Sentry/Sentry.framework",
 				"${BUILT_PRODUCTS_DIR}/Simperium-OSX/Simperium_OSX.framework",
-				"${BUILT_PRODUCTS_DIR}/Sodium/Sodium.framework",
+				"${BUILT_PRODUCTS_DIR}/Sodium-Fork/Sodium.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
@@ -1584,7 +1584,7 @@
 				"${BUILT_PRODUCTS_DIR}/Reachability/Reachability.framework",
 				"${BUILT_PRODUCTS_DIR}/Sentry/Sentry.framework",
 				"${BUILT_PRODUCTS_DIR}/Simperium-OSX/Simperium_OSX.framework",
-				"${BUILT_PRODUCTS_DIR}/Sodium/Sodium.framework",
+				"${BUILT_PRODUCTS_DIR}/Sodium-Fork/Sodium.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
@@ -1683,7 +1683,7 @@
 				"${BUILT_PRODUCTS_DIR}/Reachability/Reachability.framework",
 				"${BUILT_PRODUCTS_DIR}/Sentry/Sentry.framework",
 				"${BUILT_PRODUCTS_DIR}/Simperium-OSX/Simperium_OSX.framework",
-				"${BUILT_PRODUCTS_DIR}/Sodium/Sodium.framework",
+				"${BUILT_PRODUCTS_DIR}/Sodium-Fork/Sodium.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (


### PR DESCRIPTION
### Fix

Updates Tracks to test the changes from https://github.com/Automattic/Automattic-Tracks-iOS/pull/147. There is no source change in Simplenote, but this PR is useful to test that the new version doesn't break the app's behavior.

### Test

- Checkout this branch
- Run `bundle exec pod update Automattic-Tracks-iOS`
- Run the app make sure that it behaves as usual
- If you want, put a breakpoint at ... to verify that the path used for the store is the Documents one, as it was before.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.