### PR TITLE
Interlink: Fixing Undo + Preventing Recursive Links

### DIFF
--- a/Simplenote/InterlinkViewController.swift
+++ b/Simplenote/InterlinkViewController.swift
@@ -82,8 +82,8 @@ extension InterlinkViewController {
     ///     By design, whenever there are no results we won't be refreshing the TableView. Instead, we'll stick to the "old results".
     ///     This way we get to avoid the awkward visual effect of "empty autocomplete window"
     ///
-    func refreshInterlinks(for keyword: String) -> Bool {
-        filteredNotes = filterNotes(resultsController.fetchedObjects, byTitleKeyword: keyword)
+    func refreshInterlinks(for keyword: String, excluding excludedID: NSManagedObjectID?) -> Bool {
+        filteredNotes = filterNotes(resultsController.fetchedObjects, byTitleKeyword: keyword, excluding: excludedID)
         let displaysRows = filteredNotes.count > .zero
 
         if displaysRows {
@@ -129,11 +129,11 @@ private extension InterlinkViewController {
 //
 private extension InterlinkViewController {
 
-    func filterNotes(_ notes: [Note], byTitleKeyword keyword: String, limit: Int = Settings.maximumNumberOfResults) -> [Note] {
+    func filterNotes(_ notes: [Note], byTitleKeyword keyword: String, excluding excludedID: NSManagedObjectID?, limit: Int = Settings.maximumNumberOfResults) -> [Note] {
         var output = [Note]()
         let normalizedKeyword = keyword.folding(options: [.diacriticInsensitive, .caseInsensitive], locale: nil)
 
-        for note in notes {
+        for note in notes where note.objectID != excludedID {
             note.ensurePreviewStringsAreAvailable()
             guard let normalizedTitle = note.titlePreview?.folding(options: [.diacriticInsensitive, .caseInsensitive], locale: nil),
                   normalizedTitle.contains(normalizedKeyword)

--- a/Simplenote/NSTextView+Simplenote.swift
+++ b/Simplenote/NSTextView+Simplenote.swift
@@ -39,9 +39,11 @@ extension NSTextView {
     /// Inserts the specified Text at a given range, and ensures the document is linkified
     ///
     func insertTextAndLinkify(text: String, in range: Range<String.Index>) {
-        let range = string.utf16NSRange(from: range)
-        replaceCharacters(in: range, with: text)
-        processLinksInDocumentAsynchronously()
+        registerUndoCheckpointAndPerform { storage in
+            let range = string.utf16NSRange(from: range)
+            storage.replaceCharacters(in: range, with: text)
+            processLinksInDocumentAsynchronously()
+        }
     }
 
     /// Removes the text at the specified range, and notifies the delegate.
@@ -72,6 +74,7 @@ private extension NSTextView {
     ///     2.  Wraps up a given `Block` within an Undo Group
     ///     3.  Post a TextDidChange Notification
     ///
+    @discardableResult
     func registerUndoCheckpointAndPerform(block: (NSTextStorage) -> Void) -> Bool {
         guard let storage = textStorage, let undoManager = undoManager else {
             return false

--- a/Simplenote/NoteEditorViewController+Swift.swift
+++ b/Simplenote/NoteEditorViewController+Swift.swift
@@ -571,7 +571,7 @@ extension NoteEditorViewController {
     func processInterlinkLookup() {
         guard mustProcessInterlinkLookup,
               let (markdownRange, keywordRange, keywordText) = noteEditor.interlinkKeywordAtSelectedLocation,
-              refreshInterlinks(for: keywordText, in: markdownRange)
+              refreshInterlinks(for: keywordText, in: markdownRange, excluding: note?.objectID)
         else {
             dismissInterlinkWindow()
             return
@@ -637,7 +637,7 @@ private extension NoteEditorViewController {
     /// Refreshes the Interlinks for a given Keyword at the specified Replacement Range (including Markdown `[` opening character).
     /// - Returns: `true` whenever there *are* interlinks to be presented
     ///
-    func refreshInterlinks(for keywordText: String, in replacementRange: Range<String.Index>) -> Bool {
+    func refreshInterlinks(for keywordText: String, in replacementRange: Range<String.Index>, excluding excludedID: NSManagedObjectID?) -> Bool {
         guard let interlinkViewController = reusableInterlinkWindowController().interlinkViewController else {
             fatalError()
         }
@@ -647,7 +647,7 @@ private extension NoteEditorViewController {
             self?.dismissInterlinkWindow()
         }
 
-        return interlinkViewController.refreshInterlinks(for: keywordText)
+        return interlinkViewController.refreshInterlinks(for: keywordText, excluding: excludedID)
     }
 
     /// Returns a reusable InterlinkWindowController instance


### PR DESCRIPTION
### Details:
In this PR we're introducing (two) changes to the Interlink Autocomplete feature:

- We're wiring the same API built for Checklists, so that Undo OPs don't break Interlinks
- And we're excluding the "Note Onscreen" from the suggestions list, to avoid weird scenarios

@aerych Sir!! would you be game for a quick PR?
Thank youuu!!!

Ref. #663 

### Test
1. Open any note with Markdown Enabled
2. Type `[keyword` with **keyword** being a word contained in multiple notes
3. Select any note from the Interlink window

- [x] Verify that pressing CMD + Z properly reverts the text

### Test: Exclusions
1. Add a new note
2. Enable Markdown
3. Type `[z` in the very first line

- [x] Verify that no (self referencing) Interlink Suggestion shows up. The current document should be excluded!

### Release
These changes do not require release notes.
