### PR TITLE
Interlink References

### DIFF
--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -2661,8 +2661,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "git@github.com:Automattic/SimplenoteSearch-Swift.git";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 1.0.0;
+				kind = revision;
+				revision = 9cb8269cd9b3ef5e5d42c38bce27821b15f4d424;
 			};
 		};
 		B5609AEE24EF171D0097777A /* XCRemoteSwiftPackageReference "SimplenoteFoundation-Swift" */ = {

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -172,6 +172,8 @@
 		B532F8A820C71C1000EA3506 /* WPAuthHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 37D4DD6820B3574C00C225EA /* WPAuthHandler.m */; };
 		B535014B249D5908003837C8 /* HorizontalScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B535014A249D5908003837C8 /* HorizontalScrollView.swift */; };
 		B535014C249D5908003837C8 /* HorizontalScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B535014A249D5908003837C8 /* HorizontalScrollView.swift */; };
+		B5395E1D253F70E30068F1A6 /* MetricTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5395E1C253F70E30068F1A6 /* MetricTableViewCell.swift */; };
+		B5395E1E253F70E30068F1A6 /* MetricTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5395E1C253F70E30068F1A6 /* MetricTableViewCell.swift */; };
 		B53BF19C24ABDE7C00938C34 /* DateFormatter+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53BF19B24ABDE7C00938C34 /* DateFormatter+Simplenote.swift */; };
 		B53BF19D24ABDE7C00938C34 /* DateFormatter+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53BF19B24ABDE7C00938C34 /* DateFormatter+Simplenote.swift */; };
 		B53BF1A024AC1FB800938C34 /* Version.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53BF19F24AC1FB800938C34 /* Version.swift */; };
@@ -195,6 +197,8 @@
 		B54F9A6B24D0BDC100BCF754 /* TagTextFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54F9A6924D0BDC100BCF754 /* TagTextFormatter.swift */; };
 		B551187224E33BC2007B11E3 /* ClipView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B551187124E33BC2007B11E3 /* ClipView.swift */; };
 		B551187324E33BC2007B11E3 /* ClipView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B551187124E33BC2007B11E3 /* ClipView.swift */; };
+		B5562435253E328400836E20 /* ReferenceTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5562434253E328400836E20 /* ReferenceTableViewCell.swift */; };
+		B5562436253E328400836E20 /* ReferenceTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5562434253E328400836E20 /* ReferenceTableViewCell.swift */; };
 		B55C312624A5117F00B23B3F /* SpacerTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55C312524A5117F00B23B3F /* SpacerTableViewCell.swift */; };
 		B55C312724A5117F00B23B3F /* SpacerTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55C312524A5117F00B23B3F /* SpacerTableViewCell.swift */; };
 		B55C312C24A530A500B23B3F /* MetricsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55C312B24A530A500B23B3F /* MetricsViewController.swift */; };
@@ -547,6 +551,7 @@
 		B529F7B724586DF800B168F1 /* MarkdownViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = MarkdownViewController.xib; sourceTree = "<group>"; };
 		B52F203824C5FB1E00ABB43F /* NSWindow+Simplenote.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSWindow+Simplenote.swift"; sourceTree = "<group>"; };
 		B535014A249D5908003837C8 /* HorizontalScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HorizontalScrollView.swift; sourceTree = "<group>"; };
+		B5395E1C253F70E30068F1A6 /* MetricTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetricTableViewCell.swift; sourceTree = "<group>"; };
 		B53BF19B24ABDE7C00938C34 /* DateFormatter+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DateFormatter+Simplenote.swift"; sourceTree = "<group>"; };
 		B53BF19F24AC1FB800938C34 /* Version.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Version.swift; sourceTree = "<group>"; };
 		B53BF1A324AC38C100938C34 /* VersionsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VersionsController.swift; sourceTree = "<group>"; };
@@ -560,6 +565,7 @@
 		B54F9A6624D0B21D00BCF754 /* NSNotification+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSNotification+Simplenote.swift"; sourceTree = "<group>"; };
 		B54F9A6924D0BDC100BCF754 /* TagTextFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagTextFormatter.swift; sourceTree = "<group>"; };
 		B551187124E33BC2007B11E3 /* ClipView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipView.swift; sourceTree = "<group>"; };
+		B5562434253E328400836E20 /* ReferenceTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReferenceTableViewCell.swift; sourceTree = "<group>"; };
 		B55C312524A5117F00B23B3F /* SpacerTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpacerTableViewCell.swift; sourceTree = "<group>"; };
 		B55C312B24A530A500B23B3F /* MetricsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetricsViewController.swift; sourceTree = "<group>"; };
 		B55C313B24A55ED800B23B3F /* NSVisualEffectView+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSVisualEffectView+Simplenote.swift"; sourceTree = "<group>"; };
@@ -1337,6 +1343,8 @@
 				B5C63348251E6E3200C8BF46 /* LinkTableCellView.swift */,
 				B5DD0F902476309000C8DD41 /* NoteTableCellView.swift */,
 				B5E086342448EA3C00DEF476 /* TagTableCellView.swift */,
+				B5562434253E328400836E20 /* ReferenceTableViewCell.swift */,
+				B5395E1C253F70E30068F1A6 /* MetricTableViewCell.swift */,
 				B55C312524A5117F00B23B3F /* SpacerTableViewCell.swift */,
 			);
 			name = TableViewCells;
@@ -1792,6 +1800,7 @@
 				3712FC8C1FE1ACAA008544AC /* Style.swift in Sources */,
 				375D294021E033D1007AB25A /* html_smartypants.c in Sources */,
 				B551187224E33BC2007B11E3 /* ClipView.swift in Sources */,
+				B5395E1D253F70E30068F1A6 /* MetricTableViewCell.swift in Sources */,
 				B5E061772450AEDA0076111A /* ToolbarView.swift in Sources */,
 				F998F3EB22853C29008C2B59 /* CrashLogging.swift in Sources */,
 				2614F1DF1405A0B10031AE94 /* Note.m in Sources */,
@@ -1881,6 +1890,7 @@
 				373B50DF20179DFE000568A6 /* Extensions.swift in Sources */,
 				B58BBD46252411530025135F /* NSEvent+Simplenote.swift in Sources */,
 				B549B085245A2E7500FB95B9 /* NSFont+Theme.swift in Sources */,
+				B5562435253E328400836E20 /* ReferenceTableViewCell.swift in Sources */,
 				46EF5198177C4ECC00A139E0 /* SPApplication.m in Sources */,
 				B51E9FE122E615FA004F16B4 /* SPExporter.swift in Sources */,
 				46CF73071782C6B200FC2B5C /* TagListViewController.m in Sources */,
@@ -1936,6 +1946,7 @@
 				B5A5AF7D244FA7BA0051D927 /* NoteEditorViewController+Swift.swift in Sources */,
 				B500993D24213B370037A431 /* String+Simplenote.swift in Sources */,
 				B551187324E33BC2007B11E3 /* ClipView.swift in Sources */,
+				B5395E1E253F70E30068F1A6 /* MetricTableViewCell.swift in Sources */,
 				3712FC8D1FE1ACAA008544AC /* Style.swift in Sources */,
 				375D294121E033D1007AB25A /* html_smartypants.c in Sources */,
 				B5E061782450AEDA0076111A /* ToolbarView.swift in Sources */,
@@ -2025,6 +2036,7 @@
 				466FFECE17CC10A800399652 /* SPApplication.m in Sources */,
 				B58BBD47252411530025135F /* NSEvent+Simplenote.swift in Sources */,
 				B51E9FE222E615FA004F16B4 /* SPExporter.swift in Sources */,
+				B5562436253E328400836E20 /* ReferenceTableViewCell.swift in Sources */,
 				466FFECF17CC10A800399652 /* TagListViewController.m in Sources */,
 				B52F8FDA24644DD00062B8ED /* NSFont+Theme.swift in Sources */,
 				B511799C242036BD005F8936 /* NSTextView+Simplenote.swift in Sources */,

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -2679,8 +2679,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "git@github.com:Automattic/SimplenoteSearch-Swift.git";
 			requirement = {
-				kind = revision;
-				revision = 9cb8269cd9b3ef5e5d42c38bce27821b15f4d424;
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.1.0;
 			};
 		};
 		B5609AEE24EF171D0097777A /* XCRemoteSwiftPackageReference "SimplenoteFoundation-Swift" */ = {

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -160,6 +160,8 @@
 		B51E9FE222E615FA004F16B4 /* SPExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B51E9FE022E615FA004F16B4 /* SPExporter.swift */; };
 		B51E9FE522E644A0004F16B4 /* NSObject+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B51E9FE422E644A0004F16B4 /* NSObject+Helpers.swift */; };
 		B51E9FE622E644A0004F16B4 /* NSObject+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B51E9FE422E644A0004F16B4 /* NSObject+Helpers.swift */; };
+		B52197862541C65C00182928 /* NumberFormatter+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B52197852541C65C00182928 /* NumberFormatter+Simplenote.swift */; };
+		B52197872541C65C00182928 /* NumberFormatter+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B52197852541C65C00182928 /* NumberFormatter+Simplenote.swift */; };
 		B5283BD023B679C00085826F /* NSMutableAttributedString+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5283BCF23B679C00085826F /* NSMutableAttributedString+Simplenote.swift */; };
 		B5283BD123B679C00085826F /* NSMutableAttributedString+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5283BCF23B679C00085826F /* NSMutableAttributedString+Simplenote.swift */; };
 		B529F7B524586D8700B168F1 /* MarkdownViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B529F7B424586D8700B168F1 /* MarkdownViewController.swift */; };
@@ -529,6 +531,7 @@
 		B518D37D2507C356006EA7F8 /* StringSimplenoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringSimplenoteTests.swift; sourceTree = "<group>"; };
 		B51E9FE022E615FA004F16B4 /* SPExporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPExporter.swift; sourceTree = "<group>"; };
 		B51E9FE422E644A0004F16B4 /* NSObject+Helpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSObject+Helpers.swift"; sourceTree = "<group>"; };
+		B52197852541C65C00182928 /* NumberFormatter+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NumberFormatter+Simplenote.swift"; sourceTree = "<group>"; };
 		B5242DEB24C9238700437E40 /* ar */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ar; path = ar.lproj/MainMenu.strings; sourceTree = "<group>"; };
 		B5242DED24C9238C00437E40 /* zh-Hans-CN */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans-CN"; path = "zh-Hans-CN.lproj/MainMenu.strings"; sourceTree = "<group>"; };
 		B5242DEF24C9238E00437E40 /* zh-Hant-TW */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant-TW"; path = "zh-Hant-TW.lproj/MainMenu.strings"; sourceTree = "<group>"; };
@@ -1060,6 +1063,7 @@
 				B55C313B24A55ED800B23B3F /* NSVisualEffectView+Simplenote.swift */,
 				B52F203824C5FB1E00ABB43F /* NSWindow+Simplenote.swift */,
 				B58942F924E5EE8E006EC232 /* NSWindowFrameAutosaveName+Simplenote.swift */,
+				B52197852541C65C00182928 /* NumberFormatter+Simplenote.swift */,
 				B5F807CE2481A2010048CBD7 /* Simperium+Simplenote.swift */,
 				B5609AEB24EEE7200097777A /* SPBucket+Simplenote.swift */,
 				B500993B24213B370037A431 /* String+Simplenote.swift */,
@@ -1884,6 +1888,7 @@
 				B5C7DD40243E4A7D00BEE354 /* CollaborateViewController.swift in Sources */,
 				B5E196C1230F5F5300F5658A /* SPCredentials.swift in Sources */,
 				B51374F61AC0591900825FCC /* SPConstants.m in Sources */,
+				B52197862541C65C00182928 /* NumberFormatter+Simplenote.swift in Sources */,
 				B5D5887A244F890100345916 /* NSButton+Simplenote.swift in Sources */,
 				B5E086382448EE9D00DEF476 /* NSTableView+Simplenote.swift in Sources */,
 				3712FC861FE1ACAA008544AC /* Element.swift in Sources */,
@@ -2031,6 +2036,7 @@
 				B5E196C2230F5F5300F5658A /* SPCredentials.swift in Sources */,
 				B51374F71AC0591900825FCC /* SPConstants.m in Sources */,
 				B5D5887B244F890100345916 /* NSButton+Simplenote.swift in Sources */,
+				B52197872541C65C00182928 /* NumberFormatter+Simplenote.swift in Sources */,
 				B5E086392448EE9D00DEF476 /* NSTableView+Simplenote.swift in Sources */,
 				3712FC871FE1ACAA008544AC /* Element.swift in Sources */,
 				B5F04FD121594B6D004B1AA0 /* Simperium+Simplenote.m in Sources */,

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -303,6 +303,8 @@
 		B5C7DD47243E51E200BEE354 /* PublishViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5C7DD45243E51E200BEE354 /* PublishViewController.swift */; };
 		B5C7DD49243E524000BEE354 /* PublishViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = B5C7DD48243E524000BEE354 /* PublishViewController.xib */; };
 		B5C7DD4A243E524000BEE354 /* PublishViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = B5C7DD48243E524000BEE354 /* PublishViewController.xib */; };
+		B5C9776C25408BD200702C10 /* SeparatorTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5C9776B25408BD200702C10 /* SeparatorTableViewCell.swift */; };
+		B5C9776D25408BD200702C10 /* SeparatorTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5C9776B25408BD200702C10 /* SeparatorTableViewCell.swift */; };
 		B5CBB05C2419714B0003C271 /* NSAttributedStringToMarkdownConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5CBB05B2419714B0003C271 /* NSAttributedStringToMarkdownConverter.swift */; };
 		B5CBB05D2419714B0003C271 /* NSAttributedStringToMarkdownConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5CBB05B2419714B0003C271 /* NSAttributedStringToMarkdownConverter.swift */; };
 		B5CBB073241976280003C271 /* NSAttributedStringToMarkdownConverterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5CBB062241975B30003C271 /* NSAttributedStringToMarkdownConverterTests.swift */; };
@@ -647,6 +649,7 @@
 		B5C7DD42243E4A8E00BEE354 /* CollaborateViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CollaborateViewController.xib; sourceTree = "<group>"; };
 		B5C7DD45243E51E200BEE354 /* PublishViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublishViewController.swift; sourceTree = "<group>"; };
 		B5C7DD48243E524000BEE354 /* PublishViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = PublishViewController.xib; sourceTree = "<group>"; };
+		B5C9776B25408BD200702C10 /* SeparatorTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeparatorTableViewCell.swift; sourceTree = "<group>"; };
 		B5CBB05B2419714B0003C271 /* NSAttributedStringToMarkdownConverter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSAttributedStringToMarkdownConverter.swift; sourceTree = "<group>"; };
 		B5CBB062241975B30003C271 /* NSAttributedStringToMarkdownConverterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSAttributedStringToMarkdownConverterTests.swift; sourceTree = "<group>"; };
 		B5CBB069241976230003C271 /* SimplenoteTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SimplenoteTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1345,6 +1348,7 @@
 				B5E086342448EA3C00DEF476 /* TagTableCellView.swift */,
 				B5562434253E328400836E20 /* ReferenceTableViewCell.swift */,
 				B5395E1C253F70E30068F1A6 /* MetricTableViewCell.swift */,
+				B5C9776B25408BD200702C10 /* SeparatorTableViewCell.swift */,
 				B55C312524A5117F00B23B3F /* SpacerTableViewCell.swift */,
 			);
 			name = TableViewCells;
@@ -1795,6 +1799,7 @@
 				26F72AA014032D2A00A7935E /* SimplenoteAppDelegate.m in Sources */,
 				B5A5AF7C244FA7BA0051D927 /* NoteEditorViewController+Swift.swift in Sources */,
 				B500993C24213B370037A431 /* String+Simplenote.swift in Sources */,
+				B5C9776C25408BD200702C10 /* SeparatorTableViewCell.swift in Sources */,
 				B50FB214251BB2E00028DE25 /* InterlinkWindowController.swift in Sources */,
 				B58BBD2A2523D4CA0025135F /* Window.swift in Sources */,
 				3712FC8C1FE1ACAA008544AC /* Style.swift in Sources */,
@@ -1941,6 +1946,7 @@
 				B5985ACF24293E360044EDE9 /* NSRegularExpression+Simplenote.swift in Sources */,
 				B51E9FE622E644A0004F16B4 /* NSObject+Helpers.swift in Sources */,
 				466FFEAB17CC10A800399652 /* Tag.m in Sources */,
+				B5C9776D25408BD200702C10 /* SeparatorTableViewCell.swift in Sources */,
 				B50FB215251BB2E00028DE25 /* InterlinkWindowController.swift in Sources */,
 				B58BBD2B2523D4CA0025135F /* Window.swift in Sources */,
 				B5A5AF7D244FA7BA0051D927 /* NoteEditorViewController+Swift.swift in Sources */,

--- a/Simplenote.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Simplenote.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "git@github.com:Automattic/SimplenoteSearch-Swift.git",
         "state": {
           "branch": null,
-          "revision": "c594338829e8fb8954fad8743508b135da17b132",
-          "version": "1.0.0"
+          "revision": "9cb8269cd9b3ef5e5d42c38bce27821b15f4d424",
+          "version": null
         }
       }
     ]

--- a/Simplenote.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Simplenote.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "git@github.com:Automattic/SimplenoteSearch-Swift.git",
         "state": {
           "branch": null,
-          "revision": "9cb8269cd9b3ef5e5d42c38bce27821b15f4d424",
-          "version": null
+          "revision": "a0f72ae7441d0311c41b47dfa4046bc9e23823bf",
+          "version": "1.1.0"
         }
       }
     ]

--- a/Simplenote/DateFormatter+Simplenote.swift
+++ b/Simplenote/DateFormatter+Simplenote.swift
@@ -14,15 +14,6 @@ extension DateFormatter {
         return formatter
     }()
 
-    /// Date Formatter for Interlinking References
-    ///
-    static let referenceFormatter: DateFormatter = {
-        let formatter = DateFormatter()
-        formatter.dateStyle = .short
-        formatter.timeStyle = .none
-        return formatter
-    }()
-
     /// Date Formatter for History
     ///
     static let historyFormatter: DateFormatter = metricsFormatter

--- a/Simplenote/DateFormatter+Simplenote.swift
+++ b/Simplenote/DateFormatter+Simplenote.swift
@@ -14,6 +14,15 @@ extension DateFormatter {
         return formatter
     }()
 
+    /// Date Formatter for Interlinking References
+    ///
+    static let referenceFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .short
+        formatter.timeStyle = .none
+        return formatter
+    }()
+
     /// Date Formatter for History
     ///
     static let historyFormatter: DateFormatter = metricsFormatter

--- a/Simplenote/HeaderTableCellView.swift
+++ b/Simplenote/HeaderTableCellView.swift
@@ -6,8 +6,25 @@ import AppKit
 //
 class HeaderTableCellView: NSTableCellView {
 
-    override func prepareForReuse() {
-        super.prepareForReuse()
-        textField?.textColor = .simplenoteSecondaryTextColor
+    /// Wraps access to the TextField's String Value
+    ///
+    var title: String? {
+        get {
+            textField?.stringValue
+        }
+        set {
+            textField?.stringValue = newValue ?? ""
+        }
+    }
+
+    /// Wraps access to the TextField's Text Color
+    ///
+    var titleColor: NSColor? {
+        get {
+            textField?.textColor
+        }
+        set {
+            textField?.textColor = newValue
+        }
     }
 }

--- a/Simplenote/InterlinkViewController.swift
+++ b/Simplenote/InterlinkViewController.swift
@@ -163,11 +163,11 @@ extension InterlinkViewController {
 
     @objc
     func performInterlinkInsert() {
-        guard let interlinkText = noteAtRow(tableView.selectedRow)?.markdownInternalLink else {
+        guard let markdownInterlink = noteAtRow(tableView.selectedRow)?.markdownInterlink else {
             return
         }
 
-        onInsertInterlink?(interlinkText)
+        onInsertInterlink?(markdownInterlink)
     }
 }
 

--- a/Simplenote/MetricTableViewCell.swift
+++ b/Simplenote/MetricTableViewCell.swift
@@ -1,0 +1,52 @@
+import Foundation
+import AppKit
+
+
+// MARK: - MetricTableViewCell
+//
+class MetricTableViewCell: NSTableCellView {
+
+    /// Value's Text Field
+    ///
+    @IBOutlet private weak var valueTextField: NSTextField?
+
+    /// Wraps access to the TextField's String Value
+    ///
+    var title: String? {
+        get {
+            textField?.stringValue
+        }
+        set {
+            textField?.stringValue = newValue ?? ""
+        }
+    }
+
+    /// Wraps access to the Value TextField's String Value
+    ///
+    var value: String? {
+        get {
+            valueTextField?.stringValue
+        }
+        set {
+            valueTextField?.stringValue = newValue ?? ""
+        }
+    }
+
+    // MARK: - Overridden Methods
+
+    override func viewWillDraw() {
+        super.viewWillDraw()
+        refreshStyle()
+    }
+}
+
+
+// MARK: - Private API(s)
+//
+private extension MetricTableViewCell {
+
+    func refreshStyle() {
+        textField?.textColor = .simplenoteTextColor
+        valueTextField?.textColor = .simplenoteSecondaryTextColor
+    }
+}

--- a/Simplenote/MetricsViewController.swift
+++ b/Simplenote/MetricsViewController.swift
@@ -279,6 +279,7 @@ private extension MetricsViewController {
     func dequeueHeaderCell(from tableView: NSTableView, text: String) -> NSView {
         let headerCell = tableView.makeTableViewCell(ofType: HeaderTableCellView.self)
         headerCell.title = text
+        headerCell.titleColor = .simplenoteTextColor
         return headerCell
     }
 

--- a/Simplenote/MetricsViewController.swift
+++ b/Simplenote/MetricsViewController.swift
@@ -181,10 +181,10 @@ private extension MetricsViewController {
                     value: metrics.creationDate),
 
             .metric(title: NSLocalizedString("Words", comment: "Number of words in the note"),
-                    value: String(metrics.numberOfWords)),
+                    value: metrics.numberOfWords),
 
             .metric(title: NSLocalizedString("Characters", comment: "Number of characters in the note"),
-                    value: String(metrics.numberOfChars))
+                    value: metrics.numberOfChars)
         ]
     }
 

--- a/Simplenote/MetricsViewController.swift
+++ b/Simplenote/MetricsViewController.swift
@@ -7,6 +7,11 @@ import SimplenoteFoundation
 //
 class MetricsViewController: NSViewController {
 
+    /// Section Headers
+    ///
+    @IBOutlet private(set) var informationTextLabel: NSTextField!
+    @IBOutlet private(set) var referencesTextLabel: NSTextField!
+
     /// Modified: Left Text / Right Details
     ///
     @IBOutlet private(set) var modifiedTextLabel: NSTextField!

--- a/Simplenote/MetricsViewController.swift
+++ b/Simplenote/MetricsViewController.swift
@@ -213,7 +213,6 @@ extension MetricsViewController: NSTableViewDelegate {
 private extension MetricsViewController {
 
     func dequeueAndConfigureCell(at index: Int, in tableView: NSTableView) -> NSView {
-NSLog("# SETUP \(index)")
         switch rows[index] {
         case .header(let text):
             return dequeueHeaderCell(from: tableView, text: text)
@@ -244,7 +243,10 @@ NSLog("# SETUP \(index)")
 
         let referenceCell = tableView.makeTableViewCell(ofType: ReferenceTableViewCell.self)
         referenceCell.title = note.titlePreview
-        referenceCell.details = "Hello"
+        referenceCell.details = NSLocalizedString("Last modified", comment: "Reference Last Modification Date")
+                                    + .space
+                                    + DateFormatter.referenceFormatter.string(from: note.modificationDate)
+
         return referenceCell
     }
 }

--- a/Simplenote/MetricsViewController.swift
+++ b/Simplenote/MetricsViewController.swift
@@ -99,6 +99,10 @@ private extension MetricsViewController {
         }
 
         resultsController.predicate = NSPredicate.predicateForNotes(exactMatch: plainInterlink)
+        resultsController.onDidChangeContent = { [weak self] _, _ in
+            self?.refreshInterface()
+        }
+
         try? resultsController.performFetch()
     }
 
@@ -159,7 +163,9 @@ private extension MetricsViewController {
     }
 
     func adjustRootViewSize() {
-        view.frame.size = calculatePreferredSize(for: rows)
+        let preferredSize = calculatePreferredSize(for: rows)
+        view.frame.size = preferredSize
+        presentingPopover?.contentSize = preferredSize
     }
 
     /// Returns Metric Rows for a collection of notes

--- a/Simplenote/MetricsViewController.swift
+++ b/Simplenote/MetricsViewController.swift
@@ -307,7 +307,7 @@ private extension MetricsViewController {
         referenceCell.title = note.titlePreview
         referenceCell.details = NSLocalizedString("Last modified", comment: "Reference Last Modification Date")
                                     + .space
-                                    + DateFormatter.referenceFormatter.string(from: note.modificationDate)
+                                    + DateFormatter.metricsFormatter.string(from: note.modificationDate)
 
         return referenceCell
     }

--- a/Simplenote/MetricsViewController.xib
+++ b/Simplenote/MetricsViewController.xib
@@ -8,161 +8,30 @@
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="MetricsViewController" customModule="Simplenote" customModuleProvider="target">
             <connections>
-                <outlet property="charsDetailsLabel" destination="gn3-44-UTu" id="bMO-5f-X9j"/>
-                <outlet property="charsTextLabel" destination="K8z-ay-qcP" id="hEX-CG-zpu"/>
-                <outlet property="createdDetailsLabel" destination="dZ0-tU-Bc5" id="onE-fJ-GgN"/>
-                <outlet property="createdTextLabel" destination="TD2-YG-kpC" id="mXe-uL-Jyl"/>
-                <outlet property="informationTextLabel" destination="hSa-Xl-61W" id="QPu-y3-L2k"/>
-                <outlet property="modifiedDetailsLabel" destination="C9a-zL-iLu" id="VcY-tM-dzi"/>
-                <outlet property="modifiedTextLabel" destination="ZyH-GP-C2f" id="wbw-FY-Kvl"/>
-                <outlet property="referencesTextLabel" destination="YwT-om-acp" id="QTv-VS-IgT"/>
+                <outlet property="clipView" destination="zap-Ek-wU5" id="Mz7-bO-Kuh"/>
+                <outlet property="tableView" destination="utn-0E-OEM" id="NVY-Uh-aDy"/>
                 <outlet property="view" destination="9uy-MA-rkc" id="vPg-k3-f7w"/>
-                <outlet property="wordsDetailsLabel" destination="AQn-dM-7Jm" id="rUb-Ur-mZ7"/>
-                <outlet property="wordsTextLabel" destination="GPX-iN-iZj" id="lqB-Qu-nzF"/>
             </connections>
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <view translatesAutoresizingMaskIntoConstraints="NO" id="9uy-MA-rkc">
-            <rect key="frame" x="0.0" y="0.0" width="358" height="279"/>
+            <rect key="frame" x="0.0" y="0.0" width="358" height="123"/>
             <subviews>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="hSa-Xl-61W">
-                    <rect key="frame" x="18" y="243" width="322" height="16"/>
-                    <textFieldCell key="cell" lineBreakMode="clipping" title="?Information" id="i1N-fO-VXQ">
-                        <font key="font" size="14" name="SFProText-Bold"/>
-                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                    </textFieldCell>
-                </textField>
-                <stackView distribution="fill" orientation="vertical" alignment="leading" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="bIO-uD-Uuz" userLabel="Left Stack">
-                    <rect key="frame" x="40" y="147" width="108" height="88"/>
-                    <subviews>
-                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZyH-GP-C2f">
-                            <rect key="frame" x="-2" y="72" width="69" height="16"/>
-                            <textFieldCell key="cell" lineBreakMode="clipping" refusesFirstResponder="YES" allowsUndo="NO" title="?Modified" usesSingleLineMode="YES" id="B2B-hL-UQ6">
-                                <font key="font" size="14" name="SFProText-Regular"/>
-                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                            </textFieldCell>
-                        </textField>
-                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TD2-YG-kpC">
-                            <rect key="frame" x="-2" y="48" width="64" height="16"/>
-                            <textFieldCell key="cell" lineBreakMode="clipping" refusesFirstResponder="YES" allowsUndo="NO" title="?Created" usesSingleLineMode="YES" id="run-fe-x9I">
-                                <font key="font" size="14" name="SFProText-Regular"/>
-                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                            </textFieldCell>
-                        </textField>
-                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="GPX-iN-iZj">
-                            <rect key="frame" x="-2" y="24" width="54" height="16"/>
-                            <textFieldCell key="cell" lineBreakMode="clipping" refusesFirstResponder="YES" allowsUndo="NO" title="?Words" usesSingleLineMode="YES" id="hKD-Rp-G24">
-                                <font key="font" size="14" name="SFProText-Regular"/>
-                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                            </textFieldCell>
-                        </textField>
-                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="K8z-ay-qcP">
-                            <rect key="frame" x="-2" y="0.0" width="50" height="16"/>
-                            <textFieldCell key="cell" lineBreakMode="clipping" refusesFirstResponder="YES" allowsUndo="NO" title="?Chars" usesSingleLineMode="YES" id="ziF-K0-mo2">
-                                <font key="font" size="14" name="SFProText-Regular"/>
-                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                            </textFieldCell>
-                        </textField>
-                    </subviews>
-                    <constraints>
-                        <constraint firstAttribute="width" constant="108" id="AEs-IX-trN"/>
-                    </constraints>
-                    <visibilityPriorities>
-                        <integer value="1000"/>
-                        <integer value="1000"/>
-                        <integer value="1000"/>
-                        <integer value="1000"/>
-                    </visibilityPriorities>
-                    <customSpacing>
-                        <real value="3.4028234663852886e+38"/>
-                        <real value="3.4028234663852886e+38"/>
-                        <real value="3.4028234663852886e+38"/>
-                        <real value="3.4028234663852886e+38"/>
-                    </customSpacing>
-                </stackView>
-                <stackView distribution="fill" orientation="vertical" alignment="trailing" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="RDG-k9-sqx" userLabel="Right Stack">
-                    <rect key="frame" x="148" y="147" width="210" height="88"/>
-                    <subviews>
-                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="C9a-zL-iLu">
-                            <rect key="frame" x="185" y="72" width="11" height="16"/>
-                            <textFieldCell key="cell" lineBreakMode="clipping" refusesFirstResponder="YES" allowsUndo="NO" alignment="right" title="-" usesSingleLineMode="YES" id="l99-Ga-t3M">
-                                <font key="font" size="14" name="SFProText-Regular"/>
-                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                            </textFieldCell>
-                        </textField>
-                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dZ0-tU-Bc5">
-                            <rect key="frame" x="185" y="48" width="11" height="16"/>
-                            <textFieldCell key="cell" lineBreakMode="clipping" refusesFirstResponder="YES" allowsUndo="NO" alignment="right" title="-" usesSingleLineMode="YES" id="VdM-gf-xxy">
-                                <font key="font" size="14" name="SFProText-Regular"/>
-                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                            </textFieldCell>
-                        </textField>
-                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="AQn-dM-7Jm">
-                            <rect key="frame" x="185" y="24" width="11" height="16"/>
-                            <textFieldCell key="cell" lineBreakMode="clipping" refusesFirstResponder="YES" allowsUndo="NO" alignment="right" title="-" usesSingleLineMode="YES" id="EpE-je-YMD">
-                                <font key="font" size="14" name="SFProText-Regular"/>
-                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                            </textFieldCell>
-                        </textField>
-                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gn3-44-UTu">
-                            <rect key="frame" x="185" y="0.0" width="11" height="16"/>
-                            <textFieldCell key="cell" lineBreakMode="clipping" refusesFirstResponder="YES" allowsUndo="NO" alignment="right" title="-" usesSingleLineMode="YES" id="4iz-Ck-Ld5">
-                                <font key="font" size="14" name="SFProText-Regular"/>
-                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                            </textFieldCell>
-                        </textField>
-                    </subviews>
-                    <constraints>
-                        <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="dZ0-tU-Bc5" secondAttribute="trailing" constant="16" id="XaD-BI-q6D"/>
-                        <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="C9a-zL-iLu" secondAttribute="trailing" constant="16" id="d7S-bd-5ka"/>
-                        <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="AQn-dM-7Jm" secondAttribute="trailing" constant="16" id="f5C-v8-7c4"/>
-                        <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="gn3-44-UTu" secondAttribute="trailing" constant="16" id="qqz-19-Tp1"/>
-                    </constraints>
-                    <visibilityPriorities>
-                        <integer value="1000"/>
-                        <integer value="1000"/>
-                        <integer value="1000"/>
-                        <integer value="1000"/>
-                    </visibilityPriorities>
-                    <customSpacing>
-                        <real value="3.4028234663852886e+38"/>
-                        <real value="3.4028234663852886e+38"/>
-                        <real value="3.4028234663852886e+38"/>
-                        <real value="3.4028234663852886e+38"/>
-                    </customSpacing>
-                </stackView>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="YwT-om-acp">
-                    <rect key="frame" x="18" y="123" width="322" height="16"/>
-                    <textFieldCell key="cell" lineBreakMode="clipping" title="?References" id="Qbo-PK-FgE">
-                        <font key="font" size="14" name="SFProText-Bold"/>
-                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                    </textFieldCell>
-                </textField>
-                <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="EvS-7u-zOu">
-                    <rect key="frame" x="40" y="20" width="318" height="95"/>
-                    <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="zap-Ek-wU5">
-                        <rect key="frame" x="0.0" y="0.0" width="318" height="95"/>
+                <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="25" horizontalPageScroll="10" verticalLineScroll="25" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" horizontalScrollElasticity="none" translatesAutoresizingMaskIntoConstraints="NO" id="EvS-7u-zOu">
+                    <rect key="frame" x="0.0" y="0.0" width="358" height="123"/>
+                    <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zap-Ek-wU5">
+                        <rect key="frame" x="0.0" y="0.0" width="358" height="123"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnReordering="NO" columnResizing="NO" multipleSelection="NO" emptySelection="NO" autosaveColumns="NO" typeSelect="NO" rowSizeStyle="automatic" viewBased="YES" floatsGroupRows="NO" id="utn-0E-OEM">
-                                <rect key="frame" x="0.0" y="0.0" width="318" height="95"/>
+                            <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnReordering="NO" columnResizing="NO" multipleSelection="NO" emptySelection="NO" autosaveColumns="NO" typeSelect="NO" rowSizeStyle="automatic" usesAutomaticRowHeights="YES" viewBased="YES" floatsGroupRows="NO" translatesAutoresizingMaskIntoConstraints="NO" id="utn-0E-OEM">
+                                <rect key="frame" x="0.0" y="0.0" width="358" height="107"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                <size key="intercellSpacing" width="3" height="2"/>
+                                <size key="intercellSpacing" width="0.0" height="8"/>
                                 <color key="backgroundColor" white="1" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
                                 <tableColumns>
-                                    <tableColumn width="315" minWidth="40" maxWidth="1000" id="33g-cf-pFD">
+                                    <tableColumn width="358" minWidth="40" maxWidth="1000" id="33g-cf-pFD">
                                         <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border">
                                             <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                             <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
@@ -174,21 +43,96 @@
                                         </textFieldCell>
                                         <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                         <prototypeCellViews>
-                                            <tableCellView identifier="ReferenceTableViewCell" id="0of-e6-CDd" customClass="ReferenceTableViewCell" customModule="Simplenote" customModuleProvider="target">
-                                                <rect key="frame" x="1" y="1" width="315" height="17"/>
-                                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                            <tableCellView identifier="HeaderTableCellView" translatesAutoresizingMaskIntoConstraints="NO" id="5Hz-Ek-7Ep" userLabel="Header TableViewCell" customClass="HeaderTableCellView" customModule="Simplenote" customModuleProvider="target">
+                                                <rect key="frame" x="0.0" y="4" width="358" height="17"/>
                                                 <subviews>
-                                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="yrS-jS-WHs">
-                                                        <rect key="frame" x="0.0" y="1" width="315" height="16"/>
-                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
-                                                        <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Table View Cell" id="zPy-uT-2tL">
-                                                            <font key="font" usesAppearanceFont="YES"/>
+                                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="Z8N-Gi-1Tg">
+                                                        <rect key="frame" x="18" y="1" width="322" height="16"/>
+                                                        <textFieldCell key="cell" lineBreakMode="truncatingTail" allowsUndo="NO" sendsActionOnEndEditing="YES" title="Header" id="g31-xU-zcx">
+                                                            <font key="font" size="14" name="SFProText-Bold"/>
                                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                         </textFieldCell>
                                                     </textField>
                                                 </subviews>
+                                                <constraints>
+                                                    <constraint firstAttribute="trailing" secondItem="Z8N-Gi-1Tg" secondAttribute="trailing" constant="20" symbolic="YES" id="1up-9W-Wih"/>
+                                                    <constraint firstItem="Z8N-Gi-1Tg" firstAttribute="leading" secondItem="5Hz-Ek-7Ep" secondAttribute="leading" constant="20" symbolic="YES" id="KFZ-96-EgJ"/>
+                                                    <constraint firstAttribute="bottom" secondItem="Z8N-Gi-1Tg" secondAttribute="bottom" constant="1" id="Rfp-Tr-g25"/>
+                                                    <constraint firstItem="Z8N-Gi-1Tg" firstAttribute="top" secondItem="5Hz-Ek-7Ep" secondAttribute="top" id="YOp-36-2SL"/>
+                                                </constraints>
                                                 <connections>
+                                                    <outlet property="textField" destination="Z8N-Gi-1Tg" id="krv-dT-MxF"/>
+                                                </connections>
+                                            </tableCellView>
+                                            <tableCellView identifier="MetricTableViewCell" translatesAutoresizingMaskIntoConstraints="NO" id="W43-Ah-uvz" userLabel="Metric TableViewCell" customClass="MetricTableViewCell" customModule="Simplenote" customModuleProvider="target">
+                                                <rect key="frame" x="0.0" y="29" width="358" height="17"/>
+                                                <subviews>
+                                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yJF-yg-7AO" userLabel="Title TableViewCell">
+                                                        <rect key="frame" x="38" y="1" width="124" height="16"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="width" constant="120" id="5Qz-DF-nl7"/>
+                                                        </constraints>
+                                                        <textFieldCell key="cell" lineBreakMode="truncatingTail" allowsUndo="NO" sendsActionOnEndEditing="YES" title="Metric" id="BTF-0a-zIH">
+                                                            <font key="font" size="14" name="SFProText-Regular"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="abA-Iq-NzQ" userLabel="Value TableViewCell">
+                                                        <rect key="frame" x="-2" y="1" width="346" height="16"/>
+                                                        <textFieldCell key="cell" lineBreakMode="truncatingTail" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="right" title="Value" id="eZi-C6-KDY">
+                                                            <font key="font" size="14" name="SFProText-Regular"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                </subviews>
+                                                <constraints>
+                                                    <constraint firstItem="yJF-yg-7AO" firstAttribute="leading" secondItem="W43-Ah-uvz" secondAttribute="leading" constant="40" id="AcO-Xx-pqp"/>
+                                                    <constraint firstItem="yJF-yg-7AO" firstAttribute="top" secondItem="W43-Ah-uvz" secondAttribute="top" id="Cb4-Qp-ANt"/>
+                                                    <constraint firstAttribute="bottom" secondItem="abA-Iq-NzQ" secondAttribute="bottom" constant="1" id="IIg-Ak-RAd"/>
+                                                    <constraint firstAttribute="bottom" secondItem="yJF-yg-7AO" secondAttribute="bottom" constant="1" id="NFf-jQ-MYj"/>
+                                                    <constraint firstItem="abA-Iq-NzQ" firstAttribute="leading" secondItem="W43-Ah-uvz" secondAttribute="leading" id="O39-bz-lnF"/>
+                                                    <constraint firstAttribute="trailing" secondItem="abA-Iq-NzQ" secondAttribute="trailing" constant="16" id="Y9v-Ow-Jmk"/>
+                                                    <constraint firstItem="abA-Iq-NzQ" firstAttribute="top" secondItem="W43-Ah-uvz" secondAttribute="top" id="pz0-Zm-dWJ"/>
+                                                </constraints>
+                                                <connections>
+                                                    <outlet property="textField" destination="yJF-yg-7AO" id="WHX-c6-F6Z"/>
+                                                    <outlet property="valueTextField" destination="abA-Iq-NzQ" id="aH5-QG-wRY"/>
+                                                </connections>
+                                            </tableCellView>
+                                            <tableCellView identifier="ReferenceTableViewCell" translatesAutoresizingMaskIntoConstraints="NO" id="0of-e6-CDd" userLabel="Reference TableViewCell" customClass="ReferenceTableViewCell" customModule="Simplenote" customModuleProvider="target">
+                                                <rect key="frame" x="0.0" y="54" width="358" height="33"/>
+                                                <subviews>
+                                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yrS-jS-WHs" userLabel="Reference TextField">
+                                                        <rect key="frame" x="38" y="17" width="306" height="16"/>
+                                                        <textFieldCell key="cell" lineBreakMode="truncatingTail" allowsUndo="NO" sendsActionOnEndEditing="YES" title="Reference Title" id="zPy-uT-2tL">
+                                                            <font key="font" size="14" name="SFProText-Italic"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="n9Z-a7-33b" userLabel="Details TextField">
+                                                        <rect key="frame" x="38" y="1" width="306" height="16"/>
+                                                        <textFieldCell key="cell" lineBreakMode="truncatingTail" allowsUndo="NO" sendsActionOnEndEditing="YES" title="Details" id="aWI-Vm-u4V">
+                                                            <font key="font" size="14" name="SFProText-Regular"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                </subviews>
+                                                <constraints>
+                                                    <constraint firstItem="yrS-jS-WHs" firstAttribute="leading" secondItem="0of-e6-CDd" secondAttribute="leading" constant="40" id="3Y8-vj-aLO"/>
+                                                    <constraint firstItem="n9Z-a7-33b" firstAttribute="top" secondItem="yrS-jS-WHs" secondAttribute="bottom" id="B1o-0R-pok"/>
+                                                    <constraint firstAttribute="trailing" secondItem="yrS-jS-WHs" secondAttribute="trailing" constant="16" id="Jx4-2y-waX"/>
+                                                    <constraint firstAttribute="bottom" secondItem="n9Z-a7-33b" secondAttribute="bottom" constant="1" id="fSr-M2-5RI"/>
+                                                    <constraint firstItem="yrS-jS-WHs" firstAttribute="top" secondItem="0of-e6-CDd" secondAttribute="top" id="kcZ-Qo-kjj"/>
+                                                    <constraint firstItem="yrS-jS-WHs" firstAttribute="leading" secondItem="n9Z-a7-33b" secondAttribute="leading" id="otR-aH-3Ms"/>
+                                                    <constraint firstItem="yrS-jS-WHs" firstAttribute="trailing" secondItem="n9Z-a7-33b" secondAttribute="trailing" id="xmC-NR-PIy"/>
+                                                </constraints>
+                                                <connections>
+                                                    <outlet property="detailsTextField" destination="n9Z-a7-33b" id="wZL-NQ-KeD"/>
                                                     <outlet property="textField" destination="yrS-jS-WHs" id="R1I-0k-g2K"/>
                                                 </connections>
                                             </tableCellView>
@@ -202,36 +146,28 @@
                             </tableView>
                         </subviews>
                         <nil key="backgroundColor"/>
+                        <edgeInsets key="contentInsets" left="0.0" right="0.0" top="8" bottom="8"/>
                     </clipView>
+                    <constraints>
+                        <constraint firstAttribute="width" constant="358" id="0EB-lE-0LR"/>
+                    </constraints>
                     <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="owv-GV-ta2">
-                        <rect key="frame" x="0.0" y="71" width="291" height="16"/>
+                        <rect key="frame" x="-100" y="-100" width="291" height="16"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </scroller>
-                    <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="afe-zc-Pg5">
+                    <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" doubleValue="0.375" horizontal="NO" id="afe-zc-Pg5">
                         <rect key="frame" x="224" y="17" width="15" height="102"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </scroller>
                 </scrollView>
             </subviews>
             <constraints>
-                <constraint firstItem="RDG-k9-sqx" firstAttribute="bottom" secondItem="bIO-uD-Uuz" secondAttribute="bottom" id="496-vd-iy1"/>
-                <constraint firstAttribute="trailing" secondItem="hSa-Xl-61W" secondAttribute="trailing" constant="20" symbolic="YES" id="4xm-ub-Fff"/>
-                <constraint firstItem="EvS-7u-zOu" firstAttribute="top" secondItem="YwT-om-acp" secondAttribute="bottom" constant="8" symbolic="YES" id="9sy-CE-ED3"/>
-                <constraint firstItem="bIO-uD-Uuz" firstAttribute="leading" secondItem="9uy-MA-rkc" secondAttribute="leading" constant="40" id="9v1-DZ-7H5"/>
-                <constraint firstItem="RDG-k9-sqx" firstAttribute="leading" secondItem="bIO-uD-Uuz" secondAttribute="trailing" id="CoF-mi-Sc6"/>
-                <constraint firstAttribute="bottom" secondItem="EvS-7u-zOu" secondAttribute="bottom" constant="20" symbolic="YES" id="GxN-vJ-Hmh"/>
-                <constraint firstAttribute="trailing" secondItem="YwT-om-acp" secondAttribute="trailing" constant="20" symbolic="YES" id="MpB-v8-ClU"/>
-                <constraint firstItem="RDG-k9-sqx" firstAttribute="top" secondItem="bIO-uD-Uuz" secondAttribute="top" id="XdM-LH-pCb"/>
-                <constraint firstItem="EvS-7u-zOu" firstAttribute="trailing" secondItem="RDG-k9-sqx" secondAttribute="trailing" id="ZgB-Ld-am4"/>
-                <constraint firstItem="YwT-om-acp" firstAttribute="top" secondItem="bIO-uD-Uuz" secondAttribute="bottom" constant="8" symbolic="YES" id="a9E-At-lAN"/>
-                <constraint firstItem="hSa-Xl-61W" firstAttribute="top" secondItem="9uy-MA-rkc" secondAttribute="top" constant="20" symbolic="YES" id="aJL-NB-N1z"/>
-                <constraint firstAttribute="trailing" secondItem="RDG-k9-sqx" secondAttribute="trailing" id="cWZ-yw-xln"/>
-                <constraint firstItem="hSa-Xl-61W" firstAttribute="leading" secondItem="9uy-MA-rkc" secondAttribute="leading" constant="20" symbolic="YES" id="dES-nr-iN8"/>
-                <constraint firstItem="YwT-om-acp" firstAttribute="leading" secondItem="9uy-MA-rkc" secondAttribute="leading" constant="20" symbolic="YES" id="fze-CF-xKM"/>
-                <constraint firstItem="EvS-7u-zOu" firstAttribute="leading" secondItem="bIO-uD-Uuz" secondAttribute="leading" id="gSr-Mw-tzO"/>
-                <constraint firstItem="bIO-uD-Uuz" firstAttribute="top" secondItem="hSa-Xl-61W" secondAttribute="bottom" constant="8" symbolic="YES" id="n1n-TC-feu"/>
+                <constraint firstItem="EvS-7u-zOu" firstAttribute="leading" secondItem="9uy-MA-rkc" secondAttribute="leading" id="C3Q-it-1HF"/>
+                <constraint firstItem="EvS-7u-zOu" firstAttribute="top" secondItem="9uy-MA-rkc" secondAttribute="top" id="bxo-hs-E7Y"/>
+                <constraint firstAttribute="trailing" secondItem="EvS-7u-zOu" secondAttribute="trailing" id="epc-cd-xVO"/>
+                <constraint firstAttribute="bottom" secondItem="EvS-7u-zOu" secondAttribute="bottom" id="nu4-vC-L0B"/>
             </constraints>
-            <point key="canvasLocation" x="105" y="237.5"/>
+            <point key="canvasLocation" x="105" y="552"/>
         </view>
     </objects>
 </document>

--- a/Simplenote/MetricsViewController.xib
+++ b/Simplenote/MetricsViewController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="16097" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="17156" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="16097"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17156"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -12,8 +12,10 @@
                 <outlet property="charsTextLabel" destination="K8z-ay-qcP" id="hEX-CG-zpu"/>
                 <outlet property="createdDetailsLabel" destination="dZ0-tU-Bc5" id="onE-fJ-GgN"/>
                 <outlet property="createdTextLabel" destination="TD2-YG-kpC" id="mXe-uL-Jyl"/>
+                <outlet property="informationTextLabel" destination="hSa-Xl-61W" id="QPu-y3-L2k"/>
                 <outlet property="modifiedDetailsLabel" destination="C9a-zL-iLu" id="VcY-tM-dzi"/>
                 <outlet property="modifiedTextLabel" destination="ZyH-GP-C2f" id="wbw-FY-Kvl"/>
+                <outlet property="referencesTextLabel" destination="YwT-om-acp" id="QTv-VS-IgT"/>
                 <outlet property="view" destination="9uy-MA-rkc" id="vPg-k3-f7w"/>
                 <outlet property="wordsDetailsLabel" destination="AQn-dM-7Jm" id="rUb-Ur-mZ7"/>
                 <outlet property="wordsTextLabel" destination="GPX-iN-iZj" id="lqB-Qu-nzF"/>
@@ -22,10 +24,18 @@
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <view translatesAutoresizingMaskIntoConstraints="NO" id="9uy-MA-rkc">
-            <rect key="frame" x="0.0" y="0.0" width="147" height="114"/>
+            <rect key="frame" x="0.0" y="0.0" width="358" height="279"/>
             <subviews>
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="hSa-Xl-61W">
+                    <rect key="frame" x="18" y="243" width="322" height="16"/>
+                    <textFieldCell key="cell" lineBreakMode="clipping" title="?Information" id="i1N-fO-VXQ">
+                        <font key="font" size="14" name="SFProText-Bold"/>
+                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
                 <stackView distribution="fill" orientation="vertical" alignment="leading" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="bIO-uD-Uuz" userLabel="Left Stack">
-                    <rect key="frame" x="16" y="10" width="108" height="88"/>
+                    <rect key="frame" x="40" y="147" width="108" height="88"/>
                     <subviews>
                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZyH-GP-C2f">
                             <rect key="frame" x="-2" y="72" width="69" height="16"/>
@@ -62,10 +72,6 @@
                     </subviews>
                     <constraints>
                         <constraint firstAttribute="width" constant="108" id="AEs-IX-trN"/>
-                        <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="GPX-iN-iZj" secondAttribute="trailing" constant="20" id="Z5y-9R-VOU"/>
-                        <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="ZyH-GP-C2f" secondAttribute="trailing" constant="20" id="bh0-05-nY8"/>
-                        <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="TD2-YG-kpC" secondAttribute="trailing" constant="20" id="fAP-dt-933"/>
-                        <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="K8z-ay-qcP" secondAttribute="trailing" constant="20" id="lqP-xa-9kU"/>
                     </constraints>
                     <visibilityPriorities>
                         <integer value="1000"/>
@@ -80,36 +86,36 @@
                         <real value="3.4028234663852886e+38"/>
                     </customSpacing>
                 </stackView>
-                <stackView distribution="fill" orientation="vertical" alignment="leading" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="RDG-k9-sqx" userLabel="Right Stack">
-                    <rect key="frame" x="124" y="10" width="23" height="88"/>
+                <stackView distribution="fill" orientation="vertical" alignment="trailing" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="RDG-k9-sqx" userLabel="Right Stack">
+                    <rect key="frame" x="148" y="147" width="210" height="88"/>
                     <subviews>
                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="C9a-zL-iLu">
-                            <rect key="frame" x="-2" y="72" width="11" height="16"/>
-                            <textFieldCell key="cell" lineBreakMode="clipping" refusesFirstResponder="YES" allowsUndo="NO" title="-" usesSingleLineMode="YES" id="l99-Ga-t3M">
+                            <rect key="frame" x="185" y="72" width="11" height="16"/>
+                            <textFieldCell key="cell" lineBreakMode="clipping" refusesFirstResponder="YES" allowsUndo="NO" alignment="right" title="-" usesSingleLineMode="YES" id="l99-Ga-t3M">
                                 <font key="font" size="14" name="SFProText-Regular"/>
                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                 <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                             </textFieldCell>
                         </textField>
                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dZ0-tU-Bc5">
-                            <rect key="frame" x="-2" y="48" width="11" height="16"/>
-                            <textFieldCell key="cell" lineBreakMode="clipping" refusesFirstResponder="YES" allowsUndo="NO" title="-" usesSingleLineMode="YES" id="VdM-gf-xxy">
+                            <rect key="frame" x="185" y="48" width="11" height="16"/>
+                            <textFieldCell key="cell" lineBreakMode="clipping" refusesFirstResponder="YES" allowsUndo="NO" alignment="right" title="-" usesSingleLineMode="YES" id="VdM-gf-xxy">
                                 <font key="font" size="14" name="SFProText-Regular"/>
                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                 <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                             </textFieldCell>
                         </textField>
                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="AQn-dM-7Jm">
-                            <rect key="frame" x="-2" y="24" width="11" height="16"/>
-                            <textFieldCell key="cell" lineBreakMode="clipping" refusesFirstResponder="YES" allowsUndo="NO" title="-" usesSingleLineMode="YES" id="EpE-je-YMD">
+                            <rect key="frame" x="185" y="24" width="11" height="16"/>
+                            <textFieldCell key="cell" lineBreakMode="clipping" refusesFirstResponder="YES" allowsUndo="NO" alignment="right" title="-" usesSingleLineMode="YES" id="EpE-je-YMD">
                                 <font key="font" size="14" name="SFProText-Regular"/>
                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                 <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                             </textFieldCell>
                         </textField>
                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gn3-44-UTu">
-                            <rect key="frame" x="-2" y="0.0" width="11" height="16"/>
-                            <textFieldCell key="cell" lineBreakMode="clipping" refusesFirstResponder="YES" allowsUndo="NO" title="-" usesSingleLineMode="YES" id="4iz-Ck-Ld5">
+                            <rect key="frame" x="185" y="0.0" width="11" height="16"/>
+                            <textFieldCell key="cell" lineBreakMode="clipping" refusesFirstResponder="YES" allowsUndo="NO" alignment="right" title="-" usesSingleLineMode="YES" id="4iz-Ck-Ld5">
                                 <font key="font" size="14" name="SFProText-Regular"/>
                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                 <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
@@ -135,17 +141,97 @@
                         <real value="3.4028234663852886e+38"/>
                     </customSpacing>
                 </stackView>
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="YwT-om-acp">
+                    <rect key="frame" x="18" y="123" width="322" height="16"/>
+                    <textFieldCell key="cell" lineBreakMode="clipping" title="?References" id="Qbo-PK-FgE">
+                        <font key="font" size="14" name="SFProText-Bold"/>
+                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
+                <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="EvS-7u-zOu">
+                    <rect key="frame" x="40" y="20" width="318" height="95"/>
+                    <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="zap-Ek-wU5">
+                        <rect key="frame" x="0.0" y="0.0" width="318" height="95"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnReordering="NO" columnResizing="NO" multipleSelection="NO" emptySelection="NO" autosaveColumns="NO" typeSelect="NO" rowSizeStyle="automatic" viewBased="YES" floatsGroupRows="NO" id="utn-0E-OEM">
+                                <rect key="frame" x="0.0" y="0.0" width="318" height="95"/>
+                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                <size key="intercellSpacing" width="3" height="2"/>
+                                <color key="backgroundColor" white="1" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
+                                <tableColumns>
+                                    <tableColumn width="315" minWidth="40" maxWidth="1000" id="33g-cf-pFD">
+                                        <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border">
+                                            <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
+                                        </tableHeaderCell>
+                                        <textFieldCell key="dataCell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" title="Text Cell" id="GIr-J7-dIS">
+                                            <font key="font" metaFont="system"/>
+                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                        </textFieldCell>
+                                        <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
+                                        <prototypeCellViews>
+                                            <tableCellView identifier="ReferenceTableViewCell" id="0of-e6-CDd" customClass="ReferenceTableViewCell" customModule="Simplenote" customModuleProvider="target">
+                                                <rect key="frame" x="1" y="1" width="315" height="17"/>
+                                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                <subviews>
+                                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="yrS-jS-WHs">
+                                                        <rect key="frame" x="0.0" y="1" width="315" height="16"/>
+                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
+                                                        <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Table View Cell" id="zPy-uT-2tL">
+                                                            <font key="font" usesAppearanceFont="YES"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                </subviews>
+                                                <connections>
+                                                    <outlet property="textField" destination="yrS-jS-WHs" id="R1I-0k-g2K"/>
+                                                </connections>
+                                            </tableCellView>
+                                        </prototypeCellViews>
+                                    </tableColumn>
+                                </tableColumns>
+                                <connections>
+                                    <outlet property="dataSource" destination="-2" id="VAG-vA-fY3"/>
+                                    <outlet property="delegate" destination="-2" id="J3c-ZW-zjN"/>
+                                </connections>
+                            </tableView>
+                        </subviews>
+                        <nil key="backgroundColor"/>
+                    </clipView>
+                    <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="owv-GV-ta2">
+                        <rect key="frame" x="0.0" y="71" width="291" height="16"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </scroller>
+                    <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="afe-zc-Pg5">
+                        <rect key="frame" x="224" y="17" width="15" height="102"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </scroller>
+                </scrollView>
             </subviews>
             <constraints>
                 <constraint firstItem="RDG-k9-sqx" firstAttribute="bottom" secondItem="bIO-uD-Uuz" secondAttribute="bottom" id="496-vd-iy1"/>
+                <constraint firstAttribute="trailing" secondItem="hSa-Xl-61W" secondAttribute="trailing" constant="20" symbolic="YES" id="4xm-ub-Fff"/>
+                <constraint firstItem="EvS-7u-zOu" firstAttribute="top" secondItem="YwT-om-acp" secondAttribute="bottom" constant="8" symbolic="YES" id="9sy-CE-ED3"/>
+                <constraint firstItem="bIO-uD-Uuz" firstAttribute="leading" secondItem="9uy-MA-rkc" secondAttribute="leading" constant="40" id="9v1-DZ-7H5"/>
                 <constraint firstItem="RDG-k9-sqx" firstAttribute="leading" secondItem="bIO-uD-Uuz" secondAttribute="trailing" id="CoF-mi-Sc6"/>
-                <constraint firstAttribute="bottom" secondItem="bIO-uD-Uuz" secondAttribute="bottom" constant="10" id="Fvr-Wi-Xux"/>
-                <constraint firstItem="bIO-uD-Uuz" firstAttribute="top" secondItem="9uy-MA-rkc" secondAttribute="top" constant="16" id="HTT-kM-J5M"/>
+                <constraint firstAttribute="bottom" secondItem="EvS-7u-zOu" secondAttribute="bottom" constant="20" symbolic="YES" id="GxN-vJ-Hmh"/>
+                <constraint firstAttribute="trailing" secondItem="YwT-om-acp" secondAttribute="trailing" constant="20" symbolic="YES" id="MpB-v8-ClU"/>
                 <constraint firstItem="RDG-k9-sqx" firstAttribute="top" secondItem="bIO-uD-Uuz" secondAttribute="top" id="XdM-LH-pCb"/>
+                <constraint firstItem="EvS-7u-zOu" firstAttribute="trailing" secondItem="RDG-k9-sqx" secondAttribute="trailing" id="ZgB-Ld-am4"/>
+                <constraint firstItem="YwT-om-acp" firstAttribute="top" secondItem="bIO-uD-Uuz" secondAttribute="bottom" constant="8" symbolic="YES" id="a9E-At-lAN"/>
+                <constraint firstItem="hSa-Xl-61W" firstAttribute="top" secondItem="9uy-MA-rkc" secondAttribute="top" constant="20" symbolic="YES" id="aJL-NB-N1z"/>
                 <constraint firstAttribute="trailing" secondItem="RDG-k9-sqx" secondAttribute="trailing" id="cWZ-yw-xln"/>
-                <constraint firstItem="bIO-uD-Uuz" firstAttribute="leading" secondItem="9uy-MA-rkc" secondAttribute="leading" constant="16" id="hik-25-Sdc"/>
+                <constraint firstItem="hSa-Xl-61W" firstAttribute="leading" secondItem="9uy-MA-rkc" secondAttribute="leading" constant="20" symbolic="YES" id="dES-nr-iN8"/>
+                <constraint firstItem="YwT-om-acp" firstAttribute="leading" secondItem="9uy-MA-rkc" secondAttribute="leading" constant="20" symbolic="YES" id="fze-CF-xKM"/>
+                <constraint firstItem="EvS-7u-zOu" firstAttribute="leading" secondItem="bIO-uD-Uuz" secondAttribute="leading" id="gSr-Mw-tzO"/>
+                <constraint firstItem="bIO-uD-Uuz" firstAttribute="top" secondItem="hSa-Xl-61W" secondAttribute="bottom" constant="8" symbolic="YES" id="n1n-TC-feu"/>
             </constraints>
-            <point key="canvasLocation" x="14" y="155"/>
+            <point key="canvasLocation" x="105" y="237.5"/>
         </view>
     </objects>
 </document>

--- a/Simplenote/MetricsViewController.xib
+++ b/Simplenote/MetricsViewController.xib
@@ -16,16 +16,16 @@
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <view translatesAutoresizingMaskIntoConstraints="NO" id="9uy-MA-rkc">
-            <rect key="frame" x="0.0" y="0.0" width="358" height="123"/>
+            <rect key="frame" x="0.0" y="0.0" width="358" height="117"/>
             <subviews>
                 <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="25" horizontalPageScroll="10" verticalLineScroll="25" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" horizontalScrollElasticity="none" translatesAutoresizingMaskIntoConstraints="NO" id="EvS-7u-zOu">
-                    <rect key="frame" x="0.0" y="0.0" width="358" height="123"/>
+                    <rect key="frame" x="0.0" y="0.0" width="358" height="117"/>
                     <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zap-Ek-wU5">
-                        <rect key="frame" x="0.0" y="0.0" width="358" height="123"/>
+                        <rect key="frame" x="0.0" y="0.0" width="358" height="117"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnReordering="NO" columnResizing="NO" multipleSelection="NO" emptySelection="NO" autosaveColumns="NO" typeSelect="NO" rowSizeStyle="automatic" usesAutomaticRowHeights="YES" viewBased="YES" floatsGroupRows="NO" translatesAutoresizingMaskIntoConstraints="NO" id="utn-0E-OEM">
-                                <rect key="frame" x="0.0" y="0.0" width="358" height="107"/>
+                                <rect key="frame" x="0.0" y="0.0" width="358" height="101"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <size key="intercellSpacing" width="0.0" height="8"/>
                                 <color key="backgroundColor" white="1" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -167,7 +167,7 @@
                 <constraint firstAttribute="trailing" secondItem="EvS-7u-zOu" secondAttribute="trailing" id="epc-cd-xVO"/>
                 <constraint firstAttribute="bottom" secondItem="EvS-7u-zOu" secondAttribute="bottom" id="nu4-vC-L0B"/>
             </constraints>
-            <point key="canvasLocation" x="105" y="552"/>
+            <point key="canvasLocation" x="105" y="548.5"/>
         </view>
     </objects>
 </document>

--- a/Simplenote/MetricsViewController.xib
+++ b/Simplenote/MetricsViewController.xib
@@ -3,6 +3,7 @@
     <dependencies>
         <deployment identifier="macosx"/>
         <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17156"/>
+        <capability name="System colors introduced in macOS 10.13" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -16,18 +17,17 @@
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <view translatesAutoresizingMaskIntoConstraints="NO" id="9uy-MA-rkc">
-            <rect key="frame" x="0.0" y="0.0" width="358" height="117"/>
+            <rect key="frame" x="0.0" y="0.0" width="358" height="103"/>
             <subviews>
-                <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="25" horizontalPageScroll="10" verticalLineScroll="25" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" horizontalScrollElasticity="none" translatesAutoresizingMaskIntoConstraints="NO" id="EvS-7u-zOu">
-                    <rect key="frame" x="0.0" y="0.0" width="358" height="117"/>
+                <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="17" horizontalPageScroll="10" verticalLineScroll="17" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" horizontalScrollElasticity="none" translatesAutoresizingMaskIntoConstraints="NO" id="EvS-7u-zOu">
+                    <rect key="frame" x="0.0" y="0.0" width="358" height="103"/>
                     <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zap-Ek-wU5">
-                        <rect key="frame" x="0.0" y="0.0" width="358" height="117"/>
+                        <rect key="frame" x="0.0" y="0.0" width="358" height="103"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnReordering="NO" columnResizing="NO" multipleSelection="NO" emptySelection="NO" autosaveColumns="NO" typeSelect="NO" rowSizeStyle="automatic" usesAutomaticRowHeights="YES" viewBased="YES" floatsGroupRows="NO" translatesAutoresizingMaskIntoConstraints="NO" id="utn-0E-OEM">
-                                <rect key="frame" x="0.0" y="0.0" width="358" height="101"/>
+                                <rect key="frame" x="0.0" y="0.0" width="358" height="87"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                <size key="intercellSpacing" width="0.0" height="8"/>
                                 <color key="backgroundColor" white="1" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
                                 <tableColumns>
@@ -39,12 +39,12 @@
                                         <textFieldCell key="dataCell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" title="Text Cell" id="GIr-J7-dIS">
                                             <font key="font" metaFont="system"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                            <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="backgroundColor" name="findHighlightColor" catalog="System" colorSpace="catalog"/>
                                         </textFieldCell>
                                         <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                         <prototypeCellViews>
                                             <tableCellView identifier="HeaderTableCellView" translatesAutoresizingMaskIntoConstraints="NO" id="5Hz-Ek-7Ep" userLabel="Header TableViewCell" customClass="HeaderTableCellView" customModule="Simplenote" customModuleProvider="target">
-                                                <rect key="frame" x="0.0" y="4" width="358" height="17"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="358" height="17"/>
                                                 <subviews>
                                                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="Z8N-Gi-1Tg">
                                                         <rect key="frame" x="18" y="1" width="322" height="16"/>
@@ -66,7 +66,7 @@
                                                 </connections>
                                             </tableCellView>
                                             <tableCellView identifier="MetricTableViewCell" translatesAutoresizingMaskIntoConstraints="NO" id="W43-Ah-uvz" userLabel="Metric TableViewCell" customClass="MetricTableViewCell" customModule="Simplenote" customModuleProvider="target">
-                                                <rect key="frame" x="0.0" y="29" width="358" height="17"/>
+                                                <rect key="frame" x="0.0" y="17" width="358" height="17"/>
                                                 <subviews>
                                                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yJF-yg-7AO" userLabel="Title TableViewCell">
                                                         <rect key="frame" x="38" y="1" width="124" height="16"/>
@@ -103,7 +103,7 @@
                                                 </connections>
                                             </tableCellView>
                                             <tableCellView identifier="ReferenceTableViewCell" translatesAutoresizingMaskIntoConstraints="NO" id="0of-e6-CDd" userLabel="Reference TableViewCell" customClass="ReferenceTableViewCell" customModule="Simplenote" customModuleProvider="target">
-                                                <rect key="frame" x="0.0" y="54" width="358" height="33"/>
+                                                <rect key="frame" x="0.0" y="34" width="358" height="33"/>
                                                 <subviews>
                                                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yrS-jS-WHs" userLabel="Reference TextField">
                                                         <rect key="frame" x="38" y="17" width="306" height="16"/>
@@ -136,6 +136,27 @@
                                                     <outlet property="textField" destination="yrS-jS-WHs" id="R1I-0k-g2K"/>
                                                 </connections>
                                             </tableCellView>
+                                            <tableCellView identifier="SeparatorTableViewCell" id="cTM-uw-JCq" userLabel="Spacer TableViewCell" customClass="SeparatorTableViewCell" customModule="Simplenote" customModuleProvider="target">
+                                                <rect key="frame" x="0.0" y="67" width="358" height="13"/>
+                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                <subviews>
+                                                    <customView translatesAutoresizingMaskIntoConstraints="NO" id="6mh-tk-BwV" customClass="BackgroundView" customModule="Simplenote" customModuleProvider="target">
+                                                        <rect key="frame" x="0.0" y="6" width="358" height="2"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="2" id="M8t-DK-ZJH"/>
+                                                        </constraints>
+                                                    </customView>
+                                                </subviews>
+                                                <constraints>
+                                                    <constraint firstItem="6mh-tk-BwV" firstAttribute="leading" secondItem="cTM-uw-JCq" secondAttribute="leading" id="Zfz-Ck-uxn"/>
+                                                    <constraint firstAttribute="bottom" secondItem="6mh-tk-BwV" secondAttribute="bottom" constant="6" id="bDv-xT-A62"/>
+                                                    <constraint firstItem="6mh-tk-BwV" firstAttribute="top" secondItem="cTM-uw-JCq" secondAttribute="top" constant="5" id="pvf-WR-csz"/>
+                                                    <constraint firstAttribute="trailing" secondItem="6mh-tk-BwV" secondAttribute="trailing" id="s70-Uk-Dnd"/>
+                                                </constraints>
+                                                <connections>
+                                                    <outlet property="separatorView" destination="6mh-tk-BwV" id="t9p-Op-NMl"/>
+                                                </connections>
+                                            </tableCellView>
                                         </prototypeCellViews>
                                     </tableColumn>
                                 </tableColumns>
@@ -149,13 +170,13 @@
                         <edgeInsets key="contentInsets" left="0.0" right="0.0" top="8" bottom="8"/>
                     </clipView>
                     <constraints>
-                        <constraint firstAttribute="width" constant="358" id="0EB-lE-0LR"/>
+                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="260" id="0EB-lE-0LR"/>
                     </constraints>
                     <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="owv-GV-ta2">
                         <rect key="frame" x="-100" y="-100" width="291" height="16"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </scroller>
-                    <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" doubleValue="0.375" horizontal="NO" id="afe-zc-Pg5">
+                    <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" doubleValue="0.87096774193548387" horizontal="NO" id="afe-zc-Pg5">
                         <rect key="frame" x="224" y="17" width="15" height="102"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </scroller>
@@ -167,7 +188,7 @@
                 <constraint firstAttribute="trailing" secondItem="EvS-7u-zOu" secondAttribute="trailing" id="epc-cd-xVO"/>
                 <constraint firstAttribute="bottom" secondItem="EvS-7u-zOu" secondAttribute="bottom" id="nu4-vC-L0B"/>
             </constraints>
-            <point key="canvasLocation" x="105" y="548.5"/>
+            <point key="canvasLocation" x="105" y="541.5"/>
         </view>
     </objects>
 </document>

--- a/Simplenote/NSPasteboard+Simplenote.swift
+++ b/Simplenote/NSPasteboard+Simplenote.swift
@@ -8,7 +8,7 @@ extension NSPasteboard {
     /// Copies the Internal Link (Markdown Reference) into the OS Pasteboard
     ///
     func copyInterlink(to note: Note) {
-        guard let link = note.markdownInternalLink else {
+        guard let link = note.markdownInterlink else {
             return
         }
 

--- a/Simplenote/Note+Interlinks.swift
+++ b/Simplenote/Note+Interlinks.swift
@@ -7,13 +7,22 @@ extension Note {
 
     /// Returns the receiver's Markdown Internal Reference, when possible
     ///
-    var markdownInternalLink: String? {
-        guard let title = titlePreview, let key = simperiumKey else {
+    var plainInterlink: String? {
+        guard let key = simperiumKey else {
+            return nil
+        }
+
+        return SimplenoteConstants.simplenoteScheme + "://" + SimplenoteConstants.simplenoteInterlinkHost + "/" + key
+    }
+
+    /// Returns the receiver's Markdown Internal Reference, when possible
+    ///
+    var markdownInterlink: String? {
+        guard let title = titlePreview, let interlink = plainInterlink else {
             return nil
         }
 
         let shortened = title.truncateWords(upTo: SimplenoteConstants.simplenoteInterlinkMaxTitleLength)
-        let url = SimplenoteConstants.simplenoteScheme + "://" + SimplenoteConstants.simplenoteInterlinkHost + "/" + key
-        return "[" + shortened + "](" + url + ")"
+        return "[" + shortened + "](" + interlink + ")"
     }
 }

--- a/Simplenote/NoteMetrics.swift
+++ b/Simplenote/NoteMetrics.swift
@@ -7,11 +7,11 @@ struct NoteMetrics {
 
     /// Returns the total number of characters
     ///
-    let numberOfChars: Int
+    let numberOfChars: String
 
     /// Returns the total number of words
     ///
-    let numberOfWords: Int
+    let numberOfWords: String
 
     /// Creation Date (whenever we're in single selection mode)
     ///
@@ -29,9 +29,11 @@ struct NoteMetrics {
         let contents = notes.compactMap({ $0.content }).reduce("", +)
         let dateProviderNote = notes.count == 1 ? notes.first : nil
         let wordCount = NSSpellChecker.shared.countWords(in: contents, language: nil)
+        let safeWordCount = wordCount != -1 ? wordCount : .zero
 
-        numberOfChars = contents.count
-        numberOfWords = wordCount != -1 ? wordCount : .zero
+        numberOfChars = NumberFormatter.localizedString(from: contents.count, style: .decimal)
+
+        numberOfWords = NumberFormatter.localizedString(from: safeWordCount, style: .decimal)
 
         creationDate = dateProviderNote?.creationDate.map {
             DateFormatter.metricsFormatter.string(from: $0)

--- a/Simplenote/NumberFormatter+Simplenote.swift
+++ b/Simplenote/NumberFormatter+Simplenote.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+
+// MARK: - NumberFormatter
+//
+extension NumberFormatter {
+
+    class func localizedString(from integer: Int, style: NumberFormatter.Style) -> String {
+        let wrappedInt = NSNumber(integerLiteral: integer)
+        return NumberFormatter.localizedString(from: wrappedInt, number: style)
+    }
+}

--- a/Simplenote/ReferenceTableViewCell.swift
+++ b/Simplenote/ReferenceTableViewCell.swift
@@ -1,0 +1,51 @@
+import Foundation
+import AppKit
+
+
+// MARK: - ReferenceTableViewCell
+//
+class ReferenceTableViewCell: NSTableCellView {
+
+    /// Details TextField
+    ///
+    @IBOutlet private weak var detailsTextField: NSTextField!
+
+    /// Wraps access to the TextField's String Value
+    ///
+    var title: String? {
+        get {
+            textField?.stringValue
+        }
+        set {
+            textField?.stringValue = newValue ?? ""
+        }
+    }
+
+    /// Wraps access to the Details TextField's String Value
+    ///
+    var details: String? {
+        get {
+            detailsTextField?.stringValue
+        }
+        set {
+            detailsTextField?.stringValue = newValue ?? ""
+        }
+    }
+
+    // MARK: - Overridden Methods
+
+    override func viewWillDraw() {
+        super.viewWillDraw()
+        refreshStyle()
+    }
+}
+
+
+// MARK: - Private API(s)
+//
+private extension ReferenceTableViewCell {
+
+    func refreshStyle() {
+        textField?.textColor = .simplenoteTextColor
+    }
+}

--- a/Simplenote/ReferenceTableViewCell.swift
+++ b/Simplenote/ReferenceTableViewCell.swift
@@ -47,5 +47,6 @@ private extension ReferenceTableViewCell {
 
     func refreshStyle() {
         textField?.textColor = .simplenoteTextColor
+        detailsTextField?.textColor = .simplenoteSecondaryTextColor
     }
 }

--- a/Simplenote/SeparatorTableViewCell.swift
+++ b/Simplenote/SeparatorTableViewCell.swift
@@ -1,0 +1,19 @@
+import Foundation
+import AppKit
+
+
+// MARK: - SeparatorTableViewCell
+//
+class SeparatorTableViewCell: NSTableCellView {
+
+    /// Draws the main separator
+    ///
+    @IBOutlet private weak var separatorView: BackgroundView!
+
+    // MARK: - Overridden API(s)
+
+    override func viewWillDraw() {
+        super.viewWillDraw()
+        separatorView.fillColor = .simplenotePlaceholderTintColor
+    }
+}

--- a/Simplenote/TagListViewController+Swift.swift
+++ b/Simplenote/TagListViewController+Swift.swift
@@ -111,7 +111,8 @@ extension TagListViewController {
     ///
     func tagHeaderTableViewCell() -> HeaderTableCellView {
         let headerView = tableView.makeTableViewCell(ofType: HeaderTableCellView.self)
-        headerView.textField?.stringValue = NSLocalizedString("Tags", comment: "Tags Section Name").uppercased()
+        headerView.title = NSLocalizedString("Tags", comment: "Tags Section Name").uppercased()
+        headerView.titleColor = .simplenoteSecondaryTextColor
         return headerView
     }
 


### PR DESCRIPTION
### Details:
- Rebuilds the Metrics UI, based on NSTableView
- Implements new NSTableViewCell subclasses: `[MetricTableViewCell, ReferenceTableViewCell, SeparatorTableViewCell]`
- Metrics: We're now displaying inbound note references

@eshurakov Mind taking a look at this one Evgeny?
Thank youuu!

Ref. #663 

### Test: Multiple Selection
1. Log into your account!
2. Right click over **Note A** in your notes list: click over `Copy Internal Link`
3. Click over **Note B** and paste the contents of your clipboard
4. CMD + Click over **Note A** + **Note B** in your list
5. Click over the top right `( i )` icon

- [x] Verify only 5 rows show up:
- [x] Verify only `Words` and `Characters` are populated
- [x] Verify that editing either `Note A` or `Note B` in a secondary device (simplenote.com on the web works!) causes the UI to refresh


### Test: Single Selection
1. Log into your account!
2. Right click over **Note A** in your notes list: click over `Copy Internal Link`
3. Paste the contents of your clipboard on **at least** 4 notes (so that 4 notes reference back to Note A!)
4. Click over **Note A**
5. Click over the top right `( i )` icon

- [x] Verify that all of the inbound links (References!) you pasted in step 3 show up at the bottom of the Metrics UI
- [x] Verify that you can scroll **all of the contents** of the Metrics UI (every single row should move!)

### Release
These changes do not require release notes.


---

### Screenshots
<img width="300" alt="Screen Shot 2020-10-21 at 15 22 11" src="https://user-images.githubusercontent.com/1195260/96766432-7485d880-13b1-11eb-8327-b69ccafa78bd.png">

<img width="300" alt="Screen Shot 2020-10-21 at 15 22 24" src="https://user-images.githubusercontent.com/1195260/96766411-6df76100-13b1-11eb-8c9d-7049a6066278.png">
