### PR TITLE
CONTRIBUTING.md: Add information about our PR merge policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,3 +13,15 @@ If you’re filing a bug, specific steps to reproduce are helpful. Please includ
 ## Submitting code changes
 
 We welcome Pull Requests for bug fixes on any open issues that you'd like to contribute!
+
+All code contributions pass through pull requests. If you haven't created a pull request before, we recommend this free video series, [How to Contribute to an Open Source Project on GitHub](https://egghead.io/courses/how-to-contribute-to-an-open-source-project-on-github).
+
+Note: If you are part of the org and have the permissions on the repo, don't forget to assign yourself to the PR, and add the appropriate GitHub label and Milestone for the PR
+
+### PR merge policy
+
+* PRs require one reviewer to approve the PR before it can be merged to the base branch
+* We keep the PR git history when merging (merge via "merge commit")
+* Who merges the PR once it's approved and green?
+  * For PRs authored by people external to the organisation and not having push permissions, the reviewer who approved the PR will merge it.
+  * For PRs authored by contributors with push permissions, the author of the PR will merge their own PR.


### PR DESCRIPTION
### Fix

Improve CONTRIBUTING.md doc to mention our merge policy for this repo (similar to https://github.com/Automattic/simplenote-ios/pull/962)

### Review

Only one developer is required to review these changes, but anyone can perform the review.

### Release

These changes do not require release notes.
