### PR TITLE
Main Window: Drops titlebar

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 2.5
 -----
+- Removed Main Window's Titlebar #719
 
 2.4
 ---

--- a/Simplenote/Base.lproj/MainMenu.xib
+++ b/Simplenote/Base.lproj/MainMenu.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="17156" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="17506" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17156"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17506"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -713,11 +713,11 @@
             </connections>
             <point key="canvasLocation" x="-84" y="-325"/>
         </menu>
-        <window allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="SPWindow" animationBehavior="default" tabbingMode="disallowed" titleVisibility="hidden" id="371" customClass="Window" customModule="Simplenote" customModuleProvider="target">
+        <window allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="SPWindow" animationBehavior="default" tabbingMode="disallowed" titlebarAppearsTransparent="YES" titleVisibility="hidden" id="371" customClass="Window" customModule="Simplenote" customModuleProvider="target">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES" fullSizeContentView="YES"/>
             <windowCollectionBehavior key="collectionBehavior" fullScreenPrimary="YES"/>
             <rect key="contentRect" x="199" y="95" width="900" height="618"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1027"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1025"/>
             <value key="minSize" type="size" width="720" height="400"/>
             <view key="contentView" id="372">
                 <rect key="frame" x="0.0" y="0.0" width="900" height="618"/>

--- a/Simplenote/Main.storyboard
+++ b/Simplenote/Main.storyboard
@@ -197,13 +197,13 @@
                                 <rect key="frame" x="0.0" y="0.0" width="292" height="618"/>
                             </customView>
                             <customView translatesAutoresizingMaskIntoConstraints="NO" id="s2j-Xp-jGd" userLabel="Divider View" customClass="BackgroundView" customModule="Simplenote" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="570" width="292" height="48"/>
+                                <rect key="frame" x="0.0" y="566" width="292" height="52"/>
                             </customView>
                             <view translatesAutoresizingMaskIntoConstraints="NO" id="weN-h2-sJL" userLabel="SearchView">
-                                <rect key="frame" x="0.0" y="570" width="292" height="48"/>
+                                <rect key="frame" x="0.0" y="566" width="292" height="52"/>
                                 <subviews>
                                     <searchField wantsLayer="YES" verticalHuggingPriority="750" tag="1" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="cvh-C8-b0b" userLabel="SearchField">
-                                        <rect key="frame" x="12" y="11" width="228" height="26"/>
+                                        <rect key="frame" x="12" y="11" width="228" height="30"/>
                                         <searchFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" borderStyle="bezel" placeholderString="Search" usesSingleLineMode="YES" bezelStyle="round" id="Umi-3H-Bn4">
                                             <font key="font" metaFont="system"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -215,7 +215,7 @@
                                         </connections>
                                     </searchField>
                                     <button toolTip="Add Note" translatesAutoresizingMaskIntoConstraints="NO" id="LGw-AF-2MK" userLabel="NewNote">
-                                        <rect key="frame" x="256" y="14" width="20" height="20"/>
+                                        <rect key="frame" x="256" y="16" width="20" height="20"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="20" id="mDL-V4-Sng"/>
                                             <constraint firstAttribute="height" constant="20" id="oUz-t6-8il"/>
@@ -235,18 +235,18 @@
                                     <constraint firstItem="LGw-AF-2MK" firstAttribute="leading" secondItem="cvh-C8-b0b" secondAttribute="trailing" constant="16" id="EaC-ed-3nU"/>
                                     <constraint firstItem="LGw-AF-2MK" firstAttribute="centerY" secondItem="cvh-C8-b0b" secondAttribute="centerY" id="GdR-Rc-HQZ"/>
                                     <constraint firstAttribute="bottom" secondItem="cvh-C8-b0b" secondAttribute="bottom" constant="11" id="Gz4-wE-pXe"/>
-                                    <constraint firstAttribute="height" constant="48" id="Reo-KD-mIh"/>
+                                    <constraint firstAttribute="height" constant="52" id="Reo-KD-mIh"/>
                                     <constraint firstItem="cvh-C8-b0b" firstAttribute="leading" secondItem="weN-h2-sJL" secondAttribute="leading" constant="12" id="uDy-dn-4qz"/>
                                 </constraints>
                             </view>
                             <scrollView focusRingType="none" borderType="none" horizontalLineScroll="80" horizontalPageScroll="10" verticalLineScroll="80" verticalPageScroll="10" hasHorizontalScroller="NO" horizontalScrollElasticity="none" translatesAutoresizingMaskIntoConstraints="NO" id="JDR-c6-dqi">
-                                <rect key="frame" x="0.0" y="0.0" width="292" height="570"/>
+                                <rect key="frame" x="0.0" y="0.0" width="292" height="566"/>
                                 <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="zul-ko-TNO">
-                                    <rect key="frame" x="0.0" y="0.0" width="292" height="570"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="292" height="566"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="firstColumnOnly" selectionHighlightStyle="sourceList" emptySelection="NO" autosaveColumns="NO" typeSelect="NO" rowHeight="72" rowSizeStyle="automatic" viewBased="YES" floatsGroupRows="NO" id="q9F-rT-PZ2" customClass="SPTableView">
-                                            <rect key="frame" x="0.0" y="0.0" width="292" height="570"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="292" height="566"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <size key="intercellSpacing" width="0.0" height="8"/>
                                             <color key="backgroundColor" red="1" green="0.0" blue="0.0" alpha="0.0" colorSpace="calibratedRGB"/>
@@ -373,12 +373,12 @@
                                     <autoresizingMask key="autoresizingMask"/>
                                 </scroller>
                                 <scroller key="verticalScroller" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="OEr-We-MDq">
-                                    <rect key="frame" x="276" y="0.0" width="16" height="570"/>
+                                    <rect key="frame" x="276" y="0.0" width="16" height="566"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                 </scroller>
                             </scrollView>
                             <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="2I0-KH-uBu">
-                                <rect key="frame" x="10" y="327" width="272" height="23"/>
+                                <rect key="frame" x="10" y="323" width="272" height="23"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="No Notes" id="5l7-bS-Xdk">
                                     <font key="font" size="20" name="HelveticaNeue"/>
                                     <color key="textColor" white="0.0" alpha="0.20000000000000001" colorSpace="custom" customColorSpace="deviceWhite"/>
@@ -386,7 +386,7 @@
                                 </textFieldCell>
                             </textField>
                             <progressIndicator wantsLayer="YES" horizontalHuggingPriority="750" verticalHuggingPriority="750" maxValue="100" bezeled="NO" indeterminate="YES" controlSize="small" style="spinning" translatesAutoresizingMaskIntoConstraints="NO" id="5oO-Ju-l1S">
-                                <rect key="frame" x="138" y="296" width="16" height="16"/>
+                                <rect key="frame" x="138" y="292" width="16" height="16"/>
                             </progressIndicator>
                         </subviews>
                         <constraints>
@@ -487,16 +487,16 @@
                                 <rect key="frame" x="0.0" y="0.0" width="508" height="618"/>
                             </customView>
                             <customView translatesAutoresizingMaskIntoConstraints="NO" id="JAG-km-JCo" userLabel="Top Divider View" customClass="BackgroundView" customModule="Simplenote" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="570" width="508" height="48"/>
+                                <rect key="frame" x="0.0" y="566" width="508" height="52"/>
                             </customView>
                             <customView translatesAutoresizingMaskIntoConstraints="NO" id="mdt-4X-jeq" customClass="ToolbarView" customModule="Simplenote" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="570" width="508" height="48"/>
+                                <rect key="frame" x="0.0" y="566" width="508" height="52"/>
                                 <subviews>
                                     <stackView distribution="fill" orientation="horizontal" alignment="centerY" spacing="25" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="8xD-dy-bio">
-                                        <rect key="frame" x="337" y="0.0" width="155" height="48"/>
+                                        <rect key="frame" x="337" y="0.0" width="155" height="52"/>
                                         <subviews>
                                             <button toolTip="Preview Markdown" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="TI9-l9-KN8" userLabel="Markdown">
-                                                <rect key="frame" x="0.0" y="14" width="20" height="20"/>
+                                                <rect key="frame" x="0.0" y="16" width="20" height="20"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="20" id="1ZX-mt-a4G"/>
                                                     <constraint firstAttribute="width" constant="20" id="JLQ-dt-xp9"/>
@@ -510,7 +510,7 @@
                                                 </connections>
                                             </button>
                                             <button toolTip="Restore" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="W50-6o-QGr" userLabel="Restore">
-                                                <rect key="frame" x="45" y="14" width="20" height="20"/>
+                                                <rect key="frame" x="45" y="16" width="20" height="20"/>
                                                 <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="button_restore" imagePosition="only" alignment="center" imageScaling="proportionallyUpOrDown" inset="2" id="GVO-Z6-G3X">
                                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                                     <font key="font" metaFont="system"/>
@@ -520,7 +520,7 @@
                                                 </connections>
                                             </button>
                                             <button toolTip="Info" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="hVc-Cl-DHn" userLabel="Metrics">
-                                                <rect key="frame" x="90" y="14" width="20" height="20"/>
+                                                <rect key="frame" x="90" y="16" width="20" height="20"/>
                                                 <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="button_info" imagePosition="only" alignment="center" imageScaling="proportionallyUpOrDown" inset="2" id="JJe-f9-FSN">
                                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                                     <font key="font" metaFont="system"/>
@@ -533,7 +533,7 @@
                                                 </connections>
                                             </button>
                                             <button toolTip="Info" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Z7O-L9-Q1P" userLabel="More">
-                                                <rect key="frame" x="135" y="14" width="20" height="20"/>
+                                                <rect key="frame" x="135" y="16" width="20" height="20"/>
                                                 <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="button_ellipsis" imagePosition="only" alignment="center" imageScaling="proportionallyUpOrDown" inset="2" id="Ble-fl-POM">
                                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                                     <font key="font" metaFont="system"/>
@@ -567,7 +567,7 @@
                                 </subviews>
                                 <constraints>
                                     <constraint firstAttribute="bottom" secondItem="8xD-dy-bio" secondAttribute="bottom" id="PxV-l3-3xc"/>
-                                    <constraint firstAttribute="height" constant="48" id="Sbd-Ya-Bl9"/>
+                                    <constraint firstAttribute="height" constant="52" id="Sbd-Ya-Bl9"/>
                                     <constraint firstItem="8xD-dy-bio" firstAttribute="top" secondItem="mdt-4X-jeq" secondAttribute="top" id="Wcs-Kz-DWc"/>
                                     <constraint firstAttribute="trailing" secondItem="8xD-dy-bio" secondAttribute="trailing" constant="16" id="YLX-ev-0uq"/>
                                 </constraints>
@@ -580,17 +580,17 @@
                                 </connections>
                             </customView>
                             <scrollView borderType="none" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" horizontalScrollElasticity="none" translatesAutoresizingMaskIntoConstraints="NO" id="3M9-OX-Hpx">
-                                <rect key="frame" x="0.0" y="48" width="508" height="522"/>
+                                <rect key="frame" x="0.0" y="48" width="508" height="518"/>
                                 <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="4oT-JU-wrs">
-                                    <rect key="frame" x="0.0" y="0.0" width="508" height="522"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="508" height="518"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <textView drawsBackground="NO" importsGraphics="NO" richText="NO" verticallyResizable="YES" findStyle="panel" incrementalSearchingEnabled="YES" continuousSpellChecking="YES" allowsUndo="YES" allowsNonContiguousLayout="YES" linkDetection="YES" dataDetection="YES" smartInsertDelete="YES" id="84J-wh-qoX" customClass="SPTextView">
-                                            <rect key="frame" x="0.0" y="0.0" width="493" height="522"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="493" height="518"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
                                             <color key="backgroundColor" red="1" green="0.0" blue="0.0" alpha="0.0" colorSpace="calibratedRGB"/>
-                                            <size key="minSize" width="493" height="522"/>
+                                            <size key="minSize" width="508" height="518"/>
                                             <size key="maxSize" width="10000000" height="10000000"/>
                                             <color key="insertionPointColor" name="textColor" catalog="System" colorSpace="catalog"/>
                                             <connections>
@@ -605,7 +605,7 @@
                                     <autoresizingMask key="autoresizingMask"/>
                                 </scroller>
                                 <scroller key="verticalScroller" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="lkL-cz-Hnm">
-                                    <rect key="frame" x="492" y="0.0" width="16" height="522"/>
+                                    <rect key="frame" x="492" y="0.0" width="16" height="518"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                 </scroller>
                             </scrollView>

--- a/Simplenote/Main.storyboard
+++ b/Simplenote/Main.storyboard
@@ -15,7 +15,7 @@
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <visualEffectView blendingMode="behindWindow" material="menu" state="active" translatesAutoresizingMaskIntoConstraints="NO" id="9tf-Lw-qRu">
-                                <rect key="frame" x="0.0" y="0.0" width="140" height="618"/>
+                                <rect key="frame" x="0.0" y="0.0" width="140" height="566"/>
                             </visualEffectView>
                             <scrollView borderType="none" horizontalLineScroll="29" horizontalPageScroll="10" verticalLineScroll="29" verticalPageScroll="10" hasHorizontalScroller="NO" hasVerticalScroller="NO" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2Hn-Sh-zaZ">
                                 <rect key="frame" x="0.0" y="0.0" width="140" height="618"/>
@@ -24,7 +24,7 @@
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnSelection="YES" multipleSelection="NO" emptySelection="NO" autosaveColumns="NO" rowHeight="29" rowSizeStyle="automatic" viewBased="YES" id="1PS-xY-Vtk" customClass="SPTableView">
-                                            <rect key="frame" x="0.0" y="0.0" width="140" height="618"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="140" height="566"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <color key="backgroundColor" red="1" green="0.0074358092779999996" blue="0.18312235169999999" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                             <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
@@ -148,7 +148,7 @@
                                             </connections>
                                         </tableView>
                                     </subviews>
-                                    <edgeInsets key="contentInsets" left="0.0" right="0.0" top="0.0" bottom="0.0"/>
+                                    <edgeInsets key="contentInsets" left="0.0" right="0.0" top="52" bottom="0.0"/>
                                 </clipView>
                                 <constraints>
                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="120" id="SFn-Uk-yVD"/>
@@ -163,22 +163,41 @@
                                     <autoresizingMask key="autoresizingMask"/>
                                 </scroller>
                             </scrollView>
+                            <visualEffectView blendingMode="behindWindow" material="menu" state="active" translatesAutoresizingMaskIntoConstraints="NO" id="W0l-PR-dA6">
+                                <rect key="frame" x="0.0" y="566" width="140" height="52"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="52" id="1Jn-yq-nkd"/>
+                                </constraints>
+                            </visualEffectView>
+                            <customView translatesAutoresizingMaskIntoConstraints="NO" id="LCF-v1-7tj" userLabel="Header Separator View" customClass="BackgroundView" customModule="Simplenote" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="566" width="140" height="52"/>
+                            </customView>
                         </subviews>
                         <constraints>
+                            <constraint firstItem="W0l-PR-dA6" firstAttribute="top" secondItem="Muw-Yd-KYW" secondAttribute="top" id="143-Uc-OCx"/>
+                            <constraint firstItem="LCF-v1-7tj" firstAttribute="leading" secondItem="W0l-PR-dA6" secondAttribute="leading" id="59t-ro-30o"/>
                             <constraint firstAttribute="trailing" secondItem="2Hn-Sh-zaZ" secondAttribute="trailing" id="AZD-du-wyV"/>
                             <constraint firstItem="9tf-Lw-qRu" firstAttribute="leading" secondItem="Muw-Yd-KYW" secondAttribute="leading" id="CBl-CF-qi6"/>
+                            <constraint firstItem="LCF-v1-7tj" firstAttribute="bottom" secondItem="W0l-PR-dA6" secondAttribute="bottom" id="Mk8-8J-GGs"/>
+                            <constraint firstItem="W0l-PR-dA6" firstAttribute="leading" secondItem="Muw-Yd-KYW" secondAttribute="leading" id="PNh-J2-KN1"/>
+                            <constraint firstAttribute="trailing" secondItem="W0l-PR-dA6" secondAttribute="trailing" id="Vyf-mU-PIx"/>
+                            <constraint firstItem="LCF-v1-7tj" firstAttribute="top" secondItem="W0l-PR-dA6" secondAttribute="top" id="XpM-6E-WAJ"/>
                             <constraint firstAttribute="bottom" secondItem="2Hn-Sh-zaZ" secondAttribute="bottom" id="aWt-va-hvV"/>
                             <constraint firstAttribute="trailing" secondItem="9tf-Lw-qRu" secondAttribute="trailing" id="cYz-y6-jvd"/>
-                            <constraint firstItem="9tf-Lw-qRu" firstAttribute="top" secondItem="Muw-Yd-KYW" secondAttribute="top" id="cjN-94-D5D"/>
                             <constraint firstAttribute="bottom" secondItem="9tf-Lw-qRu" secondAttribute="bottom" id="hLs-ft-9Mk"/>
                             <constraint firstItem="2Hn-Sh-zaZ" firstAttribute="leading" secondItem="Muw-Yd-KYW" secondAttribute="leading" id="o7j-wo-hkv"/>
+                            <constraint firstItem="LCF-v1-7tj" firstAttribute="trailing" secondItem="W0l-PR-dA6" secondAttribute="trailing" id="tjZ-SU-BMZ"/>
                             <constraint firstItem="2Hn-Sh-zaZ" firstAttribute="top" secondItem="Muw-Yd-KYW" secondAttribute="top" id="uEi-hD-Qps"/>
+                            <constraint firstItem="9tf-Lw-qRu" firstAttribute="top" secondItem="LCF-v1-7tj" secondAttribute="bottom" id="y38-zs-lj1"/>
                         </constraints>
                     </view>
                     <connections>
+                        <outlet property="backgroundVisualEffectsView" destination="9tf-Lw-qRu" id="OsZ-lV-va3"/>
                         <outlet property="clipView" destination="elT-nR-XZN" id="LCl-3r-y3e"/>
+                        <outlet property="headerSeparatorView" destination="LCF-v1-7tj" id="hru-zD-RQL"/>
+                        <outlet property="headerVisualEffectsView" destination="W0l-PR-dA6" id="RxX-vO-ofp"/>
+                        <outlet property="scrollView" destination="2Hn-Sh-zaZ" id="q9P-tJ-TUc"/>
                         <outlet property="tableView" destination="1PS-xY-Vtk" id="JSq-mF-TJ5"/>
-                        <outlet property="visualEffectsView" destination="9tf-Lw-qRu" id="XDR-Tf-1aN"/>
                     </connections>
                 </viewController>
                 <customObject id="CM3-Mo-F1C" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
@@ -590,7 +609,7 @@
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
                                             <color key="backgroundColor" red="1" green="0.0" blue="0.0" alpha="0.0" colorSpace="calibratedRGB"/>
-                                            <size key="minSize" width="508" height="518"/>
+                                            <size key="minSize" width="493" height="518"/>
                                             <size key="maxSize" width="10000000" height="10000000"/>
                                             <color key="insertionPointColor" name="textColor" catalog="System" colorSpace="catalog"/>
                                             <connections>

--- a/Simplenote/Main.storyboard
+++ b/Simplenote/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="16097.3" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="17506" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="16097.3"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17506"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -11,25 +11,25 @@
             <objects>
                 <viewController storyboardIdentifier="TagListViewController" id="DTE-cl-X3E" customClass="TagListViewController" sceneMemberID="viewController">
                     <view key="view" id="Muw-Yd-KYW">
-                        <rect key="frame" x="0.0" y="0.0" width="120" height="618"/>
+                        <rect key="frame" x="0.0" y="0.0" width="140" height="618"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <visualEffectView blendingMode="behindWindow" material="menu" state="active" translatesAutoresizingMaskIntoConstraints="NO" id="9tf-Lw-qRu">
-                                <rect key="frame" x="0.0" y="0.0" width="120" height="618"/>
+                                <rect key="frame" x="0.0" y="0.0" width="140" height="618"/>
                             </visualEffectView>
                             <scrollView borderType="none" horizontalLineScroll="29" horizontalPageScroll="10" verticalLineScroll="29" verticalPageScroll="10" hasHorizontalScroller="NO" hasVerticalScroller="NO" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2Hn-Sh-zaZ">
-                                <rect key="frame" x="0.0" y="0.0" width="120" height="618"/>
+                                <rect key="frame" x="0.0" y="0.0" width="140" height="618"/>
                                 <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="elT-nR-XZN" customClass="ClipView" customModule="Simplenote" customModuleProvider="target">
-                                    <rect key="frame" x="0.0" y="0.0" width="120" height="618"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="140" height="618"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnSelection="YES" multipleSelection="NO" emptySelection="NO" autosaveColumns="NO" rowHeight="29" rowSizeStyle="automatic" viewBased="YES" id="1PS-xY-Vtk" customClass="SPTableView">
-                                            <rect key="frame" x="0.0" y="0.0" width="120" height="618"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="140" height="618"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <color key="backgroundColor" red="1" green="0.0074358092779999996" blue="0.18312235169999999" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                             <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
                                             <tableColumns>
-                                                <tableColumn identifier="NameColumn" width="120" minWidth="40" maxWidth="1000" id="TbY-k2-hUl">
+                                                <tableColumn identifier="NameColumn" width="108" minWidth="40" maxWidth="1000" id="TbY-k2-hUl">
                                                     <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left">
                                                         <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" white="0.33333298560000002" alpha="1" colorSpace="calibratedWhite"/>
@@ -42,7 +42,7 @@
                                                     <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                                     <prototypeCellViews>
                                                         <tableCellView identifier="SpacerTableViewCell" id="RyL-oL-AZL" userLabel="Spacer" customClass="SpacerTableViewCell" customModule="Simplenote" customModuleProvider="target">
-                                                            <rect key="frame" x="0.0" y="0.0" width="120" height="16"/>
+                                                            <rect key="frame" x="10" y="0.0" width="120" height="16"/>
                                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                             <subviews>
                                                                 <customView translatesAutoresizingMaskIntoConstraints="NO" id="xjr-Tk-HSi">
@@ -60,13 +60,13 @@
                                                             </constraints>
                                                         </tableCellView>
                                                         <tableCellView identifier="HeaderTableCellView" id="ftn-CT-UtG" userLabel="Header" customClass="HeaderTableCellView" customModule="Simplenote" customModuleProvider="target">
-                                                            <rect key="frame" x="0.0" y="16" width="120" height="27"/>
+                                                            <rect key="frame" x="10" y="16" width="120" height="27"/>
                                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                             <subviews>
                                                                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3Gk-Te-s8H">
                                                                     <rect key="frame" x="14" y="6" width="96" height="15"/>
                                                                     <textFieldCell key="cell" lineBreakMode="truncatingTail" allowsUndo="NO" sendsActionOnEndEditing="YES" title="Header" placeholderString="" usesSingleLineMode="YES" id="4mI-A4-Nw3">
-                                                                        <font key="font" metaFont="label" size="12"/>
+                                                                        <font key="font" metaFont="cellTitle"/>
                                                                         <color key="textColor" white="0.40000000000000002" alpha="1" colorSpace="calibratedWhite"/>
                                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                     </textFieldCell>
@@ -86,7 +86,7 @@
                                                             </connections>
                                                         </tableCellView>
                                                         <tableCellView identifier="TagTableCellView" id="Nrb-k8-TzG" userLabel="Tag" customClass="TagTableCellView" customModule="Simplenote" customModuleProvider="target">
-                                                            <rect key="frame" x="0.0" y="43" width="120" height="29"/>
+                                                            <rect key="frame" x="10" y="43" width="120" height="29"/>
                                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                             <subviews>
                                                                 <stackView distribution="fill" orientation="horizontal" alignment="top" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="EiU-KW-NFn">
@@ -153,6 +153,7 @@
                                 <constraints>
                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="120" id="SFn-Uk-yVD"/>
                                 </constraints>
+                                <edgeInsets key="contentInsets" left="0.0" right="0.0" top="0.0" bottom="0.0"/>
                                 <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="v61-wc-zHq">
                                     <rect key="frame" x="-100" y="-100" width="152" height="16"/>
                                     <autoresizingMask key="autoresizingMask"/>
@@ -189,20 +190,20 @@
             <objects>
                 <viewController storyboardIdentifier="NoteListViewController" id="JtV-0Z-Zh8" customClass="NoteListViewController" sceneMemberID="viewController">
                     <view key="view" id="PJl-uT-IxK">
-                        <rect key="frame" x="0.0" y="0.0" width="270" height="618"/>
+                        <rect key="frame" x="0.0" y="0.0" width="292" height="618"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <customView translatesAutoresizingMaskIntoConstraints="NO" id="Dfi-py-m83" customClass="BackgroundView" customModule="Simplenote" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="0.0" width="270" height="618"/>
+                                <rect key="frame" x="0.0" y="0.0" width="292" height="618"/>
                             </customView>
                             <customView translatesAutoresizingMaskIntoConstraints="NO" id="s2j-Xp-jGd" userLabel="Divider View" customClass="BackgroundView" customModule="Simplenote" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="570" width="270" height="48"/>
+                                <rect key="frame" x="0.0" y="570" width="292" height="48"/>
                             </customView>
                             <view translatesAutoresizingMaskIntoConstraints="NO" id="weN-h2-sJL" userLabel="SearchView">
-                                <rect key="frame" x="0.0" y="570" width="270" height="48"/>
+                                <rect key="frame" x="0.0" y="570" width="292" height="48"/>
                                 <subviews>
                                     <searchField wantsLayer="YES" verticalHuggingPriority="750" tag="1" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="cvh-C8-b0b" userLabel="SearchField">
-                                        <rect key="frame" x="12" y="11" width="206" height="26"/>
+                                        <rect key="frame" x="12" y="11" width="228" height="26"/>
                                         <searchFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" borderStyle="bezel" placeholderString="Search" usesSingleLineMode="YES" bezelStyle="round" id="Umi-3H-Bn4">
                                             <font key="font" metaFont="system"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -214,7 +215,7 @@
                                         </connections>
                                     </searchField>
                                     <button toolTip="Add Note" translatesAutoresizingMaskIntoConstraints="NO" id="LGw-AF-2MK" userLabel="NewNote">
-                                        <rect key="frame" x="234" y="14" width="20" height="20"/>
+                                        <rect key="frame" x="256" y="14" width="20" height="20"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="20" id="mDL-V4-Sng"/>
                                             <constraint firstAttribute="height" constant="20" id="oUz-t6-8il"/>
@@ -239,32 +240,32 @@
                                 </constraints>
                             </view>
                             <scrollView focusRingType="none" borderType="none" horizontalLineScroll="80" horizontalPageScroll="10" verticalLineScroll="80" verticalPageScroll="10" hasHorizontalScroller="NO" horizontalScrollElasticity="none" translatesAutoresizingMaskIntoConstraints="NO" id="JDR-c6-dqi">
-                                <rect key="frame" x="0.0" y="0.0" width="270" height="570"/>
+                                <rect key="frame" x="0.0" y="0.0" width="292" height="570"/>
                                 <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="zul-ko-TNO">
-                                    <rect key="frame" x="0.0" y="0.0" width="270" height="570"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="292" height="570"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="firstColumnOnly" selectionHighlightStyle="sourceList" emptySelection="NO" autosaveColumns="NO" typeSelect="NO" rowHeight="72" rowSizeStyle="automatic" viewBased="YES" floatsGroupRows="NO" id="q9F-rT-PZ2" customClass="SPTableView">
-                                            <rect key="frame" x="0.0" y="0.0" width="270" height="570"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="292" height="570"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <size key="intercellSpacing" width="0.0" height="8"/>
                                             <color key="backgroundColor" red="1" green="0.0" blue="0.0" alpha="0.0" colorSpace="calibratedRGB"/>
                                             <color key="gridColor" white="0.94999999999999996" alpha="1" colorSpace="deviceWhite"/>
                                             <tableColumns>
-                                                <tableColumn width="270" maxWidth="10000000" id="FbW-7t-Y9x">
+                                                <tableColumn width="260" maxWidth="10000000" id="FbW-7t-Y9x">
                                                     <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left">
                                                         <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" white="0.33333298560000002" alpha="1" colorSpace="calibratedWhite"/>
                                                     </tableHeaderCell>
                                                     <textFieldCell key="dataCell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" alignment="left" title="Text Cell" id="dMY-8o-TzC">
-                                                        <font key="font" metaFont="label" size="12"/>
+                                                        <font key="font" metaFont="cellTitle"/>
                                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                     </textFieldCell>
                                                     <tableColumnResizingMask key="resizingMask" resizeWithTable="YES"/>
                                                     <prototypeCellViews>
                                                         <tableCellView identifier="NoteTableCellView" id="bde-Ei-vv5" customClass="NoteTableCellView" customModule="Simplenote" customModuleProvider="target">
-                                                            <rect key="frame" x="0.0" y="4" width="270" height="72"/>
+                                                            <rect key="frame" x="10" y="4" width="272" height="72"/>
                                                             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMaxX="YES" flexibleMinY="YES" heightSizable="YES" flexibleMaxY="YES"/>
                                                             <subviews>
                                                                 <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="YP5-KE-GnO" userLabel="Pin Image View">
@@ -276,13 +277,13 @@
                                                                     <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="icon_pin" id="wSK-Lh-kY8"/>
                                                                 </imageView>
                                                                 <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="2" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Y6i-es-ABJ">
-                                                                    <rect key="frame" x="24" y="15" width="230" height="49"/>
+                                                                    <rect key="frame" x="24" y="15" width="232" height="49"/>
                                                                     <subviews>
                                                                         <stackView distribution="fill" orientation="horizontal" alignment="centerY" spacing="0.0" horizontalStackHuggingPriority="251.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="8v7-8o-Tsk">
-                                                                            <rect key="frame" x="0.0" y="32" width="230" height="17"/>
+                                                                            <rect key="frame" x="0.0" y="32" width="232" height="17"/>
                                                                             <subviews>
                                                                                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UdO-10-DWt" userLabel="Title Label">
-                                                                                    <rect key="frame" x="-2" y="0.0" width="222" height="17"/>
+                                                                                    <rect key="frame" x="-2" y="0.0" width="224" height="17"/>
                                                                                     <textFieldCell key="cell" allowsUndo="NO" sendsActionOnEndEditing="YES" title="Note Title!" placeholderString="" allowsEditingTextAttributes="YES" id="yy1-Iz-EEZ">
                                                                                         <font key="font" metaFont="systemMedium" size="14"/>
                                                                                         <color key="textColor" white="0.5" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
@@ -293,7 +294,7 @@
                                                                                     </attributedString>
                                                                                 </textField>
                                                                                 <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="DYD-qJ-8kp" userLabel="Shared Image View">
-                                                                                    <rect key="frame" x="218" y="3" width="12" height="12"/>
+                                                                                    <rect key="frame" x="220" y="3" width="12" height="12"/>
                                                                                     <constraints>
                                                                                         <constraint firstAttribute="height" constant="12" id="h39-F8-6Cf"/>
                                                                                         <constraint firstAttribute="width" constant="12" id="oAn-YZ-vIs"/>
@@ -311,9 +312,9 @@
                                                                             </customSpacing>
                                                                         </stackView>
                                                                         <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1z2-Wd-bPU" userLabel="Body Label">
-                                                                            <rect key="frame" x="-2" y="0.0" width="234" height="30"/>
+                                                                            <rect key="frame" x="-2" y="0.0" width="236" height="30"/>
                                                                             <textFieldCell key="cell" allowsUndo="NO" sendsActionOnEndEditing="YES" title="Entered of cordial do on no hearted. Yet agreed whence and unable limit…" placeholderString="" allowsEditingTextAttributes="YES" id="f5t-6G-s13">
-                                                                                <font key="font" metaFont="label" size="12"/>
+                                                                                <font key="font" metaFont="cellTitle"/>
                                                                                 <color key="textColor" white="0.5" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
                                                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                             </textFieldCell>
@@ -372,12 +373,12 @@
                                     <autoresizingMask key="autoresizingMask"/>
                                 </scroller>
                                 <scroller key="verticalScroller" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="OEr-We-MDq">
-                                    <rect key="frame" x="254" y="0.0" width="16" height="570"/>
+                                    <rect key="frame" x="276" y="0.0" width="16" height="570"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                 </scroller>
                             </scrollView>
                             <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="2I0-KH-uBu">
-                                <rect key="frame" x="10" y="327" width="250" height="23"/>
+                                <rect key="frame" x="10" y="327" width="272" height="23"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="No Notes" id="5l7-bS-Xdk">
                                     <font key="font" size="20" name="HelveticaNeue"/>
                                     <color key="textColor" white="0.0" alpha="0.20000000000000001" colorSpace="custom" customColorSpace="deviceWhite"/>
@@ -385,14 +386,14 @@
                                 </textFieldCell>
                             </textField>
                             <progressIndicator wantsLayer="YES" horizontalHuggingPriority="750" verticalHuggingPriority="750" maxValue="100" bezeled="NO" indeterminate="YES" controlSize="small" style="spinning" translatesAutoresizingMaskIntoConstraints="NO" id="5oO-Ju-l1S">
-                                <rect key="frame" x="127" y="296" width="16" height="16"/>
+                                <rect key="frame" x="138" y="296" width="16" height="16"/>
                             </progressIndicator>
                         </subviews>
                         <constraints>
                             <constraint firstItem="Dfi-py-m83" firstAttribute="top" secondItem="PJl-uT-IxK" secondAttribute="top" id="0no-zJ-IpG"/>
                             <constraint firstItem="weN-h2-sJL" firstAttribute="trailing" secondItem="s2j-Xp-jGd" secondAttribute="trailing" id="2fC-QI-CQl"/>
                             <constraint firstItem="2I0-KH-uBu" firstAttribute="top" secondItem="weN-h2-sJL" secondAttribute="bottom" constant="220" id="5IF-k2-BrN"/>
-                            <constraint firstItem="weN-h2-sJL" firstAttribute="top" secondItem="PJl-uT-IxK" secondAttribute="top" placeholder="YES" id="5v9-sz-uMi"/>
+                            <constraint firstItem="weN-h2-sJL" firstAttribute="top" secondItem="PJl-uT-IxK" secondAttribute="top" id="5v9-sz-uMi"/>
                             <constraint firstAttribute="trailing" secondItem="Dfi-py-m83" secondAttribute="trailing" id="8vm-DU-QCc"/>
                             <constraint firstAttribute="trailing" secondItem="weN-h2-sJL" secondAttribute="trailing" id="AIj-4D-kwX"/>
                             <constraint firstItem="5oO-Ju-l1S" firstAttribute="centerX" secondItem="PJl-uT-IxK" secondAttribute="centerX" id="Hze-oN-sBR"/>
@@ -629,7 +630,7 @@
                                                 <tokenField horizontalHuggingPriority="750" verticalHuggingPriority="750" placeholderIntrinsicWidth="462" placeholderIntrinsicHeight="25" mirrorLayoutDirectionWhenInternationalizing="always" translatesAutoresizingMaskIntoConstraints="NO" id="U3o-VN-U2S" customClass="TagsField" customModule="Simplenote" customModuleProvider="target">
                                                     <rect key="frame" x="-2" y="0.0" width="466" height="25"/>
                                                     <tokenFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" baseWritingDirection="leftToRight" alignment="left" allowsEditingTextAttributes="YES" id="rEO-Bg-V6m" customClass="TagsFieldCell" customModule="Simplenote" customModuleProvider="target">
-                                                        <font key="font" metaFont="label" size="12"/>
+                                                        <font key="font" metaFont="cellTitle"/>
                                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                     </tokenFieldCell>
@@ -698,7 +699,7 @@
                             <constraint firstItem="Zgz-qj-sTm" firstAttribute="leading" secondItem="w7Z-Cl-xvM" secondAttribute="leading" id="ZU3-rD-Cfp"/>
                             <constraint firstItem="Zgz-qj-sTm" firstAttribute="top" secondItem="3M9-OX-Hpx" secondAttribute="bottom" id="n6g-mu-Sf5"/>
                             <constraint firstItem="Dj2-Ut-m6l" firstAttribute="centerY" secondItem="w7Z-Cl-xvM" secondAttribute="centerY" id="nea-OO-Awf"/>
-                            <constraint firstItem="mdt-4X-jeq" firstAttribute="top" secondItem="w7Z-Cl-xvM" secondAttribute="top" placeholder="YES" id="oil-IL-VG8"/>
+                            <constraint firstItem="mdt-4X-jeq" firstAttribute="top" secondItem="w7Z-Cl-xvM" secondAttribute="top" id="oil-IL-VG8"/>
                             <constraint firstItem="Zgz-qj-sTm" firstAttribute="top" secondItem="3M9-OX-Hpx" secondAttribute="bottom" id="pNt-od-Vf5"/>
                             <constraint firstAttribute="bottom" secondItem="RoF-0f-Ugm" secondAttribute="bottom" id="qeu-Jg-mO9"/>
                             <constraint firstAttribute="bottom" secondItem="Zgz-qj-sTm" secondAttribute="bottom" id="w2I-mr-ERE"/>

--- a/Simplenote/NoteEditorViewController+Swift.swift
+++ b/Simplenote/NoteEditorViewController+Swift.swift
@@ -36,35 +36,6 @@ extension NoteEditorViewController {
 }
 
 
-// MARK: - Autolayout FTW
-//
-extension NoteEditorViewController {
-
-    open override func updateViewConstraints() {
-        if mustUpdateToolbarConstraint {
-            updateToolbarTopConstraint()
-        }
-
-        super.updateViewConstraints()
-    }
-
-    var mustUpdateToolbarConstraint: Bool {
-        toolbarViewTopConstraint == nil
-    }
-
-    func updateToolbarTopConstraint() {
-        guard let layoutGuide = toolbarView.window?.contentLayoutGuide as? NSLayoutGuide else {
-            return
-        }
-
-        let newTopConstraint = toolbarView.topAnchor.constraint(equalTo: layoutGuide.topAnchor)
-        newTopConstraint.isActive = true
-
-        toolbarViewTopConstraint = newTopConstraint
-    }
-}
-
-
 // MARK: - Internal State
 //
 extension NoteEditorViewController {

--- a/Simplenote/NoteEditorViewController.h
+++ b/Simplenote/NoteEditorViewController.h
@@ -64,7 +64,6 @@ typedef NS_ENUM(NSInteger, NoteFontSize) {
 @property (nonatomic, strong, readonly) MarkdownViewController                  *markdownViewController;
 @property (nonatomic, strong, readonly) NSArray<Note *>                         *selectedNotes;
 @property (nonatomic, assign, readonly) BOOL                                    viewingTrash;
-@property (nonatomic, strong, nullable) NSLayoutConstraint                      *toolbarViewTopConstraint;
 @property (nonatomic, strong, nullable) InterlinkWindowController               *interlinkWindowController;
 @property (nonatomic,   weak) Note                                              *note;
 @property (nonatomic,   weak) id<EditorControllerNoteActionsDelegate>           noteActionsDelegate;

--- a/Simplenote/NoteListViewController+Swift.swift
+++ b/Simplenote/NoteListViewController+Swift.swift
@@ -120,33 +120,6 @@ extension NoteListViewController {
 }
 
 
-// MARK: - Autolayout FTW
-//
-extension NoteListViewController {
-
-    open override func updateViewConstraints() {
-        if mustUpdateSearchViewConstraint {
-            updateSearchViewTopConstraint()
-        }
-
-        super.updateViewConstraints()
-    }
-
-    var mustUpdateSearchViewConstraint: Bool {
-        searchViewTopConstraint == nil
-    }
-
-    func updateSearchViewTopConstraint() {
-        guard let layoutGuide = searchView.window?.contentLayoutGuide as? NSLayoutGuide else {
-            return
-        }
-
-        searchViewTopConstraint = searchView.topAnchor.constraint(equalTo: layoutGuide.topAnchor)
-        searchViewTopConstraint?.isActive = true
-    }
-}
-
-
 // MARK: - Helpers
 //
 private extension NoteListViewController {

--- a/Simplenote/NoteListViewController.h
+++ b/Simplenote/NoteListViewController.h
@@ -31,7 +31,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, readonly) IBOutlet NSMenu                 *noteListMenu;
 @property (nonatomic, strong, readonly) IBOutlet NSMenu                 *trashListMenu;
 
-@property (nonatomic, strong, nullable) NSLayoutConstraint              *searchViewTopConstraint;
 @property (nonatomic, assign, readonly) BOOL                            searching;
 @property (nonatomic, assign, readonly) BOOL                            viewingTrash;
 

--- a/Simplenote/TagListViewController+Swift.swift
+++ b/Simplenote/TagListViewController+Swift.swift
@@ -195,5 +195,5 @@ extension TagListViewController: SPTextFieldDelegate {
 //
 private enum Settings {
     static let titlebarHeight = CGFloat(22)
-    static let searchBarHeight = CGFloat(48)
+    static let searchBarHeight = CGFloat(52)
 }

--- a/Simplenote/TagListViewController+Swift.swift
+++ b/Simplenote/TagListViewController+Swift.swift
@@ -9,9 +9,7 @@ extension TagListViewController {
     ///
     @objc
     func refreshExtendedContentInsets() {
-        let titlebarHeight = view.window?.simplenoteTitlebarHeight ?? Settings.titlebarHeight
-        let topContentInset = titlebarHeight + Settings.searchBarHeight
-
+        let topContentInset = Settings.searchBarHeight
         guard clipView.contentInsets.top != topContentInset else {
             return
         }

--- a/Simplenote/TagListViewController+Swift.swift
+++ b/Simplenote/TagListViewController+Swift.swift
@@ -5,6 +5,12 @@ import Foundation
 //
 extension TagListViewController {
 
+    @objc
+    func setupHeaderSeparator() {
+        headerSeparatorView.drawsBottomBorder = true
+        refreshHeaderSeparatorAlpha()
+    }
+
     /// Refreshes the Top Content Insets: We'll match the Notes List Insets
     ///
     @objc
@@ -40,6 +46,35 @@ extension TagListViewController {
         }
 
         return state.rowAtIndex(selectedIndex)
+    }
+}
+
+
+// MARK: - Notifications
+//
+extension TagListViewController {
+
+    @objc
+    func startListeningToScrollNotifications() {
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(clipViewDidScroll),
+                                               name: NSView.boundsDidChangeNotification,
+                                               object: clipView)
+    }
+
+    @objc
+    func clipViewDidScroll(sender: Notification) {
+        refreshHeaderSeparatorAlpha()
+    }
+
+    @objc
+    func refreshHeaderSeparatorAlpha() {
+        headerSeparatorView.alphaValue = alphaForHeaderSeparatorView
+    }
+
+    private var alphaForHeaderSeparatorView: CGFloat {
+        let absoluteOffSetY = scrollView.documentVisibleRect.origin.y + clipView.contentInsets.top
+        return min(max(absoluteOffSetY / Settings.maximumAlphaGradientOffset, 0), 1)
     }
 }
 
@@ -194,6 +229,7 @@ extension TagListViewController: SPTextFieldDelegate {
 // MARK: - Settings!
 //
 private enum Settings {
-    static let titlebarHeight = CGFloat(22)
+    static let maximumAlphaGradientOffset = CGFloat(30)
     static let searchBarHeight = CGFloat(52)
+    static let titlebarHeight = CGFloat(22)
 }

--- a/Simplenote/TagListViewController.h
+++ b/Simplenote/TagListViewController.h
@@ -27,7 +27,10 @@ extern NSString * const TagListDidEmptyTrashNotification;
                                                      NSDraggingDestination,
                                                      EditorControllerTagActionsDelegate>
 
-@property (nonatomic, strong, readwrite) IBOutlet NSVisualEffectView    *visualEffectsView;
+@property (nonatomic, strong, readwrite) IBOutlet NSVisualEffectView    *backgroundVisualEffectsView;
+@property (nonatomic, strong, readwrite) IBOutlet NSVisualEffectView    *headerVisualEffectsView;
+@property (nonatomic, strong, readwrite) IBOutlet BackgroundView        *headerSeparatorView;
+@property (nonatomic, strong, readwrite) IBOutlet NSScrollView          *scrollView;
 @property (nonatomic, strong, readwrite) IBOutlet NSClipView            *clipView;
 @property (nonatomic, strong, readwrite) IBOutlet NSTableView           *tableView;
 @property (nonatomic, strong,  readonly) NSMenu                         *tagDropdownMenu;

--- a/Simplenote/TagListViewController.m
+++ b/Simplenote/TagListViewController.m
@@ -63,7 +63,10 @@ CGFloat const TagListEstimatedRowHeight                     = 30;
     [self.tableView registerForDraggedTypes:[NSArray arrayWithObject:@"Tag"]];
     [self.tableView setDraggingSourceOperationMask:NSDragOperationMove forLocal:YES];
 
-    [self startListeningToNotifications];
+    [self setupHeaderSeparator];
+
+    [self startListeningToSettingsNotifications];
+    [self startListeningToScrollNotifications];
 }
 
 - (void)viewWillAppear
@@ -78,7 +81,7 @@ CGFloat const TagListEstimatedRowHeight                     = 30;
     [self refreshExtendedContentInsets];
 }
 
-- (void)startListeningToNotifications
+- (void)startListeningToSettingsNotifications
 {
     NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
     [nc addObserver:self selector:@selector(sortModeWasUpdated:) name:TagSortModeDidChangeNotification object:nil];
@@ -592,8 +595,11 @@ CGFloat const TagListEstimatedRowHeight                     = 30;
 
 - (void)applyStyle
 {
-    self.visualEffectsView.appearance = [NSAppearance simplenoteAppearance];
-    self.visualEffectsView.material = [NSVisualEffectView simplenoteTaglistMaterial];
+    self.headerSeparatorView.borderColor = [NSColor simplenoteDividerColor];
+    self.headerVisualEffectsView.appearance = [NSAppearance simplenoteAppearance];
+    self.headerVisualEffectsView.material = [NSVisualEffectView simplenoteTaglistMaterial];
+    self.backgroundVisualEffectsView.appearance = [NSAppearance simplenoteAppearance];
+    self.backgroundVisualEffectsView.material = [NSVisualEffectView simplenoteTaglistMaterial];
     [self reloadDataAndPreserveSelection];
 }
 


### PR DESCRIPTION
### Fix
In this PR we're dropping the main window's titlebar:

- Updated Top Bar's height to 52pt
- Tags List: New Top Separator

**Known Issues:**
Collapsing the Tags List is causing a collision between the Window's semaphore and the Search Bar. We're fixing that soon!

cc @eshurakov (Thank youuuu!!)
Ref. #718

### Test
1. Log into Simplenote!

- [x] Verify the app looks great!

### Release
`RELEASE-NOTES.txt` was updated in 393af7c with:

> Removed Main Window's Titlebar #719
