### PR TITLE
Updates TableView Styles

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
   Test:
     executor:
       name: ios/default
-      xcode-version: "12.0"
+      xcode-version: "12.2"
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
   Test:
     executor:
       name: ios/default
-      xcode-version: "12.2"
+      xcode-version: "12.0"
     steps:
       - checkout
       - run:

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 2.5
 -----
 - Removed Main Window's Titlebar #719
+- Adopting BigSur Inset Style #721
 
 2.4
 ---

--- a/Simplenote/InterlinkViewController.swift
+++ b/Simplenote/InterlinkViewController.swift
@@ -113,11 +113,9 @@ private extension InterlinkViewController {
         tableView.target = self
         tableView.doubleAction = #selector(performInterlinkInsert)
 
-        guard #available(macOS 11.0, *) else {
-            return
+        if #available(macOS 11, *) {
+            tableView.style = .fullWidth
         }
-
-        tableView.style = .fullWidth
     }
 
     func setupTrackingAreas() {

--- a/Simplenote/InterlinkViewController.swift
+++ b/Simplenote/InterlinkViewController.swift
@@ -112,6 +112,12 @@ private extension InterlinkViewController {
         tableView.becomeFirstResponder()
         tableView.target = self
         tableView.doubleAction = #selector(performInterlinkInsert)
+
+        guard #available(OSX 11.0, *) else {
+            return
+        }
+
+        tableView.style = .fullWidth
     }
 
     func setupTrackingAreas() {

--- a/Simplenote/InterlinkViewController.swift
+++ b/Simplenote/InterlinkViewController.swift
@@ -113,7 +113,7 @@ private extension InterlinkViewController {
         tableView.target = self
         tableView.doubleAction = #selector(performInterlinkInsert)
 
-        guard #available(OSX 11.0, *) else {
+        guard #available(macOS 11.0, *) else {
             return
         }
 

--- a/Simplenote/InterlinkViewController.swift
+++ b/Simplenote/InterlinkViewController.swift
@@ -245,7 +245,9 @@ extension InterlinkViewController: SPTableViewDelegate {
     }
 
     public func tableView(_ tableView: NSTableView, rowViewForRow row: Int) -> NSTableRowView? {
-        TableRowView(style: .fullWidth)
+        let rowView = TableRowView()
+        rowView.style = .fullWidth
+        return rowView
     }
 
     public func tableView(_ tableView: NSTableView, viewFor tableColumn: NSTableColumn?, row: Int) -> NSView? {

--- a/Simplenote/InterlinkViewController.swift
+++ b/Simplenote/InterlinkViewController.swift
@@ -113,9 +113,7 @@ private extension InterlinkViewController {
         tableView.target = self
         tableView.doubleAction = #selector(performInterlinkInsert)
 
-        if #available(macOS 11, *) {
-            tableView.style = .fullWidth
-        }
+        tableView.ensureStyleIsFullWidth()
     }
 
     func setupTrackingAreas() {

--- a/Simplenote/InterlinkViewController.swift
+++ b/Simplenote/InterlinkViewController.swift
@@ -245,9 +245,7 @@ extension InterlinkViewController: SPTableViewDelegate {
     }
 
     public func tableView(_ tableView: NSTableView, rowViewForRow row: Int) -> NSTableRowView? {
-        let rowView = TableRowView()
-        rowView.selectedBackgroundColor = .simplenoteSelectedBackgroundColor
-        return rowView
+        TableRowView(style: .fullWidth)
     }
 
     public func tableView(_ tableView: NSTableView, viewFor tableColumn: NSTableColumn?, row: Int) -> NSView? {

--- a/Simplenote/Main.storyboard
+++ b/Simplenote/Main.storyboard
@@ -513,8 +513,8 @@
                             <customView translatesAutoresizingMaskIntoConstraints="NO" id="mdt-4X-jeq" customClass="ToolbarView" customModule="Simplenote" customModuleProvider="target">
                                 <rect key="frame" x="0.0" y="566" width="508" height="52"/>
                                 <subviews>
-                                    <stackView distribution="fill" orientation="horizontal" alignment="centerY" spacing="25" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="8xD-dy-bio">
-                                        <rect key="frame" x="337" y="0.0" width="155" height="52"/>
+                                    <stackView distribution="fill" orientation="horizontal" alignment="centerY" spacing="22" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="8xD-dy-bio">
+                                        <rect key="frame" x="346" y="0.0" width="146" height="52"/>
                                         <subviews>
                                             <button toolTip="Preview Markdown" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="TI9-l9-KN8" userLabel="Markdown">
                                                 <rect key="frame" x="0.0" y="16" width="20" height="20"/>
@@ -531,7 +531,7 @@
                                                 </connections>
                                             </button>
                                             <button toolTip="Restore" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="W50-6o-QGr" userLabel="Restore">
-                                                <rect key="frame" x="45" y="16" width="20" height="20"/>
+                                                <rect key="frame" x="42" y="16" width="20" height="20"/>
                                                 <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="button_restore" imagePosition="only" alignment="center" imageScaling="proportionallyUpOrDown" inset="2" id="GVO-Z6-G3X">
                                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                                     <font key="font" metaFont="system"/>
@@ -541,7 +541,7 @@
                                                 </connections>
                                             </button>
                                             <button toolTip="Info" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="hVc-Cl-DHn" userLabel="Metrics">
-                                                <rect key="frame" x="90" y="16" width="20" height="20"/>
+                                                <rect key="frame" x="84" y="16" width="20" height="20"/>
                                                 <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="button_info" imagePosition="only" alignment="center" imageScaling="proportionallyUpOrDown" inset="2" id="JJe-f9-FSN">
                                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                                     <font key="font" metaFont="system"/>
@@ -554,7 +554,7 @@
                                                 </connections>
                                             </button>
                                             <button toolTip="Info" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Z7O-L9-Q1P" userLabel="More">
-                                                <rect key="frame" x="135" y="16" width="20" height="20"/>
+                                                <rect key="frame" x="126" y="16" width="20" height="20"/>
                                                 <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="button_ellipsis_outline" imagePosition="only" alignment="center" imageScaling="proportionallyUpOrDown" inset="2" id="Ble-fl-POM">
                                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                                     <font key="font" metaFont="system"/>

--- a/Simplenote/Main.storyboard
+++ b/Simplenote/Main.storyboard
@@ -11,20 +11,20 @@
             <objects>
                 <viewController storyboardIdentifier="TagListViewController" id="DTE-cl-X3E" customClass="TagListViewController" sceneMemberID="viewController">
                     <view key="view" id="Muw-Yd-KYW">
-                        <rect key="frame" x="0.0" y="0.0" width="140" height="618"/>
+                        <rect key="frame" x="0.0" y="0.0" width="120" height="618"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <visualEffectView blendingMode="behindWindow" material="menu" state="active" translatesAutoresizingMaskIntoConstraints="NO" id="9tf-Lw-qRu">
-                                <rect key="frame" x="0.0" y="0.0" width="140" height="566"/>
+                                <rect key="frame" x="0.0" y="0.0" width="120" height="566"/>
                             </visualEffectView>
                             <scrollView borderType="none" horizontalLineScroll="29" horizontalPageScroll="10" verticalLineScroll="29" verticalPageScroll="10" hasHorizontalScroller="NO" hasVerticalScroller="NO" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2Hn-Sh-zaZ">
-                                <rect key="frame" x="0.0" y="0.0" width="140" height="618"/>
+                                <rect key="frame" x="0.0" y="0.0" width="120" height="618"/>
                                 <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="elT-nR-XZN" customClass="ClipView" customModule="Simplenote" customModuleProvider="target">
-                                    <rect key="frame" x="0.0" y="0.0" width="140" height="618"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="120" height="618"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
-                                        <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnSelection="YES" multipleSelection="NO" emptySelection="NO" autosaveColumns="NO" rowHeight="29" rowSizeStyle="automatic" viewBased="YES" id="1PS-xY-Vtk" customClass="SPTableView">
-                                            <rect key="frame" x="0.0" y="0.0" width="140" height="566"/>
+                                        <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" tableStyle="fullWidth" columnSelection="YES" multipleSelection="NO" emptySelection="NO" autosaveColumns="NO" rowHeight="29" rowSizeStyle="automatic" viewBased="YES" id="1PS-xY-Vtk" customClass="SPTableView">
+                                            <rect key="frame" x="0.0" y="0.0" width="120" height="554"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <color key="backgroundColor" red="1" green="0.0074358092779999996" blue="0.18312235169999999" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                             <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
@@ -42,7 +42,7 @@
                                                     <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                                     <prototypeCellViews>
                                                         <tableCellView identifier="SpacerTableViewCell" id="RyL-oL-AZL" userLabel="Spacer" customClass="SpacerTableViewCell" customModule="Simplenote" customModuleProvider="target">
-                                                            <rect key="frame" x="10" y="0.0" width="120" height="16"/>
+                                                            <rect key="frame" x="0.0" y="0.0" width="120" height="16"/>
                                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                             <subviews>
                                                                 <customView translatesAutoresizingMaskIntoConstraints="NO" id="xjr-Tk-HSi">
@@ -60,7 +60,7 @@
                                                             </constraints>
                                                         </tableCellView>
                                                         <tableCellView identifier="HeaderTableCellView" id="ftn-CT-UtG" userLabel="Header" customClass="HeaderTableCellView" customModule="Simplenote" customModuleProvider="target">
-                                                            <rect key="frame" x="10" y="16" width="120" height="27"/>
+                                                            <rect key="frame" x="0.0" y="16" width="120" height="27"/>
                                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                             <subviews>
                                                                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3Gk-Te-s8H">
@@ -86,7 +86,7 @@
                                                             </connections>
                                                         </tableCellView>
                                                         <tableCellView identifier="TagTableCellView" id="Nrb-k8-TzG" userLabel="Tag" customClass="TagTableCellView" customModule="Simplenote" customModuleProvider="target">
-                                                            <rect key="frame" x="10" y="43" width="120" height="29"/>
+                                                            <rect key="frame" x="0.0" y="43" width="120" height="29"/>
                                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                             <subviews>
                                                                 <stackView distribution="fill" orientation="horizontal" alignment="top" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="EiU-KW-NFn">
@@ -148,7 +148,7 @@
                                             </connections>
                                         </tableView>
                                     </subviews>
-                                    <edgeInsets key="contentInsets" left="0.0" right="0.0" top="52" bottom="0.0"/>
+                                    <edgeInsets key="contentInsets" left="0.0" right="0.0" top="64" bottom="0.0"/>
                                 </clipView>
                                 <constraints>
                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="120" id="SFn-Uk-yVD"/>
@@ -164,13 +164,13 @@
                                 </scroller>
                             </scrollView>
                             <visualEffectView blendingMode="behindWindow" material="menu" state="active" translatesAutoresizingMaskIntoConstraints="NO" id="W0l-PR-dA6">
-                                <rect key="frame" x="0.0" y="566" width="140" height="52"/>
+                                <rect key="frame" x="0.0" y="566" width="120" height="52"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="52" id="1Jn-yq-nkd"/>
                                 </constraints>
                             </visualEffectView>
                             <customView translatesAutoresizingMaskIntoConstraints="NO" id="LCF-v1-7tj" userLabel="Header Separator View" customClass="BackgroundView" customModule="Simplenote" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="566" width="140" height="52"/>
+                                <rect key="frame" x="0.0" y="566" width="120" height="52"/>
                             </customView>
                         </subviews>
                         <constraints>
@@ -209,20 +209,20 @@
             <objects>
                 <viewController storyboardIdentifier="NoteListViewController" id="JtV-0Z-Zh8" customClass="NoteListViewController" sceneMemberID="viewController">
                     <view key="view" id="PJl-uT-IxK">
-                        <rect key="frame" x="0.0" y="0.0" width="292" height="618"/>
+                        <rect key="frame" x="0.0" y="0.0" width="272" height="618"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <customView translatesAutoresizingMaskIntoConstraints="NO" id="Dfi-py-m83" customClass="BackgroundView" customModule="Simplenote" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="0.0" width="292" height="618"/>
+                                <rect key="frame" x="0.0" y="0.0" width="272" height="618"/>
                             </customView>
                             <customView translatesAutoresizingMaskIntoConstraints="NO" id="s2j-Xp-jGd" userLabel="Divider View" customClass="BackgroundView" customModule="Simplenote" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="566" width="292" height="52"/>
+                                <rect key="frame" x="0.0" y="566" width="272" height="52"/>
                             </customView>
                             <view translatesAutoresizingMaskIntoConstraints="NO" id="weN-h2-sJL" userLabel="SearchView">
-                                <rect key="frame" x="0.0" y="566" width="292" height="52"/>
+                                <rect key="frame" x="0.0" y="566" width="272" height="52"/>
                                 <subviews>
                                     <searchField wantsLayer="YES" verticalHuggingPriority="750" tag="1" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="cvh-C8-b0b" userLabel="SearchField">
-                                        <rect key="frame" x="12" y="11" width="228" height="30"/>
+                                        <rect key="frame" x="12" y="11" width="208" height="30"/>
                                         <searchFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" borderStyle="bezel" placeholderString="Search" usesSingleLineMode="YES" bezelStyle="round" id="Umi-3H-Bn4">
                                             <font key="font" metaFont="system"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -234,7 +234,7 @@
                                         </connections>
                                     </searchField>
                                     <button toolTip="Add Note" translatesAutoresizingMaskIntoConstraints="NO" id="LGw-AF-2MK" userLabel="NewNote">
-                                        <rect key="frame" x="256" y="16" width="20" height="20"/>
+                                        <rect key="frame" x="236" y="16" width="20" height="20"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="20" id="mDL-V4-Sng"/>
                                             <constraint firstAttribute="height" constant="20" id="oUz-t6-8il"/>
@@ -259,16 +259,16 @@
                                 </constraints>
                             </view>
                             <scrollView focusRingType="none" borderType="none" horizontalLineScroll="80" horizontalPageScroll="10" verticalLineScroll="80" verticalPageScroll="10" hasHorizontalScroller="NO" horizontalScrollElasticity="none" translatesAutoresizingMaskIntoConstraints="NO" id="JDR-c6-dqi">
-                                <rect key="frame" x="0.0" y="0.0" width="292" height="566"/>
+                                <rect key="frame" x="0.0" y="0.0" width="272" height="566"/>
                                 <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="zul-ko-TNO">
-                                    <rect key="frame" x="0.0" y="0.0" width="292" height="566"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="272" height="566"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
-                                        <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="firstColumnOnly" selectionHighlightStyle="sourceList" emptySelection="NO" autosaveColumns="NO" typeSelect="NO" rowHeight="72" rowSizeStyle="automatic" viewBased="YES" floatsGroupRows="NO" id="q9F-rT-PZ2" customClass="SPTableView">
-                                            <rect key="frame" x="0.0" y="0.0" width="292" height="566"/>
+                                        <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="firstColumnOnly" tableStyle="fullWidth" emptySelection="NO" autosaveColumns="NO" typeSelect="NO" rowHeight="72" rowSizeStyle="automatic" viewBased="YES" floatsGroupRows="NO" id="q9F-rT-PZ2" customClass="SPTableView">
+                                            <rect key="frame" x="0.0" y="0.0" width="272" height="554"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <size key="intercellSpacing" width="0.0" height="8"/>
-                                            <color key="backgroundColor" red="1" green="0.0" blue="0.0" alpha="0.0" colorSpace="calibratedRGB"/>
+                                            <color key="backgroundColor" red="1" green="1" blue="1" alpha="0.0" colorSpace="custom" customColorSpace="displayP3"/>
                                             <color key="gridColor" white="0.94999999999999996" alpha="1" colorSpace="deviceWhite"/>
                                             <tableColumns>
                                                 <tableColumn width="260" maxWidth="10000000" id="FbW-7t-Y9x">
@@ -284,11 +284,11 @@
                                                     <tableColumnResizingMask key="resizingMask" resizeWithTable="YES"/>
                                                     <prototypeCellViews>
                                                         <tableCellView identifier="NoteTableCellView" id="bde-Ei-vv5" customClass="NoteTableCellView" customModule="Simplenote" customModuleProvider="target">
-                                                            <rect key="frame" x="10" y="4" width="272" height="72"/>
+                                                            <rect key="frame" x="0.0" y="4" width="272" height="72"/>
                                                             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMaxX="YES" flexibleMinY="YES" heightSizable="YES" flexibleMaxY="YES"/>
                                                             <subviews>
                                                                 <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="YP5-KE-GnO" userLabel="Pin Image View">
-                                                                    <rect key="frame" x="7" y="50" width="12" height="12"/>
+                                                                    <rect key="frame" x="18" y="54" width="12" height="12"/>
                                                                     <constraints>
                                                                         <constraint firstAttribute="height" constant="12" id="3hZ-oW-r14"/>
                                                                         <constraint firstAttribute="width" constant="12" id="GP8-O5-fwy"/>
@@ -296,13 +296,13 @@
                                                                     <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="icon_pin" id="wSK-Lh-kY8"/>
                                                                 </imageView>
                                                                 <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="2" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Y6i-es-ABJ">
-                                                                    <rect key="frame" x="24" y="15" width="232" height="49"/>
+                                                                    <rect key="frame" x="36" y="4" width="208" height="64"/>
                                                                     <subviews>
                                                                         <stackView distribution="fill" orientation="horizontal" alignment="centerY" spacing="0.0" horizontalStackHuggingPriority="251.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="8v7-8o-Tsk">
-                                                                            <rect key="frame" x="0.0" y="32" width="232" height="17"/>
+                                                                            <rect key="frame" x="0.0" y="47" width="208" height="17"/>
                                                                             <subviews>
                                                                                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UdO-10-DWt" userLabel="Title Label">
-                                                                                    <rect key="frame" x="-2" y="0.0" width="224" height="17"/>
+                                                                                    <rect key="frame" x="-2" y="0.0" width="200" height="17"/>
                                                                                     <textFieldCell key="cell" allowsUndo="NO" sendsActionOnEndEditing="YES" title="Note Title!" placeholderString="" allowsEditingTextAttributes="YES" id="yy1-Iz-EEZ">
                                                                                         <font key="font" metaFont="systemMedium" size="14"/>
                                                                                         <color key="textColor" white="0.5" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
@@ -313,7 +313,7 @@
                                                                                     </attributedString>
                                                                                 </textField>
                                                                                 <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="DYD-qJ-8kp" userLabel="Shared Image View">
-                                                                                    <rect key="frame" x="220" y="3" width="12" height="12"/>
+                                                                                    <rect key="frame" x="196" y="3" width="12" height="12"/>
                                                                                     <constraints>
                                                                                         <constraint firstAttribute="height" constant="12" id="h39-F8-6Cf"/>
                                                                                         <constraint firstAttribute="width" constant="12" id="oAn-YZ-vIs"/>
@@ -330,9 +330,9 @@
                                                                                 <real value="3.4028234663852886e+38"/>
                                                                             </customSpacing>
                                                                         </stackView>
-                                                                        <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1z2-Wd-bPU" userLabel="Body Label">
-                                                                            <rect key="frame" x="-2" y="0.0" width="236" height="30"/>
-                                                                            <textFieldCell key="cell" allowsUndo="NO" sendsActionOnEndEditing="YES" title="Entered of cordial do on no hearted. Yet agreed whence and unable limit…" placeholderString="" allowsEditingTextAttributes="YES" id="f5t-6G-s13">
+                                                                        <textField verticalHuggingPriority="751" horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="749" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1z2-Wd-bPU" userLabel="Body Label">
+                                                                            <rect key="frame" x="-2" y="0.0" width="212" height="45"/>
+                                                                            <textFieldCell key="cell" lineBreakMode="charWrapping" allowsUndo="NO" sendsActionOnEndEditing="YES" title="Entered of cordial do on no hearted. Yet agreed whence and unable limit…" placeholderString="" allowsEditingTextAttributes="YES" id="f5t-6G-s13">
                                                                                 <font key="font" metaFont="cellTitle"/>
                                                                                 <color key="textColor" white="0.5" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
                                                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
@@ -357,12 +357,12 @@
                                                                 </stackView>
                                                             </subviews>
                                                             <constraints>
-                                                                <constraint firstItem="Y6i-es-ABJ" firstAttribute="top" secondItem="bde-Ei-vv5" secondAttribute="top" constant="8" id="5pu-Wf-nhG"/>
-                                                                <constraint firstItem="Y6i-es-ABJ" firstAttribute="leading" secondItem="bde-Ei-vv5" secondAttribute="leading" constant="24" id="BTW-kr-NIC"/>
+                                                                <constraint firstItem="Y6i-es-ABJ" firstAttribute="top" secondItem="bde-Ei-vv5" secondAttribute="top" constant="4" id="5pu-Wf-nhG"/>
+                                                                <constraint firstItem="Y6i-es-ABJ" firstAttribute="leading" secondItem="bde-Ei-vv5" secondAttribute="leading" constant="36" id="BTW-kr-NIC"/>
                                                                 <constraint firstItem="8v7-8o-Tsk" firstAttribute="centerY" secondItem="YP5-KE-GnO" secondAttribute="centerY" id="lce-PS-EYS"/>
-                                                                <constraint firstItem="YP5-KE-GnO" firstAttribute="leading" secondItem="bde-Ei-vv5" secondAttribute="leading" constant="7" id="s9T-qT-2jd"/>
-                                                                <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="Y6i-es-ABJ" secondAttribute="bottom" constant="8" id="tVE-Mi-trA"/>
-                                                                <constraint firstAttribute="trailing" secondItem="Y6i-es-ABJ" secondAttribute="trailing" constant="16" id="xMo-0i-fuZ"/>
+                                                                <constraint firstItem="YP5-KE-GnO" firstAttribute="leading" secondItem="bde-Ei-vv5" secondAttribute="leading" constant="18" id="s9T-qT-2jd"/>
+                                                                <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="Y6i-es-ABJ" secondAttribute="bottom" constant="4" id="tVE-Mi-trA"/>
+                                                                <constraint firstAttribute="trailing" secondItem="Y6i-es-ABJ" secondAttribute="trailing" constant="28" id="xMo-0i-fuZ"/>
                                                             </constraints>
                                                             <connections>
                                                                 <outlet property="bodyTextField" destination="1z2-Wd-bPU" id="sFg-Zg-Puc"/>
@@ -384,7 +384,8 @@
                                             </connections>
                                         </tableView>
                                     </subviews>
-                                    <color key="backgroundColor" red="1" green="0.0074358092779999996" blue="0.18312235169999999" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
+                                    <nil key="backgroundColor"/>
+                                    <edgeInsets key="contentInsets" left="0.0" right="0.0" top="12" bottom="0.0"/>
                                 </clipView>
                                 <edgeInsets key="contentInsets" left="0.0" right="0.0" top="0.0" bottom="0.0"/>
                                 <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="jZz-dv-fIm">
@@ -392,12 +393,12 @@
                                     <autoresizingMask key="autoresizingMask"/>
                                 </scroller>
                                 <scroller key="verticalScroller" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="OEr-We-MDq">
-                                    <rect key="frame" x="276" y="0.0" width="16" height="566"/>
+                                    <rect key="frame" x="256" y="0.0" width="16" height="566"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                 </scroller>
                             </scrollView>
                             <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="2I0-KH-uBu">
-                                <rect key="frame" x="10" y="323" width="272" height="23"/>
+                                <rect key="frame" x="10" y="323" width="252" height="23"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="No Notes" id="5l7-bS-Xdk">
                                     <font key="font" size="20" name="HelveticaNeue"/>
                                     <color key="textColor" white="0.0" alpha="0.20000000000000001" colorSpace="custom" customColorSpace="deviceWhite"/>
@@ -405,7 +406,7 @@
                                 </textFieldCell>
                             </textField>
                             <progressIndicator wantsLayer="YES" horizontalHuggingPriority="750" verticalHuggingPriority="750" maxValue="100" bezeled="NO" indeterminate="YES" controlSize="small" style="spinning" translatesAutoresizingMaskIntoConstraints="NO" id="5oO-Ju-l1S">
-                                <rect key="frame" x="138" y="292" width="16" height="16"/>
+                                <rect key="frame" x="128" y="292" width="16" height="16"/>
                             </progressIndicator>
                         </subviews>
                         <constraints>
@@ -435,6 +436,7 @@
                         <outlet property="addNoteButton" destination="LGw-AF-2MK" id="s6O-Qf-p2T"/>
                         <outlet property="arrayController" destination="QdT-mP-kT8" id="7HE-P5-XlT"/>
                         <outlet property="backgroundView" destination="Dfi-py-m83" id="OsW-dl-qhP"/>
+                        <outlet property="clipView" destination="zul-ko-TNO" id="WiT-34-HPY"/>
                         <outlet property="noteListMenu" destination="JPb-EX-UT9" id="1Ad-LU-3eM"/>
                         <outlet property="progressIndicator" destination="5oO-Ju-l1S" id="ZDk-V0-rXz"/>
                         <outlet property="searchField" destination="cvh-C8-b0b" id="R6h-sR-ND1"/>

--- a/Simplenote/Main.storyboard
+++ b/Simplenote/Main.storyboard
@@ -11,20 +11,20 @@
             <objects>
                 <viewController storyboardIdentifier="TagListViewController" id="DTE-cl-X3E" customClass="TagListViewController" sceneMemberID="viewController">
                     <view key="view" id="Muw-Yd-KYW">
-                        <rect key="frame" x="0.0" y="0.0" width="120" height="618"/>
+                        <rect key="frame" x="0.0" y="0.0" width="140" height="618"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <visualEffectView blendingMode="behindWindow" material="menu" state="active" translatesAutoresizingMaskIntoConstraints="NO" id="9tf-Lw-qRu">
-                                <rect key="frame" x="0.0" y="0.0" width="120" height="566"/>
+                                <rect key="frame" x="0.0" y="0.0" width="140" height="566"/>
                             </visualEffectView>
                             <scrollView borderType="none" horizontalLineScroll="29" horizontalPageScroll="10" verticalLineScroll="29" verticalPageScroll="10" hasHorizontalScroller="NO" hasVerticalScroller="NO" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2Hn-Sh-zaZ">
-                                <rect key="frame" x="0.0" y="0.0" width="120" height="618"/>
+                                <rect key="frame" x="0.0" y="0.0" width="140" height="618"/>
                                 <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="elT-nR-XZN" customClass="ClipView" customModule="Simplenote" customModuleProvider="target">
-                                    <rect key="frame" x="0.0" y="0.0" width="120" height="618"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="140" height="618"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
-                                        <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" tableStyle="fullWidth" columnSelection="YES" multipleSelection="NO" emptySelection="NO" autosaveColumns="NO" rowHeight="29" rowSizeStyle="automatic" viewBased="YES" id="1PS-xY-Vtk" customClass="SPTableView">
-                                            <rect key="frame" x="0.0" y="0.0" width="120" height="554"/>
+                                        <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnSelection="YES" multipleSelection="NO" emptySelection="NO" autosaveColumns="NO" rowHeight="29" rowSizeStyle="automatic" viewBased="YES" id="1PS-xY-Vtk" customClass="SPTableView">
+                                            <rect key="frame" x="0.0" y="0.0" width="140" height="554"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <color key="backgroundColor" red="1" green="0.0074358092779999996" blue="0.18312235169999999" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                             <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
@@ -42,7 +42,7 @@
                                                     <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                                     <prototypeCellViews>
                                                         <tableCellView identifier="SpacerTableViewCell" id="RyL-oL-AZL" userLabel="Spacer" customClass="SpacerTableViewCell" customModule="Simplenote" customModuleProvider="target">
-                                                            <rect key="frame" x="0.0" y="0.0" width="120" height="16"/>
+                                                            <rect key="frame" x="10" y="0.0" width="120" height="16"/>
                                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                             <subviews>
                                                                 <customView translatesAutoresizingMaskIntoConstraints="NO" id="xjr-Tk-HSi">
@@ -60,7 +60,7 @@
                                                             </constraints>
                                                         </tableCellView>
                                                         <tableCellView identifier="HeaderTableCellView" id="ftn-CT-UtG" userLabel="Header" customClass="HeaderTableCellView" customModule="Simplenote" customModuleProvider="target">
-                                                            <rect key="frame" x="0.0" y="16" width="120" height="27"/>
+                                                            <rect key="frame" x="10" y="16" width="120" height="27"/>
                                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                             <subviews>
                                                                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3Gk-Te-s8H">
@@ -86,7 +86,7 @@
                                                             </connections>
                                                         </tableCellView>
                                                         <tableCellView identifier="TagTableCellView" id="Nrb-k8-TzG" userLabel="Tag" customClass="TagTableCellView" customModule="Simplenote" customModuleProvider="target">
-                                                            <rect key="frame" x="0.0" y="43" width="120" height="29"/>
+                                                            <rect key="frame" x="10" y="43" width="120" height="29"/>
                                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                             <subviews>
                                                                 <stackView distribution="fill" orientation="horizontal" alignment="top" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="EiU-KW-NFn">
@@ -164,13 +164,13 @@
                                 </scroller>
                             </scrollView>
                             <visualEffectView blendingMode="behindWindow" material="menu" state="active" translatesAutoresizingMaskIntoConstraints="NO" id="W0l-PR-dA6">
-                                <rect key="frame" x="0.0" y="566" width="120" height="52"/>
+                                <rect key="frame" x="0.0" y="566" width="140" height="52"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="52" id="1Jn-yq-nkd"/>
                                 </constraints>
                             </visualEffectView>
                             <customView translatesAutoresizingMaskIntoConstraints="NO" id="LCF-v1-7tj" userLabel="Header Separator View" customClass="BackgroundView" customModule="Simplenote" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="566" width="120" height="52"/>
+                                <rect key="frame" x="0.0" y="566" width="140" height="52"/>
                             </customView>
                         </subviews>
                         <constraints>
@@ -209,20 +209,20 @@
             <objects>
                 <viewController storyboardIdentifier="NoteListViewController" id="JtV-0Z-Zh8" customClass="NoteListViewController" sceneMemberID="viewController">
                     <view key="view" id="PJl-uT-IxK">
-                        <rect key="frame" x="0.0" y="0.0" width="272" height="618"/>
+                        <rect key="frame" x="0.0" y="0.0" width="294" height="618"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <customView translatesAutoresizingMaskIntoConstraints="NO" id="Dfi-py-m83" customClass="BackgroundView" customModule="Simplenote" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="0.0" width="272" height="618"/>
+                                <rect key="frame" x="0.0" y="0.0" width="294" height="618"/>
                             </customView>
                             <customView translatesAutoresizingMaskIntoConstraints="NO" id="s2j-Xp-jGd" userLabel="Divider View" customClass="BackgroundView" customModule="Simplenote" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="566" width="272" height="52"/>
+                                <rect key="frame" x="0.0" y="566" width="294" height="52"/>
                             </customView>
                             <view translatesAutoresizingMaskIntoConstraints="NO" id="weN-h2-sJL" userLabel="SearchView">
-                                <rect key="frame" x="0.0" y="566" width="272" height="52"/>
+                                <rect key="frame" x="0.0" y="566" width="294" height="52"/>
                                 <subviews>
                                     <searchField wantsLayer="YES" verticalHuggingPriority="750" tag="1" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="cvh-C8-b0b" userLabel="SearchField">
-                                        <rect key="frame" x="12" y="11" width="208" height="30"/>
+                                        <rect key="frame" x="12" y="11" width="230" height="30"/>
                                         <searchFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" borderStyle="bezel" placeholderString="Search" usesSingleLineMode="YES" bezelStyle="round" id="Umi-3H-Bn4">
                                             <font key="font" metaFont="system"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -234,7 +234,7 @@
                                         </connections>
                                     </searchField>
                                     <button toolTip="Add Note" translatesAutoresizingMaskIntoConstraints="NO" id="LGw-AF-2MK" userLabel="NewNote">
-                                        <rect key="frame" x="236" y="16" width="20" height="20"/>
+                                        <rect key="frame" x="258" y="16" width="20" height="20"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="20" id="mDL-V4-Sng"/>
                                             <constraint firstAttribute="height" constant="20" id="oUz-t6-8il"/>
@@ -259,18 +259,18 @@
                                 </constraints>
                             </view>
                             <scrollView focusRingType="none" borderType="none" horizontalLineScroll="72" horizontalPageScroll="10" verticalLineScroll="72" verticalPageScroll="10" hasHorizontalScroller="NO" horizontalScrollElasticity="none" translatesAutoresizingMaskIntoConstraints="NO" id="JDR-c6-dqi">
-                                <rect key="frame" x="0.0" y="0.0" width="272" height="566"/>
+                                <rect key="frame" x="0.0" y="0.0" width="294" height="566"/>
                                 <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="zul-ko-TNO">
-                                    <rect key="frame" x="0.0" y="0.0" width="272" height="566"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="294" height="566"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
-                                        <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="firstColumnOnly" tableStyle="fullWidth" emptySelection="NO" autosaveColumns="NO" typeSelect="NO" rowHeight="72" rowSizeStyle="automatic" viewBased="YES" floatsGroupRows="NO" id="q9F-rT-PZ2" customClass="SPTableView">
-                                            <rect key="frame" x="0.0" y="0.0" width="272" height="554"/>
+                                        <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="firstColumnOnly" emptySelection="NO" autosaveColumns="NO" typeSelect="NO" rowHeight="72" rowSizeStyle="automatic" viewBased="YES" floatsGroupRows="NO" id="q9F-rT-PZ2" customClass="SPTableView">
+                                            <rect key="frame" x="0.0" y="0.0" width="294" height="554"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <color key="backgroundColor" red="1" green="1" blue="1" alpha="0.0" colorSpace="custom" customColorSpace="displayP3"/>
                                             <color key="gridColor" white="0.94999999999999996" alpha="1" colorSpace="deviceWhite"/>
                                             <tableColumns>
-                                                <tableColumn width="260" maxWidth="10000000" id="FbW-7t-Y9x">
+                                                <tableColumn width="262" maxWidth="10000000" id="FbW-7t-Y9x">
                                                     <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left">
                                                         <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" white="0.33333298560000002" alpha="1" colorSpace="calibratedWhite"/>
@@ -283,7 +283,7 @@
                                                     <tableColumnResizingMask key="resizingMask" resizeWithTable="YES"/>
                                                     <prototypeCellViews>
                                                         <tableCellView identifier="NoteTableCellView" translatesAutoresizingMaskIntoConstraints="NO" id="bde-Ei-vv5" customClass="NoteTableCellView" customModule="Simplenote" customModuleProvider="target">
-                                                            <rect key="frame" x="0.0" y="0.0" width="272" height="72"/>
+                                                            <rect key="frame" x="10" y="0.0" width="274" height="72"/>
                                                             <subviews>
                                                                 <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="YP5-KE-GnO" userLabel="Pin Image View">
                                                                     <rect key="frame" x="18" y="50" width="12" height="12"/>
@@ -294,13 +294,13 @@
                                                                     <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="icon_pin" id="wSK-Lh-kY8"/>
                                                                 </imageView>
                                                                 <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="2" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Y6i-es-ABJ">
-                                                                    <rect key="frame" x="36" y="15" width="208" height="49"/>
+                                                                    <rect key="frame" x="36" y="15" width="210" height="49"/>
                                                                     <subviews>
                                                                         <stackView distribution="fill" orientation="horizontal" alignment="centerY" spacing="0.0" horizontalStackHuggingPriority="251.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="8v7-8o-Tsk">
-                                                                            <rect key="frame" x="0.0" y="32" width="208" height="17"/>
+                                                                            <rect key="frame" x="0.0" y="32" width="210" height="17"/>
                                                                             <subviews>
                                                                                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UdO-10-DWt" userLabel="Title Label">
-                                                                                    <rect key="frame" x="-2" y="0.0" width="200" height="17"/>
+                                                                                    <rect key="frame" x="-2" y="0.0" width="202" height="17"/>
                                                                                     <textFieldCell key="cell" allowsUndo="NO" sendsActionOnEndEditing="YES" title="Note Title!" placeholderString="" allowsEditingTextAttributes="YES" id="yy1-Iz-EEZ">
                                                                                         <font key="font" metaFont="systemMedium" size="14"/>
                                                                                         <color key="textColor" white="0.5" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
@@ -311,7 +311,7 @@
                                                                                     </attributedString>
                                                                                 </textField>
                                                                                 <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="DYD-qJ-8kp" userLabel="Shared Image View">
-                                                                                    <rect key="frame" x="196" y="3" width="12" height="12"/>
+                                                                                    <rect key="frame" x="198" y="3" width="12" height="12"/>
                                                                                     <constraints>
                                                                                         <constraint firstAttribute="height" constant="12" id="h39-F8-6Cf"/>
                                                                                         <constraint firstAttribute="width" constant="12" id="oAn-YZ-vIs"/>
@@ -329,7 +329,7 @@
                                                                             </customSpacing>
                                                                         </stackView>
                                                                         <textField verticalHuggingPriority="751" horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="749" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1z2-Wd-bPU" userLabel="Body Label">
-                                                                            <rect key="frame" x="-2" y="0.0" width="212" height="30"/>
+                                                                            <rect key="frame" x="-2" y="0.0" width="214" height="30"/>
                                                                             <textFieldCell key="cell" lineBreakMode="charWrapping" allowsUndo="NO" sendsActionOnEndEditing="YES" title="Entered of cordial do on no hearted. Yet agreed whence and unable" placeholderString="" allowsEditingTextAttributes="YES" id="f5t-6G-s13">
                                                                                 <font key="font" metaFont="cellTitle"/>
                                                                                 <color key="textColor" white="0.5" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
@@ -391,12 +391,12 @@
                                     <autoresizingMask key="autoresizingMask"/>
                                 </scroller>
                                 <scroller key="verticalScroller" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="OEr-We-MDq">
-                                    <rect key="frame" x="256" y="0.0" width="16" height="566"/>
+                                    <rect key="frame" x="278" y="0.0" width="16" height="566"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                 </scroller>
                             </scrollView>
                             <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="2I0-KH-uBu">
-                                <rect key="frame" x="10" y="323" width="252" height="23"/>
+                                <rect key="frame" x="10" y="323" width="274" height="23"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="No Notes" id="5l7-bS-Xdk">
                                     <font key="font" size="20" name="HelveticaNeue"/>
                                     <color key="textColor" white="0.0" alpha="0.20000000000000001" colorSpace="custom" customColorSpace="deviceWhite"/>
@@ -404,7 +404,7 @@
                                 </textFieldCell>
                             </textField>
                             <progressIndicator wantsLayer="YES" horizontalHuggingPriority="750" verticalHuggingPriority="750" maxValue="100" bezeled="NO" indeterminate="YES" controlSize="small" style="spinning" translatesAutoresizingMaskIntoConstraints="NO" id="5oO-Ju-l1S">
-                                <rect key="frame" x="128" y="292" width="16" height="16"/>
+                                <rect key="frame" x="139" y="292" width="16" height="16"/>
                             </progressIndicator>
                         </subviews>
                         <constraints>

--- a/Simplenote/Main.storyboard
+++ b/Simplenote/Main.storyboard
@@ -258,7 +258,7 @@
                                     <constraint firstItem="cvh-C8-b0b" firstAttribute="leading" secondItem="weN-h2-sJL" secondAttribute="leading" constant="12" id="uDy-dn-4qz"/>
                                 </constraints>
                             </view>
-                            <scrollView focusRingType="none" borderType="none" horizontalLineScroll="80" horizontalPageScroll="10" verticalLineScroll="80" verticalPageScroll="10" hasHorizontalScroller="NO" horizontalScrollElasticity="none" translatesAutoresizingMaskIntoConstraints="NO" id="JDR-c6-dqi">
+                            <scrollView focusRingType="none" borderType="none" horizontalLineScroll="72" horizontalPageScroll="10" verticalLineScroll="72" verticalPageScroll="10" hasHorizontalScroller="NO" horizontalScrollElasticity="none" translatesAutoresizingMaskIntoConstraints="NO" id="JDR-c6-dqi">
                                 <rect key="frame" x="0.0" y="0.0" width="272" height="566"/>
                                 <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="zul-ko-TNO">
                                     <rect key="frame" x="0.0" y="0.0" width="272" height="566"/>
@@ -267,7 +267,6 @@
                                         <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="firstColumnOnly" tableStyle="fullWidth" emptySelection="NO" autosaveColumns="NO" typeSelect="NO" rowHeight="72" rowSizeStyle="automatic" viewBased="YES" floatsGroupRows="NO" id="q9F-rT-PZ2" customClass="SPTableView">
                                             <rect key="frame" x="0.0" y="0.0" width="272" height="554"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                            <size key="intercellSpacing" width="0.0" height="8"/>
                                             <color key="backgroundColor" red="1" green="1" blue="1" alpha="0.0" colorSpace="custom" customColorSpace="displayP3"/>
                                             <color key="gridColor" white="0.94999999999999996" alpha="1" colorSpace="deviceWhite"/>
                                             <tableColumns>
@@ -283,12 +282,11 @@
                                                     </textFieldCell>
                                                     <tableColumnResizingMask key="resizingMask" resizeWithTable="YES"/>
                                                     <prototypeCellViews>
-                                                        <tableCellView identifier="NoteTableCellView" id="bde-Ei-vv5" customClass="NoteTableCellView" customModule="Simplenote" customModuleProvider="target">
-                                                            <rect key="frame" x="0.0" y="4" width="272" height="72"/>
-                                                            <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMaxX="YES" flexibleMinY="YES" heightSizable="YES" flexibleMaxY="YES"/>
+                                                        <tableCellView identifier="NoteTableCellView" translatesAutoresizingMaskIntoConstraints="NO" id="bde-Ei-vv5" customClass="NoteTableCellView" customModule="Simplenote" customModuleProvider="target">
+                                                            <rect key="frame" x="0.0" y="0.0" width="272" height="72"/>
                                                             <subviews>
                                                                 <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="YP5-KE-GnO" userLabel="Pin Image View">
-                                                                    <rect key="frame" x="18" y="54" width="12" height="12"/>
+                                                                    <rect key="frame" x="18" y="50" width="12" height="12"/>
                                                                     <constraints>
                                                                         <constraint firstAttribute="height" constant="12" id="3hZ-oW-r14"/>
                                                                         <constraint firstAttribute="width" constant="12" id="GP8-O5-fwy"/>
@@ -296,10 +294,10 @@
                                                                     <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="icon_pin" id="wSK-Lh-kY8"/>
                                                                 </imageView>
                                                                 <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="2" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Y6i-es-ABJ">
-                                                                    <rect key="frame" x="36" y="4" width="208" height="64"/>
+                                                                    <rect key="frame" x="36" y="15" width="208" height="49"/>
                                                                     <subviews>
                                                                         <stackView distribution="fill" orientation="horizontal" alignment="centerY" spacing="0.0" horizontalStackHuggingPriority="251.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="8v7-8o-Tsk">
-                                                                            <rect key="frame" x="0.0" y="47" width="208" height="17"/>
+                                                                            <rect key="frame" x="0.0" y="32" width="208" height="17"/>
                                                                             <subviews>
                                                                                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UdO-10-DWt" userLabel="Title Label">
                                                                                     <rect key="frame" x="-2" y="0.0" width="200" height="17"/>
@@ -331,8 +329,8 @@
                                                                             </customSpacing>
                                                                         </stackView>
                                                                         <textField verticalHuggingPriority="751" horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="749" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1z2-Wd-bPU" userLabel="Body Label">
-                                                                            <rect key="frame" x="-2" y="0.0" width="212" height="45"/>
-                                                                            <textFieldCell key="cell" lineBreakMode="charWrapping" allowsUndo="NO" sendsActionOnEndEditing="YES" title="Entered of cordial do on no hearted. Yet agreed whence and unable limit…" placeholderString="" allowsEditingTextAttributes="YES" id="f5t-6G-s13">
+                                                                            <rect key="frame" x="-2" y="0.0" width="212" height="30"/>
+                                                                            <textFieldCell key="cell" lineBreakMode="charWrapping" allowsUndo="NO" sendsActionOnEndEditing="YES" title="Entered of cordial do on no hearted. Yet agreed whence and unable" placeholderString="" allowsEditingTextAttributes="YES" id="f5t-6G-s13">
                                                                                 <font key="font" metaFont="cellTitle"/>
                                                                                 <color key="textColor" white="0.5" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
                                                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
@@ -357,11 +355,11 @@
                                                                 </stackView>
                                                             </subviews>
                                                             <constraints>
-                                                                <constraint firstItem="Y6i-es-ABJ" firstAttribute="top" secondItem="bde-Ei-vv5" secondAttribute="top" constant="4" id="5pu-Wf-nhG"/>
+                                                                <constraint firstItem="Y6i-es-ABJ" firstAttribute="top" secondItem="bde-Ei-vv5" secondAttribute="top" constant="8" id="5pu-Wf-nhG"/>
                                                                 <constraint firstItem="Y6i-es-ABJ" firstAttribute="leading" secondItem="bde-Ei-vv5" secondAttribute="leading" constant="36" id="BTW-kr-NIC"/>
                                                                 <constraint firstItem="8v7-8o-Tsk" firstAttribute="centerY" secondItem="YP5-KE-GnO" secondAttribute="centerY" id="lce-PS-EYS"/>
                                                                 <constraint firstItem="YP5-KE-GnO" firstAttribute="leading" secondItem="bde-Ei-vv5" secondAttribute="leading" constant="18" id="s9T-qT-2jd"/>
-                                                                <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="Y6i-es-ABJ" secondAttribute="bottom" constant="4" id="tVE-Mi-trA"/>
+                                                                <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="Y6i-es-ABJ" secondAttribute="bottom" constant="8" id="tVE-Mi-trA"/>
                                                                 <constraint firstAttribute="trailing" secondItem="Y6i-es-ABJ" secondAttribute="trailing" constant="28" id="xMo-0i-fuZ"/>
                                                             </constraints>
                                                             <connections>

--- a/Simplenote/MetricsViewController.swift
+++ b/Simplenote/MetricsViewController.swift
@@ -119,7 +119,7 @@ private extension MetricsViewController {
     }
 
     func setupTableView() {
-        guard #available(OSX 11.0, *) else {
+        guard #available(macOS 11.0, *) else {
             return
         }
 

--- a/Simplenote/MetricsViewController.swift
+++ b/Simplenote/MetricsViewController.swift
@@ -119,11 +119,9 @@ private extension MetricsViewController {
     }
 
     func setupTableView() {
-        guard #available(macOS 11.0, *) else {
-            return
+        if #available(macOS 11, *) {
+            tableView.style = .fullWidth
         }
-
-        tableView.style = .fullWidth
     }
 
     var mustSetupResultsController: Bool {

--- a/Simplenote/MetricsViewController.swift
+++ b/Simplenote/MetricsViewController.swift
@@ -119,9 +119,7 @@ private extension MetricsViewController {
     }
 
     func setupTableView() {
-        if #available(macOS 11, *) {
-            tableView.style = .fullWidth
-        }
+        tableView.ensureStyleIsFullWidth()
     }
 
     var mustSetupResultsController: Bool {

--- a/Simplenote/MetricsViewController.swift
+++ b/Simplenote/MetricsViewController.swift
@@ -264,7 +264,9 @@ extension MetricsViewController: NSTableViewDataSource {
 extension MetricsViewController: NSTableViewDelegate {
 
     public func tableView(_ tableView: NSTableView, rowViewForRow row: Int) -> NSTableRowView? {
-        return TableRowView()
+        let rowView = TableRowView()
+        rowView.style = .fullWidth
+        return rowView
     }
 
     public func tableView(_ tableView: NSTableView, viewFor tableColumn: NSTableColumn?, row: Int) -> NSView? {

--- a/Simplenote/MetricsViewController.swift
+++ b/Simplenote/MetricsViewController.swift
@@ -85,6 +85,7 @@ class MetricsViewController: NSViewController {
         super.viewDidLoad()
         setupEntityObserver()
         setupResultsControllerIfNeeded()
+        setupTableView()
         startListeningToNotifications()
         refreshInterface()
     }
@@ -115,6 +116,14 @@ private extension MetricsViewController {
         }
 
         try? resultsController.performFetch()
+    }
+
+    func setupTableView() {
+        guard #available(OSX 11.0, *) else {
+            return
+        }
+
+        tableView.style = .fullWidth
     }
 
     var mustSetupResultsController: Bool {

--- a/Simplenote/NSTableView+Simplenote.swift
+++ b/Simplenote/NSTableView+Simplenote.swift
@@ -49,4 +49,18 @@ extension NSTableView {
         scrollRowToVisible(.zero)
         reloadData()
     }
+
+    /// Whenever we're compiling Simplenote in macOS +11 **AND** we're running the binary in macOS +11, we'll make sure the
+    /// receiver's style is set to Full Width.
+    ///
+    func ensureStyleIsFullWidth() {
+// BigSur compile-time guard
+#if canImport(WidgetKit)
+        guard #available(macOS 11, *) else {
+            return
+        }
+
+        style = .fullWidth
+#endif
+    }
 }

--- a/Simplenote/NoteListViewController+Swift.swift
+++ b/Simplenote/NoteListViewController+Swift.swift
@@ -161,7 +161,9 @@ private extension NoteListViewController {
 extension NoteListViewController: NSTableViewDelegate {
 
     public func tableView(_ tableView: NSTableView, rowViewForRow row: Int) -> NSTableRowView? {
-        TableRowView(style: .list)
+        let rowView = TableRowView()
+        rowView.style = .list
+        return rowView
     }
 }
 

--- a/Simplenote/NoteListViewController+Swift.swift
+++ b/Simplenote/NoteListViewController+Swift.swift
@@ -161,10 +161,7 @@ private extension NoteListViewController {
 extension NoteListViewController: NSTableViewDelegate {
 
     public func tableView(_ tableView: NSTableView, rowViewForRow row: Int) -> NSTableRowView? {
-        let rowView = TableRowView()
-        rowView.selectedBackgroundColor = .simplenoteSecondarySelectedBackgroundColor
-        rowView.selectionInsets = .list
-        return rowView
+        TableRowView(style: .list)
     }
 }
 

--- a/Simplenote/NoteListViewController+Swift.swift
+++ b/Simplenote/NoteListViewController+Swift.swift
@@ -38,6 +38,18 @@ extension NoteListViewController {
         topDividerView.drawsBottomBorder = true
     }
 
+    /// Refreshes the Top Content Insets: We'll match the Notes List Insets
+    ///
+    @objc
+    func refreshScrollInsets() {
+        let topContentInset = Settings.defaultTopInset
+        guard clipView.contentInsets.top != topContentInset else {
+            return
+        }
+
+        clipView.contentInsets.top = topContentInset
+    }
+
     /// Ensures only the actions that are valid can be performed
     ///
     @objc
@@ -140,6 +152,19 @@ private extension NoteListViewController {
 
     var isSelectionNotEmpty: Bool {
         selectedNotes().isEmpty == false
+    }
+}
+
+
+// MARK: - NSTableViewDelegate Helpers
+//
+extension NoteListViewController: NSTableViewDelegate {
+
+    public func tableView(_ tableView: NSTableView, rowViewForRow row: Int) -> NSTableRowView? {
+        let rowView = TableRowView()
+        rowView.selectedBackgroundColor = .simplenoteSecondarySelectedBackgroundColor
+        rowView.selectionInsets = .list
+        return rowView
     }
 }
 
@@ -347,4 +372,11 @@ extension NoteListViewController {
 
         arrayController.setSelectionIndex(previouslySelectedIndex)
     }
+}
+
+
+// MARK: - Settings!
+//
+private enum Settings {
+    static let defaultTopInset = CGFloat(12)
 }

--- a/Simplenote/NoteListViewController+Swift.swift
+++ b/Simplenote/NoteListViewController+Swift.swift
@@ -13,6 +13,12 @@ extension NoteListViewController {
         tableView.rowHeight = NoteTableCellView.rowHeight
         tableView.selectionHighlightStyle = .regular
         tableView.backgroundColor = .clear
+
+        guard #available(macOS 11.0, *) else {
+            return
+        }
+
+        tableView.style = .fullWidth
     }
 
     /// Setup: Progress Indicator

--- a/Simplenote/NoteListViewController+Swift.swift
+++ b/Simplenote/NoteListViewController+Swift.swift
@@ -14,11 +14,9 @@ extension NoteListViewController {
         tableView.selectionHighlightStyle = .regular
         tableView.backgroundColor = .clear
 
-        guard #available(macOS 11.0, *) else {
-            return
+        if #available(macOS 11, *) {
+            tableView.style = .fullWidth
         }
-
-        tableView.style = .fullWidth
     }
 
     /// Setup: Progress Indicator

--- a/Simplenote/NoteListViewController+Swift.swift
+++ b/Simplenote/NoteListViewController+Swift.swift
@@ -14,9 +14,7 @@ extension NoteListViewController {
         tableView.selectionHighlightStyle = .regular
         tableView.backgroundColor = .clear
 
-        if #available(macOS 11, *) {
-            tableView.style = .fullWidth
-        }
+        tableView.ensureStyleIsFullWidth()
     }
 
     /// Setup: Progress Indicator

--- a/Simplenote/NoteListViewController.h
+++ b/Simplenote/NoteListViewController.h
@@ -16,13 +16,14 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface NoteListViewController : NSViewController <NSTableViewDelegate, NSTableViewDataSource, NSTextFieldDelegate, SimperiumDelegate, NSMenuDelegate>
+@interface NoteListViewController : NSViewController <NSTableViewDataSource, NSTextFieldDelegate, SimperiumDelegate, NSMenuDelegate>
 
 @property (nonatomic, strong, readonly) IBOutlet NSArrayController      *arrayController;
 @property (nonatomic, strong, readonly) IBOutlet BackgroundView         *backgroundView;
 @property (nonatomic, strong, readonly) IBOutlet BackgroundView         *topDividerView;
 @property (nonatomic, strong, readonly) IBOutlet NSTextField            *statusField;
 @property (nonatomic, strong, readonly) IBOutlet NSProgressIndicator    *progressIndicator;
+@property (nonatomic, strong, readonly) IBOutlet NSClipView             *clipView;
 @property (nonatomic, strong, readonly) IBOutlet SPTableView            *tableView;
 @property (nonatomic, strong, readonly) IBOutlet NSView                 *searchView;
 @property (nonatomic, strong, readonly) IBOutlet NSSearchField          *searchField;

--- a/Simplenote/NoteListViewController.m
+++ b/Simplenote/NoteListViewController.m
@@ -19,12 +19,13 @@
 @import Simperium_OSX;
 
 
-@interface NoteListViewController ()
+@interface NoteListViewController () <NSTableViewDelegate>
 @property (nonatomic, strong) IBOutlet NSArrayController    *arrayController;
 @property (nonatomic, strong) IBOutlet BackgroundView       *backgroundView;
 @property (nonatomic, strong) IBOutlet BackgroundView       *topDividerView;
 @property (nonatomic, strong) IBOutlet NSTextField          *statusField;
 @property (nonatomic, strong) IBOutlet NSProgressIndicator  *progressIndicator;
+@property (nonatomic, strong) IBOutlet NSClipView           *clipView;
 @property (nonatomic, strong) IBOutlet SPTableView          *tableView;
 @property (nonatomic, strong) IBOutlet NSView               *searchView;
 @property (nonatomic, strong) IBOutlet NSSearchField        *searchField;
@@ -90,6 +91,12 @@
 {
     [super viewWillAppear];
     [self applyStyle];
+}
+
+- (void)viewWillLayout
+{
+    [super viewWillLayout];
+    [self refreshScrollInsets];
 }
 
 - (void)loadNotes
@@ -225,13 +232,6 @@
     NSInteger row = [self rowForNoteKey:key];
     [self selectRow:row];
     [self scrollToRow:row];
-}
-
-- (NSTableRowView *)tableView:(NSTableView *)tableView rowViewForRow:(NSInteger)row
-{
-    TableRowView *rowView = [TableRowView new];
-    rowView.selectedBackgroundColor = [NSColor simplenoteSecondarySelectedBackgroundColor];
-    return rowView;
 }
 
 - (NSView *)tableView:(NSTableView *)tableView viewForTableColumn:(NSTableColumn *)tableColumn row:(NSInteger)row

--- a/Simplenote/NoteTableCellView.swift
+++ b/Simplenote/NoteTableCellView.swift
@@ -142,7 +142,7 @@ private enum Metrics {
     static let lineHeightForBody = Fonts.body.boundingRectForFont.height.rounded(.up)
     static let maximumNumberOfTitleLines = 1
     static let maximumNumberOfBodyLines = 2
-    static let outerVerticalStackViewInsets = NSEdgeInsets(top: 8, left: 24, bottom: 8, right: 16)
+    static let outerVerticalStackViewInsets = NSEdgeInsets(top: 11, left: 24, bottom: 11, right: 16)
     static let outerVerticalStackViewSpacing = CGFloat(2)
 }
 

--- a/Simplenote/TableRowView.swift
+++ b/Simplenote/TableRowView.swift
@@ -10,6 +10,23 @@ class TableRowView : NSTableRowView {
     ///
     var selectedBackgroundColor: NSColor?
 
+    /// Selection's Corner Radius
+    ///
+    var selectionCornerRadius: CGFloat = Settings.defaultCornerRadius {
+        didSet {
+            needsDisplay = true
+        }
+    }
+
+    /// Selection's Inner Selection Insets
+    ///
+    var selectionInsets: TableRowInset = .sidebar {
+        didSet {
+            needsDisplay = true
+        }
+    }
+
+
 
     // MARK: - Overridden
 
@@ -18,7 +35,32 @@ class TableRowView : NSTableRowView {
             return
         }
 
+        let insets = selectionInsets.vector
+        let targetRect = bounds.insetBy(dx: insets.dx, dy: insets.dy)
         backgroundColor.setFill()
-        NSBezierPath(rect: bounds).fill()
+        NSBezierPath(roundedRect: targetRect, xRadius: selectionCornerRadius, yRadius: selectionCornerRadius).fill()
+    }
+}
+
+
+
+private enum Settings {
+    static let defaultCornerRadius = CGFloat(6)
+}
+
+
+enum TableRowInset {
+    case sidebar
+    case list
+}
+
+extension TableRowInset {
+    var vector: CGVector {
+        switch self {
+        case .sidebar:
+            return CGVector(dx: 14, dy: .zero)
+        case .list:
+            return CGVector(dx: 12, dy: .zero)
+        }
     }
 }

--- a/Simplenote/TableRowView.swift
+++ b/Simplenote/TableRowView.swift
@@ -8,21 +8,10 @@ class TableRowView : NSTableRowView {
 
     /// Selection's Inner Selection Insets
     ///
-    let style: TableRowStyle
-
-    /// Designated Initialzer
-    ///
-    init(style: TableRowStyle) {
-        self.style = style
-        super.init(frame: .zero)
-    }
-
-    private override init(frame frameRect: NSRect) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+    var style: TableRowStyle = .fullWidth {
+        didSet {
+            needsDisplay = true
+        }
     }
 
 

--- a/Simplenote/TagListViewController+Swift.swift
+++ b/Simplenote/TagListViewController+Swift.swift
@@ -5,6 +5,19 @@ import Foundation
 //
 extension TagListViewController {
 
+    /// Setup: TableView
+    ///
+    @objc
+    func setupTableView() {
+        guard #available(macOS 11.0, *) else {
+            return
+        }
+
+        tableView.style = .fullWidth
+    }
+
+    /// Setup: Top Header
+    ///
     @objc
     func setupHeaderSeparator() {
         headerSeparatorView.drawsBottomBorder = true

--- a/Simplenote/TagListViewController+Swift.swift
+++ b/Simplenote/TagListViewController+Swift.swift
@@ -9,9 +9,7 @@ extension TagListViewController {
     ///
     @objc
     func setupTableView() {
-        if #available(macOS 11, *) {
-            tableView.style = .fullWidth
-        }
+        tableView.ensureStyleIsFullWidth()
     }
 
     /// Setup: Top Header

--- a/Simplenote/TagListViewController+Swift.swift
+++ b/Simplenote/TagListViewController+Swift.swift
@@ -118,7 +118,9 @@ extension TagListViewController: NSTableViewDataSource, SPTableViewDelegate {
     }
 
     public func tableView(_ tableView: NSTableView, rowViewForRow row: Int) -> NSTableRowView? {
-        TableRowView(style: .sidebar)
+        let rowView = TableRowView()
+        rowView.style = .sidebar
+        return rowView
     }
 
     public func tableView(_ tableView: NSTableView, shouldSelectRow row: Int) -> Bool {

--- a/Simplenote/TagListViewController+Swift.swift
+++ b/Simplenote/TagListViewController+Swift.swift
@@ -9,11 +9,9 @@ extension TagListViewController {
     ///
     @objc
     func setupTableView() {
-        guard #available(macOS 11.0, *) else {
-            return
+        if #available(macOS 11, *) {
+            tableView.style = .fullWidth
         }
-
-        tableView.style = .fullWidth
     }
 
     /// Setup: Top Header

--- a/Simplenote/TagListViewController+Swift.swift
+++ b/Simplenote/TagListViewController+Swift.swift
@@ -15,7 +15,7 @@ extension TagListViewController {
     ///
     @objc
     func refreshExtendedContentInsets() {
-        let topContentInset = Settings.searchBarHeight
+        let topContentInset = Settings.defaultTopInset
         guard clipView.contentInsets.top != topContentInset else {
             return
         }
@@ -229,7 +229,7 @@ extension TagListViewController: SPTextFieldDelegate {
 // MARK: - Settings!
 //
 private enum Settings {
+    static let defaultTopInset = CGFloat(64)
     static let maximumAlphaGradientOffset = CGFloat(30)
-    static let searchBarHeight = CGFloat(52)
     static let titlebarHeight = CGFloat(22)
 }

--- a/Simplenote/TagListViewController+Swift.swift
+++ b/Simplenote/TagListViewController+Swift.swift
@@ -118,9 +118,7 @@ extension TagListViewController: NSTableViewDataSource, SPTableViewDelegate {
     }
 
     public func tableView(_ tableView: NSTableView, rowViewForRow row: Int) -> NSTableRowView? {
-        let rowView = TableRowView()
-        rowView.selectedBackgroundColor = .simplenoteSelectedBackgroundColor
-        return rowView
+        TableRowView(style: .sidebar)
     }
 
     public func tableView(_ tableView: NSTableView, shouldSelectRow row: Int) -> Bool {

--- a/Simplenote/TagListViewController.m
+++ b/Simplenote/TagListViewController.m
@@ -63,6 +63,7 @@ CGFloat const TagListEstimatedRowHeight                     = 30;
     [self.tableView registerForDraggedTypes:[NSArray arrayWithObject:@"Tag"]];
     [self.tableView setDraggingSourceOperationMask:NSDragOperationMove forLocal:YES];
 
+    [self setupTableView];
     [self setupHeaderSeparator];
 
     [self startListeningToSettingsNotifications];


### PR DESCRIPTION
### Fix
In this PR we're enhancing **TableRowView** so that it renders an inset squared corner highlight, when running in Big Sur.

@eshurakov May I trouble you yet again?

**Ideally** it'd be neat to verify this in Big Sur / Catalina (we'd need to set you up with Parallels). But if time is a constraint (at least this week), verifying regressions in Catalina would be super neat.

cc @SylvesterWilmott 

Thanks in advance!!
Ref. #718

---

### Test: Tags List
1. Log into the app

- [ ] Verify the first row's vertical alignment (Tags List) matches the first row in the Notes List
- [ ] Verify the selected Tag is highlighted with a (full width) background color
- [ ] Verify that scrolling over the Tags List causes the top separator to fade in

### Test: Notes List
1. Log into the app
2. Click over any row in your Notes List

- [ ] Verify the selected Note is highlighted with a (full width) background color

### Test: Metrics
1. Log into the app
2. Select any Note
3. Click over the top right `( i )` icon

- [ ] Verify the Note Metrics look great

### Test: Interilnks
1. Log into the app
2. Type `[keyword` (with `keyword` being a word present in any of your note's titles)

- [ ] Verify the Interlinking UI looks great!

### Release
`RELEASE-NOTES.txt` was updated in b09eaee with:

> Adopting BigSur Inset Style

### Screenshots:

Main UI: Catalina|Main UI: Big Sur
-|-
<img width="300" alt="Big Sur Main" src="https://user-images.githubusercontent.com/1195260/100018437-3c602400-2dbb-11eb-8edb-69bfe3a8385a.png">|<img width="300" alt="Catalina Main" src="https://user-images.githubusercontent.com/1195260/100018444-3f5b1480-2dbb-11eb-998e-334e39b88c99.png">


Metrics UI: Catalina|Metrics UI: Big Sur
-|-
<img width="300" alt="Catalina Metrics" src="https://user-images.githubusercontent.com/1195260/100018554-64e81e00-2dbb-11eb-97ab-134aa11d1322.png">|<img width="300" alt="Big Sur Metrics" src="https://user-images.githubusercontent.com/1195260/100018578-6d405900-2dbb-11eb-8ba3-e54453a28b9d.png">

Interlinks UI: Catalina|Interlinks UI: Big Sur
-|-
<img width="300" alt="Catalina Interlinks" src="https://user-images.githubusercontent.com/1195260/100018626-8517dd00-2dbb-11eb-8b87-87ca11bf4e4c.png">|<img width="300" alt="Big Sur Interlinks" src="https://user-images.githubusercontent.com/1195260/100018630-86e1a080-2dbb-11eb-9f41-a22a69f5b9eb.png">
