### PR TITLE
Relocating Search Bar

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 -----
 - Removed Main Window's Titlebar #719
 - Adopting BigSur Inset Style #721
+- Relocated Search Bar #722
 
 2.4
 ---

--- a/Simplenote/Main.storyboard
+++ b/Simplenote/Main.storyboard
@@ -256,6 +256,7 @@
                                     <constraint firstAttribute="bottom" secondItem="cvh-C8-b0b" secondAttribute="bottom" constant="11" id="Gz4-wE-pXe"/>
                                     <constraint firstAttribute="height" constant="52" id="Reo-KD-mIh"/>
                                     <constraint firstItem="cvh-C8-b0b" firstAttribute="leading" secondItem="weN-h2-sJL" secondAttribute="leading" constant="12" id="uDy-dn-4qz"/>
+                                    <constraint firstItem="LGw-AF-2MK" firstAttribute="centerY" secondItem="weN-h2-sJL" secondAttribute="centerY" id="hPz-Ca-aJu"/>
                                 </constraints>
                             </view>
                             <scrollView focusRingType="none" borderType="none" horizontalLineScroll="72" horizontalPageScroll="10" verticalLineScroll="72" verticalPageScroll="10" hasHorizontalScroller="NO" horizontalScrollElasticity="none" translatesAutoresizingMaskIntoConstraints="NO" id="JDR-c6-dqi">
@@ -572,8 +573,8 @@
                                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                 </searchFieldCell>
                                                 <connections>
-                                                    <action selector="filterNotes:" target="JtV-0Z-Zh8" id="aDo-FQ-3qt"/>
-                                                    <outlet property="delegate" destination="JtV-0Z-Zh8" id="YnA-Oi-izd"/>
+                                                    <action selector="performSearch:" target="owM-kh-Bm6" id="Dxx-rb-etd"/>
+                                                    <outlet property="delegate" destination="owM-kh-Bm6" id="PeJ-VQ-DId"/>
                                                 </connections>
                                             </searchField>
                                         </subviews>
@@ -748,7 +749,7 @@
                         <outlet property="moreActionsMenu" destination="O2x-0v-azu" id="jSV-Gb-XpN"/>
                         <outlet property="noteEditor" destination="84J-wh-qoX" id="MHx-LW-NED"/>
                         <outlet property="scrollView" destination="3M9-OX-Hpx" id="fps-1H-haD"/>
-                        <outlet property="searchField" destination="YLv-zp-fRS" id="xGX-p6-V8f"/>
+                        <outlet property="searchField" destination="YLv-zp-fRS" id="AFT-Zt-Kry"/>
                         <outlet property="statusImageView" destination="Dj2-Ut-m6l" id="vqt-cc-z7a"/>
                         <outlet property="statusTextField" destination="VFr-Z3-HgO" id="UWY-3k-pwd"/>
                         <outlet property="tagsField" destination="U3o-VN-U2S" id="qmL-AY-16b"/>

--- a/Simplenote/Main.storyboard
+++ b/Simplenote/Main.storyboard
@@ -235,10 +235,21 @@
                                             <action selector="newNoteWasPressed:" target="JtV-0Z-Zh8" id="Zao-qM-kLO"/>
                                         </connections>
                                     </button>
+                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="hhw-aN-z6h">
+                                        <rect key="frame" x="14" y="17" width="230" height="19"/>
+                                        <textFieldCell key="cell" lineBreakMode="clipping" title="Title" id="8eL-Pk-hE4">
+                                            <font key="font" metaFont="systemBold" size="16"/>
+                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                        </textFieldCell>
+                                    </textField>
                                 </subviews>
                                 <constraints>
                                     <constraint firstAttribute="trailing" secondItem="LGw-AF-2MK" secondAttribute="trailing" constant="16" id="35i-gS-rGO"/>
+                                    <constraint firstItem="hhw-aN-z6h" firstAttribute="centerY" secondItem="weN-h2-sJL" secondAttribute="centerY" id="5vg-8O-5ju"/>
                                     <constraint firstAttribute="height" constant="52" id="Reo-KD-mIh"/>
+                                    <constraint firstItem="LGw-AF-2MK" firstAttribute="leading" secondItem="hhw-aN-z6h" secondAttribute="trailing" constant="16" id="XIf-2n-ctF"/>
+                                    <constraint firstItem="hhw-aN-z6h" firstAttribute="leading" secondItem="weN-h2-sJL" secondAttribute="leading" constant="16" id="b69-Qt-5qs"/>
                                     <constraint firstItem="LGw-AF-2MK" firstAttribute="centerY" secondItem="weN-h2-sJL" secondAttribute="centerY" id="hPz-Ca-aJu"/>
                                 </constraints>
                             </view>
@@ -424,6 +435,7 @@
                         <outlet property="progressIndicator" destination="5oO-Ju-l1S" id="ZDk-V0-rXz"/>
                         <outlet property="statusField" destination="2I0-KH-uBu" id="aPg-Cf-8Zr"/>
                         <outlet property="tableView" destination="q9F-rT-PZ2" id="TRT-PA-LSa"/>
+                        <outlet property="titleLabel" destination="hhw-aN-z6h" id="TeN-D9-RDy"/>
                         <outlet property="topDividerView" destination="s2j-Xp-jGd" id="7D1-cA-1N9"/>
                         <outlet property="trashListMenu" destination="cOD-m3-0ET" id="LM7-S3-9Vt"/>
                     </connections>

--- a/Simplenote/Main.storyboard
+++ b/Simplenote/Main.storyboard
@@ -218,7 +218,7 @@
                             <customView translatesAutoresizingMaskIntoConstraints="NO" id="s2j-Xp-jGd" userLabel="Divider View" customClass="BackgroundView" customModule="Simplenote" customModuleProvider="target">
                                 <rect key="frame" x="0.0" y="566" width="294" height="52"/>
                             </customView>
-                            <view translatesAutoresizingMaskIntoConstraints="NO" id="weN-h2-sJL" userLabel="SearchView">
+                            <view translatesAutoresizingMaskIntoConstraints="NO" id="weN-h2-sJL" userLabel="HeaderView">
                                 <rect key="frame" x="0.0" y="566" width="294" height="52"/>
                                 <subviews>
                                     <searchField wantsLayer="YES" verticalHuggingPriority="750" tag="1" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="cvh-C8-b0b" userLabel="SearchField">
@@ -435,6 +435,7 @@
                         <outlet property="arrayController" destination="QdT-mP-kT8" id="7HE-P5-XlT"/>
                         <outlet property="backgroundView" destination="Dfi-py-m83" id="OsW-dl-qhP"/>
                         <outlet property="clipView" destination="zul-ko-TNO" id="WiT-34-HPY"/>
+                        <outlet property="headerView" destination="weN-h2-sJL" id="5Hg-DU-e1C"/>
                         <outlet property="noteListMenu" destination="JPb-EX-UT9" id="1Ad-LU-3eM"/>
                         <outlet property="progressIndicator" destination="5oO-Ju-l1S" id="ZDk-V0-rXz"/>
                         <outlet property="statusField" destination="2I0-KH-uBu" id="aPg-Cf-8Zr"/>

--- a/Simplenote/Main.storyboard
+++ b/Simplenote/Main.storyboard
@@ -556,7 +556,6 @@
                                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                 </searchFieldCell>
                                                 <connections>
-                                                    <action selector="performSearch:" target="owM-kh-Bm6" id="Dxx-rb-etd"/>
                                                     <outlet property="delegate" destination="owM-kh-Bm6" id="PeJ-VQ-DId"/>
                                                 </connections>
                                             </searchField>

--- a/Simplenote/Main.storyboard
+++ b/Simplenote/Main.storyboard
@@ -544,7 +544,7 @@
                                                     <action selector="moreWasPressed:" target="owM-kh-Bm6" id="jNg-pL-Pc6"/>
                                                 </connections>
                                             </button>
-                                            <searchField wantsLayer="YES" verticalHuggingPriority="750" tag="1" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="YLv-zp-fRS" userLabel="SearchField">
+                                            <searchField verticalHuggingPriority="750" tag="1" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="YLv-zp-fRS" userLabel="SearchField">
                                                 <rect key="frame" x="168" y="12" width="230" height="29"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="29" id="qWD-ui-HWt"/>

--- a/Simplenote/Main.storyboard
+++ b/Simplenote/Main.storyboard
@@ -511,7 +511,7 @@
                                 <rect key="frame" x="0.0" y="566" width="508" height="52"/>
                                 <subviews>
                                     <stackView distribution="fill" orientation="horizontal" alignment="centerY" spacing="22" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="8xD-dy-bio">
-                                        <rect key="frame" x="346" y="0.0" width="146" height="52"/>
+                                        <rect key="frame" x="94" y="0.0" width="398" height="52"/>
                                         <subviews>
                                             <button toolTip="Preview Markdown" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="TI9-l9-KN8" userLabel="Markdown">
                                                 <rect key="frame" x="0.0" y="16" width="20" height="20"/>
@@ -560,6 +560,22 @@
                                                     <action selector="moreWasPressed:" target="owM-kh-Bm6" id="jNg-pL-Pc6"/>
                                                 </connections>
                                             </button>
+                                            <searchField wantsLayer="YES" verticalHuggingPriority="750" tag="1" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="YLv-zp-fRS" userLabel="SearchField">
+                                                <rect key="frame" x="168" y="12" width="230" height="29"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="29" id="qWD-ui-HWt"/>
+                                                    <constraint firstAttribute="width" constant="230" id="yv6-TC-X7T"/>
+                                                </constraints>
+                                                <searchFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" borderStyle="bezel" placeholderString="Search" usesSingleLineMode="YES" bezelStyle="round" id="aSI-77-VjM">
+                                                    <font key="font" metaFont="system"/>
+                                                    <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                </searchFieldCell>
+                                                <connections>
+                                                    <action selector="filterNotes:" target="JtV-0Z-Zh8" id="aDo-FQ-3qt"/>
+                                                    <outlet property="delegate" destination="JtV-0Z-Zh8" id="YnA-Oi-izd"/>
+                                                </connections>
+                                            </searchField>
                                         </subviews>
                                         <constraints>
                                             <constraint firstItem="hVc-Cl-DHn" firstAttribute="height" secondItem="TI9-l9-KN8" secondAttribute="height" id="2wO-UI-11h"/>
@@ -574,8 +590,10 @@
                                             <integer value="1000"/>
                                             <integer value="1000"/>
                                             <integer value="1000"/>
+                                            <integer value="1000"/>
                                         </visibilityPriorities>
                                         <customSpacing>
+                                            <real value="3.4028234663852886e+38"/>
                                             <real value="3.4028234663852886e+38"/>
                                             <real value="3.4028234663852886e+38"/>
                                             <real value="3.4028234663852886e+38"/>
@@ -730,6 +748,7 @@
                         <outlet property="moreActionsMenu" destination="O2x-0v-azu" id="jSV-Gb-XpN"/>
                         <outlet property="noteEditor" destination="84J-wh-qoX" id="MHx-LW-NED"/>
                         <outlet property="scrollView" destination="3M9-OX-Hpx" id="fps-1H-haD"/>
+                        <outlet property="searchField" destination="YLv-zp-fRS" id="xGX-p6-V8f"/>
                         <outlet property="statusImageView" destination="Dj2-Ut-m6l" id="vqt-cc-z7a"/>
                         <outlet property="statusTextField" destination="VFr-Z3-HgO" id="UWY-3k-pwd"/>
                         <outlet property="tagsField" destination="U3o-VN-U2S" id="qmL-AY-16b"/>

--- a/Simplenote/Main.storyboard
+++ b/Simplenote/Main.storyboard
@@ -437,8 +437,6 @@
                         <outlet property="clipView" destination="zul-ko-TNO" id="WiT-34-HPY"/>
                         <outlet property="noteListMenu" destination="JPb-EX-UT9" id="1Ad-LU-3eM"/>
                         <outlet property="progressIndicator" destination="5oO-Ju-l1S" id="ZDk-V0-rXz"/>
-                        <outlet property="searchField" destination="cvh-C8-b0b" id="R6h-sR-ND1"/>
-                        <outlet property="searchView" destination="weN-h2-sJL" id="Pbw-Ih-6lA"/>
                         <outlet property="statusField" destination="2I0-KH-uBu" id="aPg-Cf-8Zr"/>
                         <outlet property="tableView" destination="q9F-rT-PZ2" id="TRT-PA-LSa"/>
                         <outlet property="topDividerView" destination="s2j-Xp-jGd" id="7D1-cA-1N9"/>

--- a/Simplenote/Main.storyboard
+++ b/Simplenote/Main.storyboard
@@ -568,6 +568,7 @@
                                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                 </searchFieldCell>
                                                 <connections>
+                                                    <action selector="performSearch:" target="owM-kh-Bm6" id="aSU-vi-ZBC"/>
                                                     <outlet property="delegate" destination="owM-kh-Bm6" id="PeJ-VQ-DId"/>
                                                 </connections>
                                             </searchField>

--- a/Simplenote/Main.storyboard
+++ b/Simplenote/Main.storyboard
@@ -221,18 +221,6 @@
                             <view translatesAutoresizingMaskIntoConstraints="NO" id="weN-h2-sJL" userLabel="HeaderView">
                                 <rect key="frame" x="0.0" y="566" width="294" height="52"/>
                                 <subviews>
-                                    <searchField wantsLayer="YES" verticalHuggingPriority="750" tag="1" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="cvh-C8-b0b" userLabel="SearchField">
-                                        <rect key="frame" x="12" y="11" width="230" height="30"/>
-                                        <searchFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" borderStyle="bezel" placeholderString="Search" usesSingleLineMode="YES" bezelStyle="round" id="Umi-3H-Bn4">
-                                            <font key="font" metaFont="system"/>
-                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                        </searchFieldCell>
-                                        <connections>
-                                            <action selector="filterNotes:" target="JtV-0Z-Zh8" id="azo-As-k30"/>
-                                            <outlet property="delegate" destination="JtV-0Z-Zh8" id="iol-N5-Gsb"/>
-                                        </connections>
-                                    </searchField>
                                     <button toolTip="Add Note" translatesAutoresizingMaskIntoConstraints="NO" id="LGw-AF-2MK" userLabel="NewNote">
                                         <rect key="frame" x="258" y="16" width="20" height="20"/>
                                         <constraints>
@@ -250,12 +238,7 @@
                                 </subviews>
                                 <constraints>
                                     <constraint firstAttribute="trailing" secondItem="LGw-AF-2MK" secondAttribute="trailing" constant="16" id="35i-gS-rGO"/>
-                                    <constraint firstItem="cvh-C8-b0b" firstAttribute="top" secondItem="weN-h2-sJL" secondAttribute="top" constant="11" id="7z3-yq-ana"/>
-                                    <constraint firstItem="LGw-AF-2MK" firstAttribute="leading" secondItem="cvh-C8-b0b" secondAttribute="trailing" constant="16" id="EaC-ed-3nU"/>
-                                    <constraint firstItem="LGw-AF-2MK" firstAttribute="centerY" secondItem="cvh-C8-b0b" secondAttribute="centerY" id="GdR-Rc-HQZ"/>
-                                    <constraint firstAttribute="bottom" secondItem="cvh-C8-b0b" secondAttribute="bottom" constant="11" id="Gz4-wE-pXe"/>
                                     <constraint firstAttribute="height" constant="52" id="Reo-KD-mIh"/>
-                                    <constraint firstItem="cvh-C8-b0b" firstAttribute="leading" secondItem="weN-h2-sJL" secondAttribute="leading" constant="12" id="uDy-dn-4qz"/>
                                     <constraint firstItem="LGw-AF-2MK" firstAttribute="centerY" secondItem="weN-h2-sJL" secondAttribute="centerY" id="hPz-Ca-aJu"/>
                                 </constraints>
                             </view>

--- a/Simplenote/NoteEditorViewController+Swift.swift
+++ b/Simplenote/NoteEditorViewController+Swift.swift
@@ -168,6 +168,16 @@ extension NoteEditorViewController {
 }
 
 
+// MARK: - Search API
+//
+extension NoteEditorViewController {
+
+    @IBAction
+    func endSearch(_ sender: Any) {
+        searchField.stringValue = String()
+        searchField.resignFirstResponder()
+    }
+}
 // MARK: - NSMenuItemValidation
 //
 extension NoteEditorViewController: NSMenuItemValidation {

--- a/Simplenote/NoteEditorViewController+Swift.swift
+++ b/Simplenote/NoteEditorViewController+Swift.swift
@@ -335,6 +335,11 @@ extension NoteEditorViewController {
         SPTracker.trackEditorVersionsAccessed()
         displayVersionsPopover(from: toolbarView.moreButton, for: note)
     }
+
+    @IBAction
+    func searchAction(_ sender: Any) {
+        view.window?.makeFirstResponder(searchField)
+    }
 }
 
 

--- a/Simplenote/NoteEditorViewController+Swift.swift
+++ b/Simplenote/NoteEditorViewController+Swift.swift
@@ -173,6 +173,11 @@ extension NoteEditorViewController {
 extension NoteEditorViewController {
 
     @IBAction
+    func beginSearch(_ sender: Any) {
+        view.window?.makeFirstResponder(searchField)
+    }
+
+    @IBAction
     func endSearch(_ sender: Any) {
         searchField.stringValue = String()
         searchField.resignFirstResponder()
@@ -344,11 +349,6 @@ extension NoteEditorViewController {
 
         SPTracker.trackEditorVersionsAccessed()
         displayVersionsPopover(from: toolbarView.moreButton, for: note)
-    }
-
-    @IBAction
-    func searchAction(_ sender: Any) {
-        view.window?.makeFirstResponder(searchField)
     }
 }
 

--- a/Simplenote/NoteEditorViewController+Swift.swift
+++ b/Simplenote/NoteEditorViewController+Swift.swift
@@ -8,6 +8,11 @@ import SimplenoteInterlinks
 extension NoteEditorViewController {
 
     @objc
+    func setupSearchBar() {
+        searchField.centersPlaceholder = false
+    }
+
+    @objc
     func setupStatusImageView() {
         statusImageView.image = NSImage(named: .simplenoteLogoInner)
         statusImageView.tintImage(color: .simplenotePlaceholderTintColor)

--- a/Simplenote/NoteEditorViewController+Swift.swift
+++ b/Simplenote/NoteEditorViewController+Swift.swift
@@ -103,6 +103,33 @@ extension NoteEditorViewController {
         noteEditor.isHidden = isDisplayingMarkdown
     }
 
+    /// Refreshes the Editor's UX
+    ///
+    @objc
+    func refreshStyle() {
+        backgroundView.fillColor                = .simplenoteBackgroundColor
+        bottomDividerView.borderColor           = .simplenoteDividerColor
+        noteEditor.insertionPointColor          = .simplenoteTextColor
+        noteEditor.textColor                    = .simplenoteTextColor
+        searchField.textColor                   = .simplenoteTextColor
+        searchField.placeholderAttributedString = Settings.searchFieldPlaceholderString
+        statusTextField.textColor               = .simplenoteSecondaryTextColor
+        tagsField.textColor                     = .simplenoteTextColor
+        tagsField.placeholderTextColor          = .simplenoteSecondaryTextColor
+        topDividerView.borderColor              = .simplenoteDividerColor
+
+        if let note = note {
+            storage.refreshStyle(markdownEnabled: note.markdown)
+        }
+
+        // Legacy Support: High Sierra
+        if #available(macOS 10.14, *) {
+            return
+        }
+
+        searchField.appearance = .simplenoteAppearance
+    }
+
     /// Refreshes the Toolbar's Inner State
     ///
     @objc
@@ -666,4 +693,13 @@ private extension NoteEditorViewController {
 //
 private enum Settings {
     static let maximumAlphaGradientOffset = CGFloat(30)
+
+    static var searchFieldPlaceholderString: NSAttributedString {
+        let text = NSLocalizedString("Search", comment: "Search Field Placeholder")
+
+        return NSAttributedString(string: text, attributes: [
+            .foregroundColor: NSColor.simplenoteSecondaryTextColor,
+            .font: NSFont.simplenoteSecondaryTextFont
+        ])
+    }
 }

--- a/Simplenote/NoteEditorViewController+Swift.swift
+++ b/Simplenote/NoteEditorViewController+Swift.swift
@@ -178,6 +178,11 @@ extension NoteEditorViewController {
     }
 
     @IBAction
+    func performSearch(_ sender: Any) {
+        searchDelegate?.editorController(self, didSearchKeyword: searchField.stringValue)
+    }
+
+    @IBAction
     func endSearch(_ sender: Any) {
         searchField.cancelSearch()
         searchField.resignFirstResponder()
@@ -204,14 +209,6 @@ extension NoteEditorViewController: NSSearchFieldDelegate {
         }
 
         searchDelegate?.editorControllerDidBeginSearch(self)
-    }
-
-    public func controlTextDidChange(_ obj: Notification) {
-        guard let sender = obj.object as? NSSearchField else {
-            return
-        }
-
-        searchDelegate?.editorController(self, didSearchKeyword: sender.stringValue)
     }
 
     public func controlTextDidEndEditing(_ obj: Notification) {

--- a/Simplenote/NoteEditorViewController+Swift.swift
+++ b/Simplenote/NoteEditorViewController+Swift.swift
@@ -182,6 +182,10 @@ extension NoteEditorViewController {
         searchField.stringValue = String()
         searchField.resignFirstResponder()
     }
+
+    @IBAction
+    func performSearch(_ sender: Any) {
+    }
 }
 // MARK: - NSMenuItemValidation
 //

--- a/Simplenote/NoteEditorViewController+Swift.swift
+++ b/Simplenote/NoteEditorViewController+Swift.swift
@@ -179,7 +179,7 @@ extension NoteEditorViewController {
 
     @IBAction
     func endSearch(_ sender: Any) {
-        searchField.stringValue = String()
+        searchField.cancelSearch()
         searchField.resignFirstResponder()
     }
 

--- a/Simplenote/NoteEditorViewController+Swift.swift
+++ b/Simplenote/NoteEditorViewController+Swift.swift
@@ -182,11 +182,39 @@ extension NoteEditorViewController {
         searchField.cancelSearch()
         searchField.resignFirstResponder()
     }
+}
 
-    @IBAction
-    func performSearch(_ sender: Any) {
+
+// MARK: - NSSearchFieldDelegate
+//
+extension NoteEditorViewController: NSSearchFieldDelegate {
+
+    public func controlTextDidBeginEditing(_ obj: Notification) {
+        guard let _ = obj.object as? NSSearchField else {
+            return
+        }
+
+        searchDelegate?.editorControllerDidBeginSearch(self)
+    }
+
+    public func controlTextDidChange(_ obj: Notification) {
+        guard let sender = obj.object as? NSSearchField else {
+            return
+        }
+
+        searchDelegate?.editorController(self, didSearchKeyword: sender.stringValue)
+    }
+
+    public func controlTextDidEndEditing(_ obj: Notification) {
+        guard let _ = obj.object as? NSSearchField else {
+            return
+        }
+
+        searchDelegate?.editorControllerDidEndSearch(self)
     }
 }
+
+
 // MARK: - NSMenuItemValidation
 //
 extension NoteEditorViewController: NSMenuItemValidation {

--- a/Simplenote/NoteEditorViewController+Swift.swift
+++ b/Simplenote/NoteEditorViewController+Swift.swift
@@ -182,6 +182,15 @@ extension NoteEditorViewController {
         searchField.cancelSearch()
         searchField.resignFirstResponder()
     }
+
+    @objc
+    func ensureSearchIsDismissed() {
+        guard searchField.stringValue.isEmpty == false else {
+            return
+        }
+
+        endSearch(self)
+    }
 }
 
 

--- a/Simplenote/NoteEditorViewController.h
+++ b/Simplenote/NoteEditorViewController.h
@@ -45,6 +45,12 @@ typedef NS_ENUM(NSInteger, NoteFontSize) {
 - (void)editorController:(NoteEditorViewController *)controller didAddNewTag:(NSString *)tag;
 @end
 
+@protocol EditorControllerSearchDelegate <NSObject>
+- (void)editorControllerDidBeginSearch:(NoteEditorViewController *)controller;
+- (void)editorControllerDidEndSearch:(NoteEditorViewController *)controller;
+- (void)editorController:(NoteEditorViewController *)controller didSearchKeyword:(NSString *)keyword;
+@end
+
 
 
 #pragma mark - NoteEditorViewController
@@ -71,6 +77,7 @@ typedef NS_ENUM(NSInteger, NoteFontSize) {
 @property (nonatomic,   weak) Note                                              *note;
 @property (nonatomic,   weak) id<EditorControllerNoteActionsDelegate>           noteActionsDelegate;
 @property (nonatomic,   weak) id<EditorControllerTagActionsDelegate>            tagActionsDelegate;
+@property (nonatomic,   weak) id<EditorControllerSearchDelegate>                searchDelegate;
 
 - (IBAction)newNoteWasPressed:(id)sender;
 - (void)save;

--- a/Simplenote/NoteEditorViewController.h
+++ b/Simplenote/NoteEditorViewController.h
@@ -56,6 +56,7 @@ typedef NS_ENUM(NSInteger, NoteFontSize) {
 @property (nonatomic, strong) IBOutlet BackgroundView                           *topDividerView;
 @property (nonatomic, strong) IBOutlet BackgroundView                           *bottomDividerView;
 @property (nonatomic, strong) IBOutlet ToolbarView                              *toolbarView;
+@property (nonatomic, strong) IBOutlet NSSearchField                            *searchField;
 @property (nonatomic, strong) IBOutlet NSImageView                              *statusImageView;
 @property (nonatomic, strong) IBOutlet NSTextField                              *statusTextField;
 @property (nonatomic, strong) IBOutlet SPTextView                               *noteEditor;

--- a/Simplenote/NoteEditorViewController.h
+++ b/Simplenote/NoteEditorViewController.h
@@ -16,6 +16,7 @@
 @class NoteEditorViewController;
 @class NoteListViewController;
 @class MarkdownViewController;
+@class Storage;
 @class TagsField;
 @class ToolbarView;
 
@@ -62,6 +63,7 @@ typedef NS_ENUM(NSInteger, NoteFontSize) {
 @property (nonatomic, strong) IBOutlet TagsField                                *tagsField;
 
 @property (nonatomic, strong, readonly) MarkdownViewController                  *markdownViewController;
+@property (nonatomic, strong, readonly) Storage                                 *storage;
 @property (nonatomic, strong, readonly) NSArray<Note *>                         *selectedNotes;
 @property (nonatomic, assign, readonly) BOOL                                    viewingTrash;
 @property (nonatomic, strong, nullable) InterlinkWindowController               *interlinkWindowController;

--- a/Simplenote/NoteEditorViewController.h
+++ b/Simplenote/NoteEditorViewController.h
@@ -78,7 +78,6 @@ typedef NS_ENUM(NSInteger, NoteFontSize) {
 - (void)displayNotes:(NSArray<Note *> *)selectedNotes;
 - (void)didReceiveNewContent;
 - (void)willReceiveNewContent;
-- (void)applyStyle;
 - (void)fixChecklistColoring;
 - (void)updateTagsWithTokens:(NSArray<NSString *> *)tokens;
 - (NSUInteger)newCursorLocation:(NSString *)newText oldText:(NSString *)oldText currentLocation:(NSUInteger)cursorLocation;

--- a/Simplenote/NoteEditorViewController.m
+++ b/Simplenote/NoteEditorViewController.m
@@ -259,6 +259,7 @@ static NSString * const SPMarkdownPreferencesKey        = @"kMarkdownPreferences
     [self refreshEditorActions];
     [self refreshToolbarActions];
     [self refreshTagsFieldActions];
+    [self ensureSearchIsDismissed];
 }
 
 - (void)tagsDidLoad:(NSNotification *)notification
@@ -267,6 +268,7 @@ static NSString * const SPMarkdownPreferencesKey        = @"kMarkdownPreferences
     [self refreshEditorActions];
     [self refreshToolbarActions];
     [self refreshTagsFieldActions];
+    [self ensureSearchIsDismissed];
 }
 
 - (void)tagUpdated:(NSNotification *)notification
@@ -473,7 +475,7 @@ static NSString * const SPMarkdownPreferencesKey        = @"kMarkdownPreferences
         [newNote addTag:currentTag];
     }
 
-    [self endSearch:self];
+    [self ensureSearchIsDismissed];
     [self displayNote:newNote];
     [self save];
 

--- a/Simplenote/NoteEditorViewController.m
+++ b/Simplenote/NoteEditorViewController.m
@@ -97,6 +97,7 @@ static NSString * const SPMarkdownPreferencesKey        = @"kMarkdownPreferences
 	}
 
     // Interface Initialization
+    [self setupSearchBar];
     [self setupScrollView];
     [self setupTopDivider];
     [self setupStatusImageView];

--- a/Simplenote/NoteEditorViewController.m
+++ b/Simplenote/NoteEditorViewController.m
@@ -473,6 +473,7 @@ static NSString * const SPMarkdownPreferencesKey        = @"kMarkdownPreferences
         [newNote addTag:currentTag];
     }
 
+    [self endSearch:self];
     [self displayNote:newNote];
     [self save];
 

--- a/Simplenote/NoteEditorViewController.m
+++ b/Simplenote/NoteEditorViewController.m
@@ -121,7 +121,7 @@ static NSString * const SPMarkdownPreferencesKey        = @"kMarkdownPreferences
 
     [self startListeningToScrollNotifications];
 
-    [self applyStyle];
+    [self refreshStyle];
 }
 
 - (void)save
@@ -596,7 +596,7 @@ static NSString * const SPMarkdownPreferencesKey        = @"kMarkdownPreferences
 
     // Update font size preference and reset fonts
     [[NSUserDefaults standardUserDefaults] setInteger:currentFontSize forKey:SPFontSizePreferencesKey];
-    [self applyStyle];
+    [self refreshStyle];
 }
 
 #pragma mark - NoteEditor Preferences Helpers
@@ -678,22 +678,6 @@ static NSString * const SPMarkdownPreferencesKey        = @"kMarkdownPreferences
 
 
 #pragma mark - Style Helpers
-
-- (void)applyStyle
-{
-    if (self.note != nil) {
-        [self.storage refreshStyleWithMarkdownEnabled:self.note.markdown];
-    }
-
-    self.backgroundView.fillColor       = [NSColor simplenoteBackgroundColor];
-    self.topDividerView.borderColor     = [NSColor simplenoteDividerColor];
-    self.bottomDividerView.borderColor  = [NSColor simplenoteDividerColor];
-    self.statusTextField.textColor      = [NSColor simplenoteSecondaryTextColor];
-    self.noteEditor.insertionPointColor = [NSColor simplenoteTextColor];
-    self.noteEditor.textColor           = [NSColor simplenoteTextColor];
-    self.tagsField.textColor            = [NSColor simplenoteTextColor];
-    self.tagsField.placeholderTextColor = [NSColor simplenoteSecondaryTextColor];
-}
 
 // Reprocesses note checklists after switching themes, so they apply the correct color
 - (void)fixChecklistColoring

--- a/Simplenote/NoteListViewController+Swift.swift
+++ b/Simplenote/NoteListViewController+Swift.swift
@@ -26,13 +26,6 @@ extension NoteListViewController {
         progressIndicator.isHidden = true
     }
 
-    /// Setup: SearchBar
-    ///
-    @objc
-    func setupSearchBar() {
-        searchField.centersPlaceholder = false
-    }
-
     /// Setup: Top Divider
     ///
     @objc
@@ -66,17 +59,8 @@ extension NoteListViewController {
         backgroundView.fillColor = .simplenoteSecondaryBackgroundColor
         topDividerView.borderColor = .simplenoteDividerColor
         addNoteButton.tintImage(color: .simplenoteActionButtonTintColor)
-        searchField.textColor = .simplenoteTextColor
-        searchField.placeholderAttributedString = searchFieldPlaceholderString
         statusField.textColor = .simplenoteSecondaryTextColor
         reloadDataAndPreserveSelection()
-
-        // Legacy Support: High Sierra
-        if #available(macOS 10.14, *) {
-            return
-        }
-
-        searchField.appearance = .simplenoteAppearance
     }
 }
 
@@ -137,16 +121,6 @@ extension NoteListViewController {
 // MARK: - Helpers
 //
 private extension NoteListViewController {
-
-    var searchFieldPlaceholderString: NSAttributedString {
-        let text = NSLocalizedString("Search", comment: "Search Field Placeholder")
-        let attributes: [NSAttributedString.Key: Any] = [
-            .foregroundColor: NSColor.simplenoteSecondaryTextColor,
-            .font: NSFont.simplenoteSecondaryTextFont
-        ]
-
-        return NSAttributedString(string: text, attributes: attributes)
-    }
 
     var simperium: Simperium {
         SimplenoteAppDelegate.shared().simperium

--- a/Simplenote/NoteListViewController+Swift.swift
+++ b/Simplenote/NoteListViewController+Swift.swift
@@ -52,6 +52,15 @@ extension NoteListViewController {
         addNoteButton.isEnabled = !viewingTrash
     }
 
+    @objc
+    func refreshTitle() {
+        guard let title = SimplenoteAppDelegate.shared().tagListViewController.selectedRow?.title else {
+            return
+        }
+
+        titleLabel.stringValue = title
+    }
+
     /// Refreshes the receiver's style
     ///
     @objc

--- a/Simplenote/NoteListViewController+Swift.swift
+++ b/Simplenote/NoteListViewController+Swift.swift
@@ -235,7 +235,6 @@ extension NoteListViewController: EditorControllerSearchDelegate {
 
     public func editorControllerDidEndSearch(_ controller: NoteEditorViewController) {
         searchKeyword = nil
-        refreshPredicate()
     }
 }
 

--- a/Simplenote/NoteListViewController+Swift.swift
+++ b/Simplenote/NoteListViewController+Swift.swift
@@ -220,9 +220,9 @@ extension NoteListViewController: EditorControllerSearchDelegate {
     }
 
     public func editorController(_ controller: NoteEditorViewController, didSearchKeyword keyword: String) {
-        selectRow(.zero)
         searchKeyword = keyword
         refreshPredicate()
+        selectRow(.zero)
     }
 
     public func editorControllerDidEndSearch(_ controller: NoteEditorViewController) {

--- a/Simplenote/NoteListViewController+Swift.swift
+++ b/Simplenote/NoteListViewController+Swift.swift
@@ -65,6 +65,19 @@ extension NoteListViewController {
 }
 
 
+// MARK: - State
+//
+extension NoteListViewController {
+
+    /// Indicates if we're in Search Mode
+    ///
+    @objc
+    var searching: Bool {
+        searchKeyword?.isEmpty == false
+    }
+}
+
+
 // MARK: - Filtering
 //
 extension NoteListViewController {
@@ -106,13 +119,12 @@ extension NoteListViewController {
     /// Returns a NSPredicate that will filter the current Search Text (if any)
     ///
     private var searchTextPredicates: [NSPredicate] {
-        let searchText = searchField.stringValue
-        guard !searchText.isEmpty else {
+        guard let keyword = searchKeyword, !keyword.isEmpty else {
             return []
         }
 
         return [
-            NSPredicate.predicateForNotes(searchText: searchText)
+            NSPredicate.predicateForNotes(searchText: keyword)
         ]
     }
 }
@@ -195,6 +207,26 @@ extension NoteListViewController: EditorControllerNoteActionsDelegate {
 
     public func editorController(_ controller: NoteEditorViewController, updatedNoteWithSimperiumKey simperiumKey: String) {
         reloadRow(forNoteKey: simperiumKey)
+    }
+}
+
+
+// MARK: - EditorControllerSearchDelegate
+//
+extension NoteListViewController: EditorControllerSearchDelegate {
+
+    public func editorControllerDidBeginSearch(_ controller: NoteEditorViewController) {
+        SPTracker.trackListNotesSearched()
+    }
+
+    public func editorController(_ controller: NoteEditorViewController, didSearchKeyword keyword: String) {
+        selectRow(.zero)
+        searchKeyword = keyword
+        refreshPredicate()
+    }
+
+    public func editorControllerDidEndSearch(_ controller: NoteEditorViewController) {
+        searchKeyword = nil
     }
 }
 

--- a/Simplenote/NoteListViewController+Swift.swift
+++ b/Simplenote/NoteListViewController+Swift.swift
@@ -231,11 +231,11 @@ extension NoteListViewController: EditorControllerSearchDelegate {
     public func editorController(_ controller: NoteEditorViewController, didSearchKeyword keyword: String) {
         searchKeyword = keyword
         refreshPredicate()
-        selectRow(.zero)
     }
 
     public func editorControllerDidEndSearch(_ controller: NoteEditorViewController) {
         searchKeyword = nil
+        refreshPredicate()
     }
 }
 

--- a/Simplenote/NoteListViewController+Swift.swift
+++ b/Simplenote/NoteListViewController+Swift.swift
@@ -172,9 +172,6 @@ extension NoteListViewController {
 extension NoteListViewController: EditorControllerNoteActionsDelegate {
 
     public func editorController(_ controller: NoteEditorViewController, addedNoteWithSimperiumKey simperiumKey: String) {
-        searchField.cancelSearch()
-        searchField.resignFirstResponder()
-
         reloadSynchronously()
         selectRow(forNoteKey: simperiumKey)
     }

--- a/Simplenote/NoteListViewController.h
+++ b/Simplenote/NoteListViewController.h
@@ -48,7 +48,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)reloadDataAndPreserveSelection;
 - (void)deleteNote:(Note *)note;
 - (IBAction)deleteAction:(id)sender;
-- (IBAction)searchAction:(id)sender;
 - (IBAction)filterNotes:(id)sender;
 - (void)noteKeysWillChange:(NSSet *)keys;
 - (void)noteKeyDidChange:(NSString *)key memberNames:(NSArray *)memberNames;

--- a/Simplenote/NoteListViewController.h
+++ b/Simplenote/NoteListViewController.h
@@ -31,8 +31,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, readonly) IBOutlet NSMenu                 *noteListMenu;
 @property (nonatomic, strong, readonly) IBOutlet NSMenu                 *trashListMenu;
 
-@property (nonatomic, assign, readonly) BOOL                            searching;
 @property (nonatomic, assign, readonly) BOOL                            viewingTrash;
+@property (nonatomic, strong, nullable) NSString                        *searchKeyword;
 
 - (void)loadNotes;
 - (void)reloadSynchronously;
@@ -47,7 +47,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)reloadDataAndPreserveSelection;
 - (void)deleteNote:(Note *)note;
 - (IBAction)deleteAction:(id)sender;
-- (IBAction)filterNotes:(id)sender;
 - (void)noteKeysWillChange:(NSSet *)keys;
 - (void)noteKeyDidChange:(NSString *)key memberNames:(NSArray *)memberNames;
 

--- a/Simplenote/NoteListViewController.h
+++ b/Simplenote/NoteListViewController.h
@@ -25,7 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, readonly) IBOutlet NSProgressIndicator    *progressIndicator;
 @property (nonatomic, strong, readonly) IBOutlet NSClipView             *clipView;
 @property (nonatomic, strong, readonly) IBOutlet SPTableView            *tableView;
-@property (nonatomic, strong, readonly) IBOutlet NSView                 *searchView;
+@property (nonatomic, strong, readonly) IBOutlet NSView                 *headerView;
 @property (nonatomic, strong, readonly) IBOutlet NSButton               *addNoteButton;
 
 @property (nonatomic, strong, readonly) IBOutlet NSMenu                 *noteListMenu;

--- a/Simplenote/NoteListViewController.h
+++ b/Simplenote/NoteListViewController.h
@@ -21,6 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, readonly) IBOutlet NSArrayController      *arrayController;
 @property (nonatomic, strong, readonly) IBOutlet BackgroundView         *backgroundView;
 @property (nonatomic, strong, readonly) IBOutlet BackgroundView         *topDividerView;
+@property (nonatomic, strong, readonly) IBOutlet NSTextField            *titleLabel;
 @property (nonatomic, strong, readonly) IBOutlet NSTextField            *statusField;
 @property (nonatomic, strong, readonly) IBOutlet NSProgressIndicator    *progressIndicator;
 @property (nonatomic, strong, readonly) IBOutlet NSClipView             *clipView;

--- a/Simplenote/NoteListViewController.h
+++ b/Simplenote/NoteListViewController.h
@@ -26,7 +26,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, readonly) IBOutlet NSClipView             *clipView;
 @property (nonatomic, strong, readonly) IBOutlet SPTableView            *tableView;
 @property (nonatomic, strong, readonly) IBOutlet NSView                 *searchView;
-@property (nonatomic, strong, readonly) IBOutlet NSSearchField          *searchField;
 @property (nonatomic, strong, readonly) IBOutlet NSButton               *addNoteButton;
 
 @property (nonatomic, strong, readonly) IBOutlet NSMenu                 *noteListMenu;

--- a/Simplenote/NoteListViewController.h
+++ b/Simplenote/NoteListViewController.h
@@ -36,7 +36,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)loadNotes;
 - (void)reloadSynchronously;
-- (void)reset;
 - (void)setWaitingForIndex:(BOOL)waiting;
 - (NSArray<Note *> *)selectedNotes;
 - (void)setNotesPredicate:(NSPredicate *)predicate;

--- a/Simplenote/NoteListViewController.m
+++ b/Simplenote/NoteListViewController.m
@@ -32,7 +32,6 @@
 @property (nonatomic, strong) IBOutlet NSMenu               *noteListMenu;
 @property (nonatomic, strong) IBOutlet NSMenu               *trashListMenu;
 @property (nonatomic, strong) NSString                      *oldTags;
-@property (nonatomic, assign) BOOL                          searching;
 @property (nonatomic, assign) BOOL                          viewingTrash;
 @property (nonatomic, assign) BOOL                          preserveSelection;
 @end
@@ -397,25 +396,6 @@
 }
 
 
-#pragma mark - NSSearchFieldDelegate
-
-- (void)controlTextDidBeginEditing:(NSNotification *)notification
-{
-    [SPTracker trackListNotesSearched];
-    self.searching = YES;
-}
-
-- (void)controlTextDidChange:(NSNotification *)notification
-{
-    [self selectRow:0];
-}
-
-- (void)controlTextDidEndEditing:(NSNotification *)notification
-{
-    self.searching = NO;
-}
-
-
 #pragma mark - Actions
 
 - (void)deleteNote:(Note *)note
@@ -439,14 +419,6 @@
 {
     // TODO: Move the New Note Handler to a (New) NoteController!
     [self.noteEditorViewController newNoteWasPressed:sender];
-}
-
-
-#pragma mark - IBActions
-
-- (IBAction)filterNotes:(id)sender
-{
-    [self refreshPredicate];
 }
 
 @end

--- a/Simplenote/NoteListViewController.m
+++ b/Simplenote/NoteListViewController.m
@@ -445,11 +445,6 @@
     [self.noteEditorViewController newNoteWasPressed:sender];
 }
 
-- (void)searchAction:(id)sender
-{
-    [self.view.window makeFirstResponder:self.searchField];
-}
-
 
 #pragma mark - IBActions
 

--- a/Simplenote/NoteListViewController.m
+++ b/Simplenote/NoteListViewController.m
@@ -23,6 +23,7 @@
 @property (nonatomic, strong) IBOutlet NSArrayController    *arrayController;
 @property (nonatomic, strong) IBOutlet BackgroundView       *backgroundView;
 @property (nonatomic, strong) IBOutlet BackgroundView       *topDividerView;
+@property (nonatomic, strong) IBOutlet NSTextField          *titleLabel;
 @property (nonatomic, strong) IBOutlet NSTextField          *statusField;
 @property (nonatomic, strong) IBOutlet NSProgressIndicator  *progressIndicator;
 @property (nonatomic, strong) IBOutlet NSClipView           *clipView;
@@ -392,6 +393,7 @@
 {
     [self refreshEnabledActions];
     [self refreshPredicate];
+    [self refreshTitle];
     [self selectFirstRow];
 }
 

--- a/Simplenote/NoteListViewController.m
+++ b/Simplenote/NoteListViewController.m
@@ -119,11 +119,6 @@
     return [[SimplenoteAppDelegate sharedDelegate] managedObjectContext];
 }
 
-- (void)reset
-{
-    [self.searchField setStringValue:@""];
-}
-
 - (void)setNotesPredicate:(NSPredicate *)predicate
 {
     [self.arrayController setFetchPredicate:predicate];
@@ -419,6 +414,7 @@
 {
     self.searching = NO;
 }
+
 
 #pragma mark - Actions
 

--- a/Simplenote/NoteListViewController.m
+++ b/Simplenote/NoteListViewController.m
@@ -81,7 +81,6 @@
                                                object: nil];
 
     [self setupProgressIndicator];
-    [self setupSearchBar];
     [self setupTableView];
     [self setupTopDivider];
 }

--- a/Simplenote/NoteListViewController.m
+++ b/Simplenote/NoteListViewController.m
@@ -27,8 +27,7 @@
 @property (nonatomic, strong) IBOutlet NSProgressIndicator  *progressIndicator;
 @property (nonatomic, strong) IBOutlet NSClipView           *clipView;
 @property (nonatomic, strong) IBOutlet SPTableView          *tableView;
-@property (nonatomic, strong) IBOutlet NSView               *searchView;
-@property (nonatomic, strong) IBOutlet NSSearchField        *searchField;
+@property (nonatomic, strong) IBOutlet NSView               *headerView;
 @property (nonatomic, strong) IBOutlet NSButton             *addNoteButton;
 @property (nonatomic, strong) IBOutlet NSMenu               *noteListMenu;
 @property (nonatomic, strong) IBOutlet NSMenu               *trashListMenu;

--- a/Simplenote/SimplenoteAppDelegate+Swift.swift
+++ b/Simplenote/SimplenoteAppDelegate+Swift.swift
@@ -44,6 +44,7 @@ extension SimplenoteAppDelegate {
     func configureEditorController() {
         noteEditorViewController.tagActionsDelegate = tagListViewController
         noteEditorViewController.noteActionsDelegate = noteListViewController
+        noteEditorViewController.searchDelegate = noteListViewController
     }
 }
 

--- a/Simplenote/SimplenoteAppDelegate+Swift.swift
+++ b/Simplenote/SimplenoteAppDelegate+Swift.swift
@@ -126,7 +126,7 @@ extension SimplenoteAppDelegate {
 
     @IBAction
     func searchWasPressed(_ sender: Any) {
-        noteListViewController.searchAction(sender)
+        noteEditorViewController.searchAction(sender)
     }
 
     @IBAction

--- a/Simplenote/SimplenoteAppDelegate+Swift.swift
+++ b/Simplenote/SimplenoteAppDelegate+Swift.swift
@@ -126,7 +126,7 @@ extension SimplenoteAppDelegate {
 
     @IBAction
     func searchWasPressed(_ sender: Any) {
-        noteEditorViewController.searchAction(sender)
+        noteEditorViewController.beginSearch(sender)
     }
 
     @IBAction

--- a/Simplenote/SimplenoteAppDelegate.m
+++ b/Simplenote/SimplenoteAppDelegate.m
@@ -456,7 +456,7 @@
     // Remove WordPress token
     [SPKeychain deletePasswordForService:SPWPServiceName account:self.simperium.user.email];
     
-    [self.noteEditorViewController endSearch:self];
+    [self.noteEditorViewController ensureSearchIsDismissed];
     [self.noteEditorViewController displayNote:nil];
     [self.tagListViewController reset];
     [self.noteListViewController setWaitingForIndex:YES];

--- a/Simplenote/SimplenoteAppDelegate.m
+++ b/Simplenote/SimplenoteAppDelegate.m
@@ -475,7 +475,7 @@
 {
     // Needs to be here because this class is the window's delegate, and SPApplication uses sendEvent:
     // to override a search keyboard shortcut...which ends up calling searchAction: here
-    [self.noteEditorViewController searchAction:sender];
+    [self.noteEditorViewController beginSearch:sender];
 }
 
 - (IBAction)toggleSidebarAction:(id)sender

--- a/Simplenote/SimplenoteAppDelegate.m
+++ b/Simplenote/SimplenoteAppDelegate.m
@@ -475,7 +475,7 @@
 {
     // Needs to be here because this class is the window's delegate, and SPApplication uses sendEvent:
     // to override a search keyboard shortcut...which ends up calling searchAction: here
-    [self.noteListViewController searchAction:sender];
+    [self.noteEditorViewController searchAction:sender];
 }
 
 - (IBAction)toggleSidebarAction:(id)sender

--- a/Simplenote/SimplenoteAppDelegate.m
+++ b/Simplenote/SimplenoteAppDelegate.m
@@ -456,9 +456,9 @@
     // Remove WordPress token
     [SPKeychain deletePasswordForService:SPWPServiceName account:self.simperium.user.email];
     
+    [self.noteEditorViewController endSearch:self];
     [self.noteEditorViewController displayNote:nil];
     [self.tagListViewController reset];
-    [self.noteListViewController reset];
     [self.noteListViewController setWaitingForIndex:YES];
     
     [_simperium signOutAndRemoveLocalData:YES completion:^{

--- a/Simplenote/SimplenoteAppDelegate.m
+++ b/Simplenote/SimplenoteAppDelegate.m
@@ -519,7 +519,7 @@
     [self.splitViewController refreshStyle];
     [self.tagListViewController applyStyle];
     [self.noteListViewController applyStyle];
-    [self.noteEditorViewController applyStyle];
+    [self.noteEditorViewController refreshStyle];
     [self.noteEditorViewController fixChecklistColoring];
 }
 

--- a/Simplenote/TagListRow.swift
+++ b/Simplenote/TagListRow.swift
@@ -33,6 +33,23 @@ extension TagListRow {
         self != .header && self != .spacer
     }
 
+    /// Returns a human friendly descriptive string
+    ///
+    var title: String? {
+        switch self {
+        case .allNotes:
+            return NSLocalizedString("All Notes", comment: "Title of the all notes filter")
+        case .trash:
+            return NSLocalizedString("Trash", comment: "Title for the Trash filter")
+        case .tag(let tag):
+            return tag.name ?? NSLocalizedString("Unnamed Tag", comment: "Title for Tag with no Name")
+        case .untagged:
+            return NSLocalizedString("Untagged", comment: "Untagged Notes Title")
+        default:
+            return nil
+        }
+    }
+
     /// Returns a collection of Rows that
     ///
     static func buildListRows(for tags: [Tag] = []) -> [TagListRow] {


### PR DESCRIPTION
### Fix
In this PR we're:

- Moving the **SearchField** from the Notes List into the Notes Editor
- Implementing a new SearchDelegate protocol, to link Editor > List
- Swifting few things here and there!


cc @eshurakov (Thank youuu!!)
Ref. #718 

### Test: Search
- [ ] Verify that entering text over the Search Bar filters the notes in the Notes List
- [ ] Verify that clicking over any Tag (while Search is Active) causes the Search Mode to be dismissed
- [ ] Verify that clicking over the `+` New Note Action (while Search is Active) causes the Search Mode to be dismissed

### Test: UX
- [ ] Verify the Search Bar now is displayed in the Toolbar above the Editor
- [ ] Verify the Notes List now has a new Title, that presents the selection name
- [ ] Verify that switching to Light / Dark mode causes the app to refresh the UI without glitches
- [ ] Verify the Search Bar's Placeholder looks great

### Test: List Title
- [ ] Verify that clicking over any of your tags causes the Notes List Title to display the selection's name
- [ ] Verify that clicking over **Trash** causes the Notes List title to read as **Trash**
- [ ] Verify that clicking over **Untagged Notes** causes the Notes List title to read as **Untagged**
- [ ] Verify that clicking over **All Notes** causes the Notes List title to read as **All Notes**

### Test: Shortcuts
- [ ] Verify that pressing CMD + L causes the Search Bar to become the First Responder
- [ ] Verify that clicking over **Edit > Find > Search** (macOS Menu) causes the Search Bar to become First Responder


### Release
`RELEASE-NOTES.txt` was updated in 777c45f with:

> Relocated Search Bar #722


### Screenshots

Big Sur: Before|Big Sur: After
-|-
<img width="300" alt="Screen Shot 2020-11-24 at 7 51 15 PM" src="https://user-images.githubusercontent.com/1195260/100160522-82d28300-2e8e-11eb-9a59-97924f74b5c5.png"> | <img width="300" alt="Screen Shot 2020-11-24 at 7 50 24 PM" src="https://user-images.githubusercontent.com/1195260/100160531-86660a00-2e8e-11eb-984b-fb5b427b5afc.png">


Catalina: Before|Catalina: After
-|-
<img width="300" alt="Screen Shot 2020-11-24 at 8 03 27 PM" src="https://user-images.githubusercontent.com/1195260/100161559-73ecd000-2e90-11eb-9e43-e5ed022ab797.png"> | <img width="300" alt="Screen Shot 2020-11-24 at 8 04 26 PM" src="https://user-images.githubusercontent.com/1195260/100161565-77805700-2e90-11eb-8580-0a493ef631d8.png">


