### PR TITLE
Bugfix: Metrics Width

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 - Relocated Search Bar #722
 - Updated minimum required OS to 10.14 #723
 - Tags and Toolbar headers now display a blur effect #724
+- Fixed a bug that caused the Metrics UI to display overlapped text #725
 
 2.4
 ---

--- a/Simplenote/MetricsViewController.swift
+++ b/Simplenote/MetricsViewController.swift
@@ -248,8 +248,7 @@ private extension MetricsViewController {
 
         height += sizingReferenceCell.fittingSize.height * min(Metrics.maximumVisibleReferences, numberOfReferences)
 
-        let width = numberOfReferences > .zero ? Metrics.widthForNonEmptyReferences : Metrics.widthForZeroReferences
-        return CGSize(width: width, height: height)
+        return CGSize(width: Metrics.defaultWidth, height: height)
     }
 }
 
@@ -347,8 +346,7 @@ private extension MetricsViewController {
 // MARK: - Private Types
 //
 private enum Metrics {
-    static let widthForZeroReferences = CGFloat(260)
-    static let widthForNonEmptyReferences = CGFloat(360)
+    static let defaultWidth = CGFloat(360)
     static let maximumVisibleReferences = CGFloat(2.5)
 }
 


### PR DESCRIPTION
### Fix
In this PR we're adjusting the Metrics UI width, so that there is no text overlap.

cc @eshurakov (Thank youuu!!)

### Test
1. Launch Simplenote
2. Click over any note that's not being referenced elsewhere
3. Click over the top right `( i )` icon to display the metrics

- [x] Verify the References Section does not show up
- [x] Verify the text is rendered in two columns, and it does not overlap

### Release
`RELEASE-NOTES.txt` was updated in df298bb with:

> Fixed a bug that caused the Metrics UI to display overlapped text #725
