### PR TITLE
Bugfix: Title Hugging

### DIFF
--- a/Simplenote/Main.storyboard
+++ b/Simplenote/Main.storyboard
@@ -365,9 +365,9 @@
                             <customView translatesAutoresizingMaskIntoConstraints="NO" id="dMC-MU-RmS" userLabel="Header View">
                                 <rect key="frame" x="0.0" y="566" width="294" height="52"/>
                                 <subviews>
-                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="sHv-fV-cSL">
+                                    <textField horizontalHuggingPriority="1000" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="sHv-fV-cSL">
                                         <rect key="frame" x="14" y="17" width="39" height="19"/>
-                                        <textFieldCell key="cell" lineBreakMode="clipping" title="Title" id="VNw-0O-CIA">
+                                        <textFieldCell key="cell" lineBreakMode="truncatingTail" title="Title" id="VNw-0O-CIA">
                                             <font key="font" metaFont="systemBold" size="16"/>
                                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>


### PR DESCRIPTION
### Fix
In this PR we're fixing a bug that caused the Notes List Title to force a (huge) width on the SplitView column.

cc @eshurakov (Thank you for spotting this!!)
Ref. #718

### Test
1. Add a super long tag name
2. Click over a short tag
3. Verify the short tag's name shows up in the Notes List title
4. Click over the super long tag name (added in step 1)

- [x] Verify the Notes column doesn't get resized
- [x] Verify the Notes List title gets clipped

### Release
These changes do not require release notes.
