### PR TITLE
Editor: Fixing Initial Offset

### DIFF
--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -284,6 +284,8 @@
 		B5B17F382425651700DD5B34 /* TestConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5B17F372425651700DD5B34 /* TestConstants.swift */; };
 		B5B17F3A2425668400DD5B34 /* NSAttributedString+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5B17F392425668400DD5B34 /* NSAttributedString+Simplenote.swift */; };
 		B5B17F3B2425668400DD5B34 /* NSAttributedString+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5B17F392425668400DD5B34 /* NSAttributedString+Simplenote.swift */; };
+		B5B1CBCD256EE72C0040726C /* NSScrollView+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5B1CBCC256EE72C0040726C /* NSScrollView+Simplenote.swift */; };
+		B5B1CBCE256EE72C0040726C /* NSScrollView+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5B1CBCC256EE72C0040726C /* NSScrollView+Simplenote.swift */; };
 		B5B5F33D243244F100F31720 /* TextViewInputHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5B5F33C243244F100F31720 /* TextViewInputHandlerTests.swift */; };
 		B5BB8CD424DB51670024E4C5 /* NSSearchField+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5BB8CD324DB51670024E4C5 /* NSSearchField+Simplenote.swift */; };
 		B5BB8CD524DB51670024E4C5 /* NSSearchField+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5BB8CD324DB51670024E4C5 /* NSSearchField+Simplenote.swift */; };
@@ -637,6 +639,7 @@
 		B5B17F352425641E00DD5B34 /* NSAttributedStringSimplenoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSAttributedStringSimplenoteTests.swift; sourceTree = "<group>"; };
 		B5B17F372425651700DD5B34 /* TestConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestConstants.swift; sourceTree = "<group>"; };
 		B5B17F392425668400DD5B34 /* NSAttributedString+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSAttributedString+Simplenote.swift"; sourceTree = "<group>"; };
+		B5B1CBCC256EE72C0040726C /* NSScrollView+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSScrollView+Simplenote.swift"; sourceTree = "<group>"; };
 		B5B5F33C243244F100F31720 /* TextViewInputHandlerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextViewInputHandlerTests.swift; sourceTree = "<group>"; };
 		B5BB8CD324DB51670024E4C5 /* NSSearchField+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSSearchField+Simplenote.swift"; sourceTree = "<group>"; };
 		B5C19D8A243D30690014086C /* VersionsViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = VersionsViewController.xib; sourceTree = "<group>"; };
@@ -1046,6 +1049,7 @@
 				B5A2F1EF2432DE54003B29C6 /* NSRange+Simplenote.swift */,
 				B5985ACD24293E360044EDE9 /* NSRegularExpression+Simplenote.swift */,
 				B5919363245A7AD300A70C0C /* NSScreen+Simplenote.swift */,
+				B5B1CBCC256EE72C0040726C /* NSScrollView+Simplenote.swift */,
 				B5BB8CD324DB51670024E4C5 /* NSSearchField+Simplenote.swift */,
 				B58CE26424F9AE870079C04B /* NSStoryboard+Simplenote.swift */,
 				B5117997242036B0005F8936 /* NSString+Simplenote.swift */,
@@ -1871,6 +1875,7 @@
 				B5F3150924496A970036872D /* TableRowView.swift in Sources */,
 				B5CD5F7E241AC69900D0260F /* NSProcessInfo+Simplenote.swift in Sources */,
 				B59848801BCDB95A005EFBBE /* SPAutomatticTracker.m in Sources */,
+				B5B1CBCD256EE72C0040726C /* NSScrollView+Simplenote.swift in Sources */,
 				37AE49C21FFEB92A00FCB165 /* SPMarkdownParser.m in Sources */,
 				B5CBB05C2419714B0003C271 /* NSAttributedStringToMarkdownConverter.swift in Sources */,
 				B5E96B661BDE732500D707F5 /* LoginWindowController.m in Sources */,
@@ -2006,6 +2011,7 @@
 				B53BF19D24ABDE7C00938C34 /* DateFormatter+Simplenote.swift in Sources */,
 				B58942FB24E5EE8E006EC232 /* NSWindowFrameAutosaveName+Simplenote.swift in Sources */,
 				B53BF1A124AC1FB800938C34 /* Version.swift in Sources */,
+				B5B1CBCE256EE72C0040726C /* NSScrollView+Simplenote.swift in Sources */,
 				B547285D250920CA00D823BA /* URL+Interlink.swift in Sources */,
 				B57CB882244E421400BA7969 /* SPTextField.swift in Sources */,
 				B5F807D02481A2010048CBD7 /* Simperium+Simplenote.swift in Sources */,

--- a/Simplenote/Main.storyboard
+++ b/Simplenote/Main.storyboard
@@ -29,7 +29,7 @@
                                             <color key="backgroundColor" red="1" green="0.0074358092779999996" blue="0.18312235169999999" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                             <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
                                             <tableColumns>
-                                                <tableColumn identifier="NameColumn" width="108" minWidth="40" maxWidth="1000" id="TbY-k2-hUl">
+                                                <tableColumn identifier="Tags Column" width="108" minWidth="40" maxWidth="1000" id="TbY-k2-hUl">
                                                     <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left">
                                                         <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" white="0.33333298560000002" alpha="1" colorSpace="calibratedWhite"/>
@@ -41,9 +41,8 @@
                                                     </textFieldCell>
                                                     <tableColumnResizingMask key="resizingMask" resizeWithTable="YES"/>
                                                     <prototypeCellViews>
-                                                        <tableCellView identifier="SpacerTableViewCell" id="RyL-oL-AZL" userLabel="Spacer" customClass="SpacerTableViewCell" customModule="Simplenote" customModuleProvider="target">
+                                                        <tableCellView identifier="SpacerTableViewCell" translatesAutoresizingMaskIntoConstraints="NO" id="RyL-oL-AZL" userLabel="Spacer" customClass="SpacerTableViewCell" customModule="Simplenote" customModuleProvider="target">
                                                             <rect key="frame" x="10" y="0.0" width="120" height="16"/>
-                                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                             <subviews>
                                                                 <customView translatesAutoresizingMaskIntoConstraints="NO" id="xjr-Tk-HSi">
                                                                     <rect key="frame" x="0.0" y="0.0" width="120" height="16"/>
@@ -59,9 +58,8 @@
                                                                 <constraint firstAttribute="trailing" secondItem="xjr-Tk-HSi" secondAttribute="trailing" id="zC1-EW-2M9"/>
                                                             </constraints>
                                                         </tableCellView>
-                                                        <tableCellView identifier="HeaderTableCellView" id="ftn-CT-UtG" userLabel="Header" customClass="HeaderTableCellView" customModule="Simplenote" customModuleProvider="target">
+                                                        <tableCellView identifier="HeaderTableCellView" translatesAutoresizingMaskIntoConstraints="NO" id="ftn-CT-UtG" userLabel="Header" customClass="HeaderTableCellView" customModule="Simplenote" customModuleProvider="target">
                                                             <rect key="frame" x="10" y="16" width="120" height="27"/>
-                                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                             <subviews>
                                                                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3Gk-Te-s8H">
                                                                     <rect key="frame" x="14" y="6" width="96" height="15"/>
@@ -85,9 +83,8 @@
                                                                 <outlet property="textField" destination="3Gk-Te-s8H" id="4Ax-ix-Pc6"/>
                                                             </connections>
                                                         </tableCellView>
-                                                        <tableCellView identifier="TagTableCellView" id="Nrb-k8-TzG" userLabel="Tag" customClass="TagTableCellView" customModule="Simplenote" customModuleProvider="target">
+                                                        <tableCellView identifier="TagTableCellView" translatesAutoresizingMaskIntoConstraints="NO" id="Nrb-k8-TzG" userLabel="Tag" customClass="TagTableCellView" customModule="Simplenote" customModuleProvider="target">
                                                             <rect key="frame" x="10" y="43" width="120" height="29"/>
-                                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                             <subviews>
                                                                 <stackView distribution="fill" orientation="horizontal" alignment="top" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="EiU-KW-NFn">
                                                                     <rect key="frame" x="16" y="4" width="98" height="21"/>

--- a/Simplenote/Main.storyboard
+++ b/Simplenote/Main.storyboard
@@ -23,13 +23,13 @@
                                     <rect key="frame" x="0.0" y="0.0" width="140" height="618"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
-                                        <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnSelection="YES" multipleSelection="NO" emptySelection="NO" autosaveColumns="NO" rowHeight="29" rowSizeStyle="automatic" viewBased="YES" id="1PS-xY-Vtk" customClass="SPTableView">
+                                        <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" tableStyle="fullWidth" columnSelection="YES" multipleSelection="NO" emptySelection="NO" autosaveColumns="NO" rowHeight="29" rowSizeStyle="automatic" viewBased="YES" id="1PS-xY-Vtk" customClass="SPTableView">
                                             <rect key="frame" x="0.0" y="0.0" width="140" height="556"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <color key="backgroundColor" red="1" green="0.0074358092779999996" blue="0.18312235169999999" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                             <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
                                             <tableColumns>
-                                                <tableColumn identifier="Tags Column" width="108" minWidth="40" maxWidth="1000" id="TbY-k2-hUl">
+                                                <tableColumn identifier="Tags Column" width="128" minWidth="40" maxWidth="1000" id="TbY-k2-hUl">
                                                     <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left">
                                                         <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" white="0.33333298560000002" alpha="1" colorSpace="calibratedWhite"/>
@@ -42,10 +42,10 @@
                                                     <tableColumnResizingMask key="resizingMask" resizeWithTable="YES"/>
                                                     <prototypeCellViews>
                                                         <tableCellView identifier="SpacerTableViewCell" translatesAutoresizingMaskIntoConstraints="NO" id="RyL-oL-AZL" userLabel="Spacer" customClass="SpacerTableViewCell" customModule="Simplenote" customModuleProvider="target">
-                                                            <rect key="frame" x="10" y="0.0" width="120" height="16"/>
+                                                            <rect key="frame" x="0.0" y="0.0" width="140" height="16"/>
                                                             <subviews>
                                                                 <customView translatesAutoresizingMaskIntoConstraints="NO" id="xjr-Tk-HSi">
-                                                                    <rect key="frame" x="0.0" y="0.0" width="120" height="16"/>
+                                                                    <rect key="frame" x="0.0" y="0.0" width="140" height="16"/>
                                                                     <constraints>
                                                                         <constraint firstAttribute="height" constant="16" id="hSU-O1-qCm"/>
                                                                     </constraints>
@@ -59,10 +59,10 @@
                                                             </constraints>
                                                         </tableCellView>
                                                         <tableCellView identifier="HeaderTableCellView" translatesAutoresizingMaskIntoConstraints="NO" id="ftn-CT-UtG" userLabel="Header" customClass="HeaderTableCellView" customModule="Simplenote" customModuleProvider="target">
-                                                            <rect key="frame" x="10" y="16" width="120" height="27"/>
+                                                            <rect key="frame" x="0.0" y="16" width="140" height="27"/>
                                                             <subviews>
                                                                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3Gk-Te-s8H">
-                                                                    <rect key="frame" x="14" y="6" width="96" height="15"/>
+                                                                    <rect key="frame" x="14" y="6" width="116" height="15"/>
                                                                     <textFieldCell key="cell" lineBreakMode="truncatingTail" allowsUndo="NO" sendsActionOnEndEditing="YES" title="Header" placeholderString="" usesSingleLineMode="YES" id="4mI-A4-Nw3">
                                                                         <font key="font" metaFont="cellTitle"/>
                                                                         <color key="textColor" white="0.40000000000000002" alpha="1" colorSpace="calibratedWhite"/>
@@ -84,10 +84,10 @@
                                                             </connections>
                                                         </tableCellView>
                                                         <tableCellView identifier="TagTableCellView" translatesAutoresizingMaskIntoConstraints="NO" id="Nrb-k8-TzG" userLabel="Tag" customClass="TagTableCellView" customModule="Simplenote" customModuleProvider="target">
-                                                            <rect key="frame" x="10" y="43" width="120" height="29"/>
+                                                            <rect key="frame" x="0.0" y="43" width="140" height="29"/>
                                                             <subviews>
                                                                 <stackView distribution="fill" orientation="horizontal" alignment="top" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="EiU-KW-NFn">
-                                                                    <rect key="frame" x="16" y="4" width="98" height="21"/>
+                                                                    <rect key="frame" x="16" y="4" width="118" height="21"/>
                                                                     <subviews>
                                                                         <imageView hidden="YES" translatesAutoresizingMaskIntoConstraints="NO" id="EQa-wT-h4H">
                                                                             <rect key="frame" x="0.0" y="1" width="20" height="20"/>
@@ -98,7 +98,7 @@
                                                                             <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" id="ljx-Ru-cW4"/>
                                                                         </imageView>
                                                                         <textField horizontalHuggingPriority="249" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="NGW-Hf-ZuM" customClass="SPTextField" customModule="Simplenote" customModuleProvider="target">
-                                                                            <rect key="frame" x="-2" y="1" width="102" height="20"/>
+                                                                            <rect key="frame" x="-2" y="1" width="122" height="20"/>
                                                                             <constraints>
                                                                                 <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="20" id="9Yn-WV-dra"/>
                                                                             </constraints>

--- a/Simplenote/Main.storyboard
+++ b/Simplenote/Main.storyboard
@@ -39,7 +39,7 @@
                                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                     </textFieldCell>
-                                                    <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
+                                                    <tableColumnResizingMask key="resizingMask" resizeWithTable="YES"/>
                                                     <prototypeCellViews>
                                                         <tableCellView identifier="SpacerTableViewCell" id="RyL-oL-AZL" userLabel="Spacer" customClass="SpacerTableViewCell" customModule="Simplenote" customModuleProvider="target">
                                                             <rect key="frame" x="10" y="0.0" width="120" height="16"/>

--- a/Simplenote/NSScrollView+Simplenote.swift
+++ b/Simplenote/NSScrollView+Simplenote.swift
@@ -1,0 +1,15 @@
+import Foundation
+import AppKit
+
+
+// MARK: - NSScrollView + Simplenote
+//
+extension NSScrollView {
+
+    @objc
+    func scrollToTop() {
+        let yOffset = contentView.bounds.origin.y - contentView.contentInsets.top
+        let target = NSPoint(x: .zero, y: yOffset)
+        documentView?.scroll(target)
+    }
+}

--- a/Simplenote/NSScrollView+Simplenote.swift
+++ b/Simplenote/NSScrollView+Simplenote.swift
@@ -8,8 +8,7 @@ extension NSScrollView {
 
     @objc
     func scrollToTop() {
-        let yOffset = contentView.bounds.origin.y - contentView.contentInsets.top
-        let target = NSPoint(x: .zero, y: yOffset)
+        let target = NSPoint(x: .zero, y: contentView.contentInsets.top * -1)
         documentView?.scroll(target)
     }
 }

--- a/Simplenote/NoteEditorViewController.m
+++ b/Simplenote/NoteEditorViewController.m
@@ -193,7 +193,6 @@ static NSString * const SPMarkdownPreferencesKey        = @"kMarkdownPreferences
     // Issue #393: `self.note` might be populated, but it's simperiumKey inaccessible
     NSString *simperiumKey = self.note.simperiumKey;
     if (simperiumKey != nil) {
-        // Save the scrollPosition of the current note
         NSValue *positionValue = [NSValue valueWithPoint:self.scrollView.contentView.bounds.origin];
         self.noteScrollPositions[simperiumKey] = positionValue;
     }
@@ -221,19 +220,12 @@ static NSString * const SPMarkdownPreferencesKey        = @"kMarkdownPreferences
     }
 
     [self.storage refreshStyleWithMarkdownEnabled:self.note.markdown];
-    
-    if ([self.noteScrollPositions objectForKey:selectedNote.simperiumKey] != nil) {
-        // Restore scroll position for note if it was saved previously in this session
-        double scrollDelay = 0.01;
-        dispatch_time_t popTime = dispatch_time(DISPATCH_TIME_NOW, scrollDelay * NSEC_PER_SEC);
-        // #hack! Scroll after a very slight delay, to give the editor time to load the content
-        dispatch_after(popTime, dispatch_get_main_queue(), ^(void) {
-            NSPoint scrollPoint = [[self.noteScrollPositions objectForKey:selectedNote.simperiumKey] pointValue];
-            [[self.scrollView documentView] scrollPoint:scrollPoint];
-        });
+
+    NSValue *lastKnownScrollOffset = self.noteScrollPositions[selectedNote.simperiumKey];
+    if (lastKnownScrollOffset != nil) {
+        [self.scrollView.documentView scrollPoint:lastKnownScrollOffset.pointValue];
     } else {
-        // Otherwise we'll scroll to the top!
-        [[self.scrollView documentView] scrollPoint:NSMakePoint(0, 0)];
+        [self.scrollView scrollToTop];
     }
 }
 


### PR DESCRIPTION
### Fix
In this PR we're patching up calculations of the Initial Scroll Offset, so that it accounts for (the new) Insets.

cc @eshurakov (Thank you!!)
Ref. #718 

### Test
1. Launch the app
2. Click over any long note

- [ ] Verify the initial Content Offset is at the very top
- [ ] Verify that the editor remembers the last seen Offset per note (try switching back and forth between notes!)

### Release
These changes do not require release notes.
