### PR TITLE
Implements SplitItemMetrics

### DIFF
--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -274,6 +274,8 @@
 		B5A8919A231ECB3C0007EDCB /* INSTALL.markdown in Resources */ = {isa = PBXBuildFile; fileRef = B5A89191231ECB3C0007EDCB /* INSTALL.markdown */; };
 		B5A8919C231ECB3D0007EDCB /* Sparkle.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B5A89194231ECB3C0007EDCB /* Sparkle.framework */; };
 		B5A891A1231ECB710007EDCB /* Sparkle.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = B5A89194231ECB3C0007EDCB /* Sparkle.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		B5A9FE272576C40B0084F176 /* SplitItemMetrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A9FE262576C40B0084F176 /* SplitItemMetrics.swift */; };
+		B5A9FE282576C40B0084F176 /* SplitItemMetrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A9FE262576C40B0084F176 /* SplitItemMetrics.swift */; };
 		B5ACE42E24785D8C00AB02C7 /* BackgroundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5ACE42D24785D8C00AB02C7 /* BackgroundView.swift */; };
 		B5ACE42F24785D8C00AB02C7 /* BackgroundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5ACE42D24785D8C00AB02C7 /* BackgroundView.swift */; };
 		B5AF76C724A3F00600B7D530 /* TagListState.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5AF76C624A3F00600B7D530 /* TagListState.swift */; };
@@ -633,6 +635,7 @@
 		B5A89190231ECB3C0007EDCB /* org.sparkle-project.InstallerLauncher.xpc */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.xpc-service"; path = "org.sparkle-project.InstallerLauncher.xpc"; sourceTree = "<group>"; };
 		B5A89191231ECB3C0007EDCB /* INSTALL.markdown */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = INSTALL.markdown; sourceTree = "<group>"; };
 		B5A89194231ECB3C0007EDCB /* Sparkle.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Sparkle.framework; sourceTree = "<group>"; };
+		B5A9FE262576C40B0084F176 /* SplitItemMetrics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplitItemMetrics.swift; sourceTree = "<group>"; };
 		B5ACE42D24785D8C00AB02C7 /* BackgroundView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundView.swift; sourceTree = "<group>"; };
 		B5AF76C624A3F00600B7D530 /* TagListState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagListState.swift; sourceTree = "<group>"; };
 		B5AF76CA24A3F27E00B7D530 /* TagListRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagListRow.swift; sourceTree = "<group>"; };
@@ -1298,6 +1301,7 @@
 				B5AF76C924A3F06D00B7D530 /* Tags */,
 				B5D6833324ACFA79004AFF1B /* Versions */,
 				B586C061245CCD35009508EC /* SplitViewController.swift */,
+				B5A9FE262576C40B0084F176 /* SplitItemMetrics.swift */,
 				B529F7B424586D8700B168F1 /* MarkdownViewController.swift */,
 				B529F7B724586DF800B168F1 /* MarkdownViewController.xib */,
 				B5C7DD3F243E4A7D00BEE354 /* CollaborateViewController.swift */,
@@ -1856,6 +1860,7 @@
 				46EF5198177C4ECC00A139E0 /* SPApplication.m in Sources */,
 				B51E9FE122E615FA004F16B4 /* SPExporter.swift in Sources */,
 				46CF73071782C6B200FC2B5C /* TagListViewController.m in Sources */,
+				B5A9FE272576C40B0084F176 /* SplitItemMetrics.swift in Sources */,
 				B511799B242036BD005F8936 /* NSTextView+Simplenote.swift in Sources */,
 				B5ACE42E24785D8C00AB02C7 /* BackgroundView.swift in Sources */,
 				B5DD0F912476309000C8DD41 /* NoteTableCellView.swift in Sources */,
@@ -1918,6 +1923,7 @@
 				466FFEAC17CC10A800399652 /* Simplenote.xcdatamodeld in Sources */,
 				466FFEAD17CC10A800399652 /* NSString+Condensing.m in Sources */,
 				B5009938242130F70037A431 /* UnicodeScalar+Simplenote.swift in Sources */,
+				B5A9FE282576C40B0084F176 /* SplitItemMetrics.swift in Sources */,
 				B58BBD3E2523FF160025135F /* AutocompleteWindow.swift in Sources */,
 				B5985AD6242950B40044EDE9 /* NSColor+Simplenote.swift in Sources */,
 				B535014C249D5908003837C8 /* HorizontalScrollView.swift in Sources */,

--- a/Simplenote/NoteEditorViewController+Swift.swift
+++ b/Simplenote/NoteEditorViewController+Swift.swift
@@ -35,8 +35,8 @@ extension NoteEditorViewController {
 
     @objc
     func refreshScrollInsets() {
-        clipView.contentInsets.top = Settings.defaultTopInset
-        scrollView.scrollerInsets.top = Settings.defaultTopInset
+        clipView.contentInsets.top = SplitItemMetrics.editorTopInset
+        scrollView.scrollerInsets.top = SplitItemMetrics.editorTopInset
     }
 }
 
@@ -490,7 +490,7 @@ extension NoteEditorViewController {
     func refreshHeaderState() {
         let newAlpha = alphaForHeader
         headerEffectView.alphaValue = newAlpha
-        headerEffectView.state = newAlpha > Settings.activeAlphaThreshold ? .active : .inactive
+        headerEffectView.state = newAlpha > SplitItemMetrics.headerAlphaActiveThreshold ? .active : .inactive
     }
 
     private var alphaForHeader: CGFloat {
@@ -499,7 +499,7 @@ extension NoteEditorViewController {
         }
 
         let contentOffSetY = scrollView.documentVisibleRect.origin.y + clipView.contentInsets.top
-        return min(max(contentOffSetY / Settings.maximumAlphaGradientOffset, 0), 1)
+        return min(max(contentOffSetY / SplitItemMetrics.headerMaximumAlphaGradientOffset, 0), 1)
     }
 }
 
@@ -740,9 +740,6 @@ private extension NoteEditorViewController {
 // MARK: - Settings
 //
 private enum Settings {
-    static let defaultTopInset = CGFloat(48)
-    static let maximumAlphaGradientOffset = CGFloat(14)
-    static let activeAlphaThreshold = CGFloat(0.5)
 
     static var searchFieldPlaceholderString: NSAttributedString {
         let text = NSLocalizedString("Search", comment: "Search Field Placeholder")

--- a/Simplenote/NoteListViewController+Swift.swift
+++ b/Simplenote/NoteListViewController+Swift.swift
@@ -30,8 +30,8 @@ extension NoteListViewController {
     ///
     @objc
     func refreshScrollInsets() {
-        clipView.contentInsets.top = Settings.defaultTopInset
-        scrollView.scrollerInsets.top = Settings.defaultTopInset
+        clipView.contentInsets.top = SplitItemMetrics.sidebarTopInset
+        scrollView.scrollerInsets.top = SplitItemMetrics.sidebarTopInset
     }
 
     /// Ensures only the actions that are valid can be performed
@@ -163,12 +163,12 @@ extension NoteListViewController {
     func refreshHeaderState() {
         let newAlpha = alphaForHeader
         headerEffectView.alphaValue = newAlpha
-        headerEffectView.state = newAlpha > Settings.activeAlphaThreshold ? .active : .inactive
+        headerEffectView.state = newAlpha > SplitItemMetrics.headerAlphaActiveThreshold ? .active : .inactive
     }
 
     private var alphaForHeader: CGFloat {
         let contentOffSetY = scrollView.documentVisibleRect.origin.y + clipView.contentInsets.top
-        return min(max(contentOffSetY / Settings.maximumAlphaGradientOffset, 0), 1)
+        return min(max(contentOffSetY / SplitItemMetrics.headerMaximumAlphaGradientOffset, 0), 1)
     }
 }
 
@@ -404,13 +404,4 @@ extension NoteListViewController {
 
         arrayController.setSelectionIndex(previouslySelectedIndex)
     }
-}
-
-
-// MARK: - Settings!
-//
-private enum Settings {
-    static let defaultTopInset = CGFloat(62)
-    static let maximumAlphaGradientOffset = CGFloat(14)
-    static let activeAlphaThreshold = CGFloat(0.5)
 }

--- a/Simplenote/SplitItemMetrics.swift
+++ b/Simplenote/SplitItemMetrics.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+
+// MARK: - SplitItemMetrics
+//
+enum SplitItemMetrics {
+
+    /// Sidebar Insets
+    private static let sidebarTopInsetLegacy = CGFloat(52)
+    private static let sidebarTopInsetBigSur = CGFloat(62)
+
+    /// Editor Insets
+    private static let editorTopInsetLegacy = CGFloat(38)
+    private static let editorTopInsetBigSur = CGFloat(48)
+
+    
+    /// Sidebar Insets: Tags + Notes Lists
+    ///
+    static var sidebarTopInset: CGFloat {
+        guard #available(macOS 11, *) else {
+            return sidebarTopInsetLegacy
+        }
+
+        return sidebarTopInsetBigSur
+    }
+
+    /// Editor Insets
+    ///
+    static var editorTopInset: CGFloat {
+        guard #available(macOS 11, *) else {
+            return editorTopInsetLegacy
+        }
+
+        return editorTopInsetBigSur
+    }
+
+    /// Header Alpha Threshold: Alpha Visibility threshold after which the Blur should be enabled
+    ///
+    static let headerAlphaActiveThreshold = CGFloat(0.5)
+
+    /// Header: Maximum Offset after which alpha should be set to (1.0)
+    ///
+    static let headerMaximumAlphaGradientOffset = CGFloat(14)
+}

--- a/Simplenote/TagListViewController+Swift.swift
+++ b/Simplenote/TagListViewController+Swift.swift
@@ -24,7 +24,7 @@ extension TagListViewController {
     ///
     @objc
     func refreshExtendedContentInsets() {
-        clipView.contentInsets.top = Settings.defaultTopInset
+        clipView.contentInsets.top = SplitItemMetrics.sidebarTopInset
     }
 
     /// Regenerates the Internal List State
@@ -78,7 +78,7 @@ extension TagListViewController {
 
     private var alphaForHeaderSeparatorView: CGFloat {
         let absoluteOffSetY = scrollView.documentVisibleRect.origin.y + clipView.contentInsets.top
-        return min(max(absoluteOffSetY / Settings.maximumAlphaGradientOffset, 0), 1)
+        return min(max(absoluteOffSetY / SplitItemMetrics.headerMaximumAlphaGradientOffset, 0), 1)
     }
 }
 
@@ -227,13 +227,4 @@ extension TagListViewController: SPTextFieldDelegate {
     func controlAcceptsFirstResponder(_ control: NSControl) -> Bool {
         !menuShowing
     }
-}
-
-
-// MARK: - Settings!
-//
-private enum Settings {
-    static let defaultTopInset = CGFloat(62)
-    static let maximumAlphaGradientOffset = CGFloat(30)
-    static let titlebarHeight = CGFloat(22)
 }


### PR DESCRIPTION
### Fix
In this PR we're bringing back the legacy Top Insets for the Tags and Notes Lists.

Ref. #718 

cc @eshurakov (thank you!!!)
cc @SylvesterWilmott Just checking if we really really want this behavior?

### Test
1. Launch Simplenote in a Catalina or Mojave system
2. Log into your account

- [x] Verify the first Notes List row is right below the Titlebar edge (there should not be top padding!)
- [ ] Verify the app hasn't changed in Big Sur

### Release
These changes do not require release notes.

### Screenshots

Catalina Before|Catalina After
-|-
<img width="300" alt="Catalina Old" src="https://user-images.githubusercontent.com/1195260/100785584-9ed6a700-33ef-11eb-8f91-f0288afc9cee.png">|<img width="300" alt="Catalina New" src="https://user-images.githubusercontent.com/1195260/100785592-a1d19780-33ef-11eb-8cb3-1bf01e958780.png">

**Delta = Top Insets at launch!**