### PR TITLE
Preventing Title Overlap

### DIFF
--- a/Simplenote/Main.storyboard
+++ b/Simplenote/Main.storyboard
@@ -390,7 +390,7 @@
                                     <constraint firstItem="LGw-AF-2MK" firstAttribute="centerY" secondItem="dMC-MU-RmS" secondAttribute="centerY" id="EAu-95-CpX"/>
                                     <constraint firstAttribute="trailing" secondItem="LGw-AF-2MK" secondAttribute="trailing" constant="16" id="OO0-gy-TNv"/>
                                     <constraint firstItem="LGw-AF-2MK" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="sHv-fV-cSL" secondAttribute="trailing" constant="16" id="Q6T-vJ-qmu"/>
-                                    <constraint firstItem="sHv-fV-cSL" firstAttribute="leading" secondItem="dMC-MU-RmS" secondAttribute="leading" constant="16" id="rhf-28-XBu"/>
+                                    <constraint firstItem="sHv-fV-cSL" firstAttribute="leading" secondItem="dMC-MU-RmS" secondAttribute="leading" priority="249" constant="16" id="rhf-28-XBu"/>
                                 </constraints>
                             </customView>
                             <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="2I0-KH-uBu">

--- a/Simplenote/Main.storyboard
+++ b/Simplenote/Main.storyboard
@@ -362,7 +362,7 @@
                             <customView translatesAutoresizingMaskIntoConstraints="NO" id="dMC-MU-RmS" userLabel="Header View">
                                 <rect key="frame" x="0.0" y="566" width="294" height="52"/>
                                 <subviews>
-                                    <textField horizontalHuggingPriority="1000" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="sHv-fV-cSL">
+                                    <textField horizontalHuggingPriority="1000" verticalHuggingPriority="750" horizontalCompressionResistancePriority="245" translatesAutoresizingMaskIntoConstraints="NO" id="sHv-fV-cSL">
                                         <rect key="frame" x="14" y="17" width="39" height="19"/>
                                         <textFieldCell key="cell" lineBreakMode="truncatingTail" title="Title" id="VNw-0O-CIA">
                                             <font key="font" metaFont="systemBold" size="16"/>

--- a/Simplenote/Main.storyboard
+++ b/Simplenote/Main.storyboard
@@ -389,7 +389,7 @@
                                     <constraint firstItem="sHv-fV-cSL" firstAttribute="centerY" secondItem="dMC-MU-RmS" secondAttribute="centerY" id="7yr-5F-Pa7"/>
                                     <constraint firstItem="LGw-AF-2MK" firstAttribute="centerY" secondItem="dMC-MU-RmS" secondAttribute="centerY" id="EAu-95-CpX"/>
                                     <constraint firstAttribute="trailing" secondItem="LGw-AF-2MK" secondAttribute="trailing" constant="16" id="OO0-gy-TNv"/>
-                                    <constraint firstItem="LGw-AF-2MK" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="sHv-fV-cSL" secondAttribute="trailing" constant="16" id="Q6T-vJ-qmu"/>
+                                    <constraint firstItem="LGw-AF-2MK" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="sHv-fV-cSL" secondAttribute="trailing" constant="8" id="Q6T-vJ-qmu"/>
                                     <constraint firstItem="sHv-fV-cSL" firstAttribute="leading" secondItem="dMC-MU-RmS" secondAttribute="leading" priority="249" constant="16" id="rhf-28-XBu"/>
                                 </constraints>
                             </customView>

--- a/Simplenote/NSWindow+Simplenote.swift
+++ b/Simplenote/NSWindow+Simplenote.swift
@@ -5,13 +5,13 @@ import Foundation
 //
 extension NSWindow {
 
-    ///
+    /// Indicates if the receiver is in Fullscreen
     ///
     var isFullscreen: Bool {
         styleMask.contains(.fullScreen)
     }
 
-    ///
+    /// Indicates if we're in RTL mode
     ///
     var isRTL: Bool {
         windowTitlebarLayoutDirection == .rightToLeft

--- a/Simplenote/NSWindow+Simplenote.swift
+++ b/Simplenote/NSWindow+Simplenote.swift
@@ -5,12 +5,16 @@ import Foundation
 //
 extension NSWindow {
 
-    /// Returns the receiver's TitleBar Height
-    /// - Important: The SDK has a private API named `titlebarHeight`, and we `actually MUST` to namespace this..
     ///
-    @objc
-    var simplenoteTitlebarHeight: CGFloat {
-        frame.height - contentLayoutRect.height
+    ///
+    var isFullscreen: Bool {
+        styleMask.contains(.fullScreen)
+    }
+
+    ///
+    ///
+    var isRTL: Bool {
+        windowTitlebarLayoutDirection == .rightToLeft
     }
 
     /// Returns the Bounding Rect for the Window's Semaphore (Close / Minimize / Zoom)

--- a/Simplenote/NSWindow+Simplenote.swift
+++ b/Simplenote/NSWindow+Simplenote.swift
@@ -12,4 +12,13 @@ extension NSWindow {
     var simplenoteTitlebarHeight: CGFloat {
         frame.height - contentLayoutRect.height
     }
+
+    /// Returns the MaximumLocation.x for the Window's Semaphore (Close / Minimize / Zoom)
+    ///
+    var semaphoreMaximumLocationX: CGFloat? {
+        let types: [NSWindow.ButtonType] = [.closeButton, .miniaturizeButton, .zoomButton]
+        let locations = types.compactMap { standardWindowButton($0)?.frame.maxX }
+
+        return locations.max()
+    }
 }

--- a/Simplenote/NSWindow+Simplenote.swift
+++ b/Simplenote/NSWindow+Simplenote.swift
@@ -13,12 +13,28 @@ extension NSWindow {
         frame.height - contentLayoutRect.height
     }
 
-    /// Returns the MaximumLocation.x for the Window's Semaphore (Close / Minimize / Zoom)
+    /// Returns the Bounding Rect for the Window's Semaphore (Close / Minimize / Zoom)
     ///
-    var semaphoreMaximumLocationX: CGFloat? {
+    var semaphoreBoundingRect: CGRect? {
         let types: [NSWindow.ButtonType] = [.closeButton, .miniaturizeButton, .zoomButton]
-        let locations = types.compactMap { standardWindowButton($0)?.frame.maxX }
+        var bounds: CGRect?
 
-        return locations.max()
+        for type in types {
+            guard let buttonFrame = standardWindowButton(type)?.frame else {
+                continue
+            }
+
+            guard let oldBounds = bounds else {
+                bounds = buttonFrame
+                continue
+            }
+
+            var newBounds = oldBounds.union(buttonFrame)
+            newBounds.origin.y = min(newBounds.origin.y, buttonFrame.origin.y)
+            newBounds.origin.x = min(newBounds.origin.x, buttonFrame.origin.x)
+            bounds = newBounds
+        }
+
+        return bounds
     }
 }

--- a/Simplenote/NoteListViewController+Swift.swift
+++ b/Simplenote/NoteListViewController+Swift.swift
@@ -63,6 +63,47 @@ extension NoteListViewController {
 }
 
 
+// MARK: - Layout
+//
+extension NoteListViewController {
+
+    open override func updateViewConstraints() {
+        if mustUpdateSemaphoreLeadingConstraint {
+            updateSemaphoreLeadingConstraint()
+        }
+        super.updateViewConstraints()
+    }
+
+    var mustUpdateSemaphoreLeadingConstraint: Bool {
+        titleSemaphoreLeadingConstraint == nil
+    }
+
+    /// # Semaphore Leading:
+    /// We REALLY need to avoid collisions between the TitleLabel and the Window's Semaphore (Zoom / Close buttons).
+    ///
+    /// - Important:
+    ///     `priority` is set to `defaultLow` (250) for the constraint between TitleLabel and Window.contentLayoutGuide, whereas the regular `leading` is set to (249).
+    ///     This way we avoid choppy NSSplitView animations (using a higher priority interfers with AppKit internals!)
+    ///
+    func updateSemaphoreLeadingConstraint() {
+        guard let window = view.window,
+              let semaphoreMaxX = window.semaphoreMaximumLocationX,
+              let contentLayoutGuide = window.contentLayoutGuide as? NSLayoutGuide
+        else {
+            return
+        }
+
+        let padding = semaphoreMaxX + SplitItemMetrics.toolbarSemaphorePaddingX
+
+        let newConstraint = titleLabel.leadingAnchor.constraint(greaterThanOrEqualTo: contentLayoutGuide.leadingAnchor, constant: padding)
+        newConstraint.priority = .defaultLow
+        newConstraint.isActive = true
+
+        titleSemaphoreLeadingConstraint = newConstraint
+     }
+}
+
+
 // MARK: - State
 //
 extension NoteListViewController {

--- a/Simplenote/NoteListViewController+Swift.swift
+++ b/Simplenote/NoteListViewController+Swift.swift
@@ -76,6 +76,8 @@ extension NoteListViewController {
         super.updateViewConstraints()
     }
 
+    /// Indicates if the Semaphore Leading hasn't been initialized
+    ///
     private var mustSetupSemaphoreLeadingConstraint: Bool {
         titleSemaphoreLeadingConstraint == nil
     }
@@ -96,16 +98,26 @@ extension NoteListViewController {
         newConstraint.priority = .defaultLow
         newConstraint.isActive = true
         titleSemaphoreLeadingConstraint = newConstraint
-     }
+    }
 
+    /// Refreshes the Semaphore Leading
+    ///
     private func refreshSemaphoreLeadingConstant() {
-        guard let window = view.window, let semaphoreBounds = window.semaphoreBoundingRect else {
-            return
+        titleSemaphoreLeadingConstraint?.constant = semaphorePaddingX + SplitItemMetrics.toolbarSemaphorePaddingX
+    }
+
+    /// Returns the Horizontal Padding required in order to prevent overlaps between our controls and the Window's Semaphore
+    /// - Note:
+    ///     - Fullscreen: zero padding
+    ///     - LTR: Semaphore's Maximum horizontal position
+    ///     - RTL: Window's Width minus the Semaphore's Minimum horizontal location
+    ///
+    private var semaphorePaddingX: CGFloat {
+        guard let window = view.window, let semaphoreBounds = window.semaphoreBoundingRect, window.isFullscreen == false else {
+            return .zero
         }
 
-        let isLTR = window.windowTitlebarLayoutDirection == .leftToRight
-
-        titleSemaphoreLeadingConstraint?.constant = padding + SplitItemMetrics.toolbarSemaphorePaddingX
+        return window.isRTL ? (window.frame.width - semaphoreBounds.minX) : semaphoreBounds.maxX
     }
 }
 

--- a/Simplenote/NoteListViewController.h
+++ b/Simplenote/NoteListViewController.h
@@ -30,6 +30,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, readonly) IBOutlet NSButton               *addNoteButton;
 @property (nonatomic, strong, readonly) IBOutlet NSMenu                 *noteListMenu;
 @property (nonatomic, strong, readonly) IBOutlet NSMenu                 *trashListMenu;
+@property (nonatomic, strong, nullable) NSLayoutConstraint              *titleSemaphoreLeadingConstraint;
 
 @property (nonatomic, assign, readonly) BOOL                            viewingTrash;
 @property (nonatomic, strong, nullable) NSString                        *searchKeyword;

--- a/Simplenote/NoteListViewController.m
+++ b/Simplenote/NoteListViewController.m
@@ -83,6 +83,7 @@
     [self setupProgressIndicator];
     [self setupTableView];
     [self startListeningToScrollNotifications];
+    [self startListeningToWindowNotifications];
 }
 
 - (void)viewWillAppear

--- a/Simplenote/SplitItemMetrics.swift
+++ b/Simplenote/SplitItemMetrics.swift
@@ -41,4 +41,8 @@ enum SplitItemMetrics {
     /// Header: Maximum Offset after which alpha should be set to (1.0)
     ///
     static let headerMaximumAlphaGradientOffset = CGFloat(14)
+
+    /// Spacing required between the Window's Semaphore (Close / Minimize / Maximize) and the first View component
+    ///
+    static let toolbarSemaphorePaddingX = CGFloat(16)
 }


### PR DESCRIPTION
### Fix
In this PR we're adding a new Layout Constraint that prevents the **Notes List Title** from overlapping with the Window's semaphore (Close / Minimize / Zoom buttons).

@eshurakov Almost there!! Thanks in advance!!

Ref. #718

### Test: LTR
1. Launch the app in **Left to Right** mode

- [x] Verify the Notes List title looks great when the three panels are visible (Tags List / Notes List / Editor)
- [x] Verify that when the Tags List is closed, the Notes List title stops sliding as soon as the Window Semaphore is reached
- [x] Verify that going into fullscreen mode causes the Title to reach the edge of the screen (the buttons aren't really visible!)

### Test: RTL
1. Launch the app in **Right to Left** mode

- [x] Verify that collapsing the Tags List causes the Notes List title to avoid the Window Semaphore area
- [x] Verify the Notes List title has no padding when you go fullscreen

### Release
These changes do not require release notes.

### Screenshots

LTR|RTL
-|-
<img width="300" alt="LTR" src="https://user-images.githubusercontent.com/1195260/100933804-a28c2b80-34cc-11eb-9a63-8b5b996235b9.png"> | <img width="300" alt="RTL" src="https://user-images.githubusercontent.com/1195260/100933814-a61fb280-34cc-11eb-827c-d6575767a605.png">
