### PR TITLE
Adds missing Search Action

### DIFF
--- a/Simplenote/Main.storyboard
+++ b/Simplenote/Main.storyboard
@@ -659,6 +659,7 @@
                                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                 </searchFieldCell>
                                                 <connections>
+                                                    <action selector="performSearch:" target="owM-kh-Bm6" id="m0W-x6-X1K"/>
                                                     <outlet property="delegate" destination="owM-kh-Bm6" id="PeJ-VQ-DId"/>
                                                 </connections>
                                             </searchField>


### PR DESCRIPTION
### Fix
In this PR we're rewiring the Search Action, which got broken in a recent PR (2.5 / the bug didn't ship!)

### Test
1. Log into your account
2. Click over the top right Search Bar
3. Type any keyword

- [x] Verify the Notes List gets filtered accordingly

### Release
These changes do not require release notes.
