### PR TITLE
Fix for archive failure

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org' do
   gem 'rake'
-  gem 'cocoapods', '~> 1.8'
+  gem 'cocoapods', '~> 1.10'
   gem 'cocoapods-repo-update', '~> 0.0.3'
   gem 'xcpretty-travis-formatter'
   gem 'octokit', "~> 4.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,10 @@
 GIT
   remote: https://github.com/wordpress-mobile/release-toolkit
-  revision: dd4dd1b1af753f7369f08715343d031be09a2c27
-  tag: 0.9.14
+  revision: b7531404002a5b09aba4af2e123b9ac8a55fa1de
+  branch: bump-active-support
   specs:
-    fastlane-plugin-wpmreleasetoolkit (0.9.14)
-      activesupport (~> 4)
+    fastlane-plugin-wpmreleasetoolkit (0.10.0)
+      activesupport (~> 5)
       bigdecimal (~> 1.4)
       chroma (= 0.2.0)
       diffy (~> 3.3)
@@ -20,11 +20,11 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    CFPropertyList (3.0.2)
-    activesupport (4.2.11.3)
-      i18n (~> 0.7)
+    CFPropertyList (3.0.3)
+    activesupport (5.2.4.4)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
       minitest (~> 5.1)
-      thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
@@ -52,15 +52,14 @@ GEM
     bigdecimal (1.4.4)
     chroma (0.2.0)
     claide (1.0.3)
-    cocoapods (1.9.3)
-      activesupport (>= 4.0.2, < 5)
+    cocoapods (1.10.0)
+      addressable (~> 2.6)
       claide (>= 1.0.2, < 2.0)
-      cocoapods-core (= 1.9.3)
+      cocoapods-core (= 1.10.0)
       cocoapods-deintegrate (>= 1.0.3, < 2.0)
-      cocoapods-downloader (>= 1.2.2, < 2.0)
+      cocoapods-downloader (>= 1.4.0, < 2.0)
       cocoapods-plugins (>= 1.0.0, < 2.0)
       cocoapods-search (>= 1.0.0, < 2.0)
-      cocoapods-stats (>= 1.0.0, < 2.0)
       cocoapods-trunk (>= 1.4.0, < 2.0)
       cocoapods-try (>= 1.1.0, < 2.0)
       colored2 (~> 3.1)
@@ -70,14 +69,16 @@ GEM
       molinillo (~> 0.6.6)
       nap (~> 1.0)
       ruby-macho (~> 1.4)
-      xcodeproj (>= 1.14.0, < 2.0)
-    cocoapods-core (1.9.3)
-      activesupport (>= 4.0.2, < 6)
+      xcodeproj (>= 1.19.0, < 2.0)
+    cocoapods-core (1.10.0)
+      activesupport (> 5.0, < 6)
+      addressable (~> 2.6)
       algoliasearch (~> 1.0)
       concurrent-ruby (~> 1.1)
       fuzzy_match (~> 2.0.4)
       nap (~> 1.0)
       netrc (~> 0.11)
+      public_suffix
       typhoeus (~> 1.0)
     cocoapods-deintegrate (1.0.4)
     cocoapods-downloader (1.4.0)
@@ -86,7 +87,6 @@ GEM
     cocoapods-repo-update (0.0.4)
       cocoapods (~> 1.0, >= 1.3.0)
     cocoapods-search (1.0.0)
-    cocoapods-stats (1.1.0)
     cocoapods-trunk (1.5.0)
       nap (>= 0.8, < 2.0)
       netrc (~> 0.11)
@@ -192,7 +192,7 @@ GEM
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     httpclient (2.8.3)
-    i18n (0.9.5)
+    i18n (1.8.5)
       concurrent-ruby (~> 1.0)
     jmespath (1.4.0)
     json (2.3.1)
@@ -217,13 +217,13 @@ GEM
     octokit (4.18.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
-    oj (3.10.14)
+    oj (3.10.16)
     optimist (3.0.1)
     options (2.3.2)
     os (1.1.1)
-    parallel (1.19.2)
+    parallel (1.20.1)
     plist (3.5.0)
-    progress_bar (1.3.1)
+    progress_bar (1.3.3)
       highline (>= 1.6, < 3)
       options (~> 2.3.0)
     public_suffix (4.0.6)
@@ -285,7 +285,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  cocoapods (~> 1.8)!
+  cocoapods (~> 1.10)!
   cocoapods-repo-update (~> 0.0.3)!
   dotenv!
   fastlane (~> 2)!

--- a/Podfile
+++ b/Podfile
@@ -15,7 +15,7 @@ abstract_target 'Automattic' do
 
   # Automattic Shared
   #
-  pod 'Automattic-Tracks-iOS', '~> 0.6'
+  pod 'Automattic-Tracks-iOS', git: 'https://github.com/Automattic/Automattic-Tracks-iOS', branch: 'switch-back-to-sodium-trunk'
   pod 'Simperium-OSX', '1.1'
 
   # Main Target

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -2,16 +2,16 @@ PODS:
   - Automattic-Tracks-iOS (0.6.0):
     - CocoaLumberjack (~> 3)
     - Reachability (~> 3)
-    - Sentry (~> 4)
-    - Sodium-Fork (= 0.8.2)
+    - Sentry (~> 5)
+    - Sodium (~> 0.9)
     - UIDeviceIdentifier (~> 1)
   - CocoaLumberjack (3.7.0):
     - CocoaLumberjack/Core (= 3.7.0)
   - CocoaLumberjack/Core (3.7.0)
   - Reachability (3.2)
-  - Sentry (4.5.0):
-    - Sentry/Core (= 4.5.0)
-  - Sentry/Core (4.5.0)
+  - Sentry (5.2.2):
+    - Sentry/Core (= 5.2.2)
+  - Sentry/Core (5.2.2)
   - Simperium-OSX (1.1.0):
     - Simperium-OSX/DiffMatchPach (= 1.1.0)
     - Simperium-OSX/JRSwizzle (= 1.1.0)
@@ -23,29 +23,38 @@ PODS:
   - Simperium-OSX/SocketRocket (1.1.0)
   - Simperium-OSX/SPReachability (1.1.0)
   - Simperium-OSX/SSKeychain (1.1.0)
-  - Sodium-Fork (0.8.2)
+  - Sodium (0.9.0)
 
 DEPENDENCIES:
-  - Automattic-Tracks-iOS (~> 0.6)
+  - Automattic-Tracks-iOS (from `https://github.com/Automattic/Automattic-Tracks-iOS`, branch `switch-back-to-sodium-trunk`)
   - Simperium-OSX (= 1.1)
 
 SPEC REPOS:
   trunk:
-    - Automattic-Tracks-iOS
     - CocoaLumberjack
     - Reachability
     - Sentry
     - Simperium-OSX
-    - Sodium-Fork
+    - Sodium
+
+EXTERNAL SOURCES:
+  Automattic-Tracks-iOS:
+    :branch: switch-back-to-sodium-trunk
+    :git: https://github.com/Automattic/Automattic-Tracks-iOS
+
+CHECKOUT OPTIONS:
+  Automattic-Tracks-iOS:
+    :commit: 8d710e62a6ac2b27dbc80e8fb83652bdabb86698
+    :git: https://github.com/Automattic/Automattic-Tracks-iOS
 
 SPEC CHECKSUMS:
-  Automattic-Tracks-iOS: c525679cbf91ac8bcbcbed01bdaa564867173182
+  Automattic-Tracks-iOS: aabe126ab03ac9fdf3af812062ad3964acb9b770
   CocoaLumberjack: e8955b9d337ac307103b0a34fd141c32f27e53c5
   Reachability: 33e18b67625424e47b6cde6d202dce689ad7af96
-  Sentry: ab6c209f23700d1460691dbc90e19ed0a05d496b
+  Sentry: 8fa58a051237554f22507fb483b9a1de0171a2dc
   Simperium-OSX: 705b67b53840c46953a5ae9309a77a9a5ee126fc
-  Sodium-Fork: 45fe3a7c675898ca0635af4eadcb34985477e868
+  Sodium: 8106500200d1a80021cb9ea069ba0ea71fc26291
 
-PODFILE CHECKSUM: 31bdc08b539bb0bdc122701bfcc0bb548844b33e
+PODFILE CHECKSUM: e92b8f888a6432d8874b3eba91f5620ceda58532
 
-COCOAPODS: 1.9.3
+COCOAPODS: 1.10.0

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -1589,12 +1589,23 @@
 			buildActionMask = 2147483647;
 			files = (
 			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Automattic-SimplenoteTests/Pods-Automattic-SimplenoteTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Automattic-SimplenoteTests/Pods-Automattic-SimplenoteTests-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/Automattic-Tracks-iOS/AutomatticTracks.framework",
+				"${BUILT_PRODUCTS_DIR}/CocoaLumberjack/CocoaLumberjack.framework",
+				"${BUILT_PRODUCTS_DIR}/Reachability/Reachability.framework",
+				"${BUILT_PRODUCTS_DIR}/Sentry/Sentry.framework",
+				"${BUILT_PRODUCTS_DIR}/Simperium-OSX/Simperium_OSX.framework",
+				"${BUILT_PRODUCTS_DIR}/Sodium/Sodium.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Automattic-SimplenoteTests/Pods-Automattic-SimplenoteTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/AutomatticTracks.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/CocoaLumberjack.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Reachability.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Sentry.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Simperium_OSX.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Sodium.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -1650,12 +1661,23 @@
 			buildActionMask = 2147483647;
 			files = (
 			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Automattic-Simplenote-AppStore/Pods-Automattic-Simplenote-AppStore-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Automattic-Simplenote-AppStore/Pods-Automattic-Simplenote-AppStore-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/Automattic-Tracks-iOS/AutomatticTracks.framework",
+				"${BUILT_PRODUCTS_DIR}/CocoaLumberjack/CocoaLumberjack.framework",
+				"${BUILT_PRODUCTS_DIR}/Reachability/Reachability.framework",
+				"${BUILT_PRODUCTS_DIR}/Sentry/Sentry.framework",
+				"${BUILT_PRODUCTS_DIR}/Simperium-OSX/Simperium_OSX.framework",
+				"${BUILT_PRODUCTS_DIR}/Sodium/Sodium.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Automattic-Simplenote-AppStore/Pods-Automattic-Simplenote-AppStore-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/AutomatticTracks.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/CocoaLumberjack.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Reachability.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Sentry.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Simperium_OSX.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Sodium.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -1734,12 +1756,23 @@
 			buildActionMask = 2147483647;
 			files = (
 			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Automattic-Simplenote/Pods-Automattic-Simplenote-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Automattic-Simplenote/Pods-Automattic-Simplenote-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/Automattic-Tracks-iOS/AutomatticTracks.framework",
+				"${BUILT_PRODUCTS_DIR}/CocoaLumberjack/CocoaLumberjack.framework",
+				"${BUILT_PRODUCTS_DIR}/Reachability/Reachability.framework",
+				"${BUILT_PRODUCTS_DIR}/Sentry/Sentry.framework",
+				"${BUILT_PRODUCTS_DIR}/Simperium-OSX/Simperium_OSX.framework",
+				"${BUILT_PRODUCTS_DIR}/Sodium/Sodium.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Automattic-Simplenote/Pods-Automattic-Simplenote-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/AutomatticTracks.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/CocoaLumberjack.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Reachability.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Sentry.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Simperium_OSX.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Sodium.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -2,6 +2,6 @@
 #
 # Ensure this file is checked in to source control!
 
-gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag: '0.9.14'
+gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', branch: 'bump-active-support'
 gem 'fastlane-plugin-sentry'
 gem 'fastlane-plugin-appcenter', '1.6.0'


### PR DESCRIPTION
### Fix
This PR updates the pods to versions that compile under Xcode 12.2 after upgrading to Tracks 0.6.0. (I think the Xcode version is the reason why the archiving fails)

### Test
Checkout this branch, run `bundle install && bundle exec pod install`, and Archive both Simplenote and Simplenote-AppStore targets.

### Review
Only one platform developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.