### PR TITLE
Window Semaphore: Alignment!

### DIFF
--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -166,6 +166,8 @@
 		B52197872541C65C00182928 /* NumberFormatter+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B52197852541C65C00182928 /* NumberFormatter+Simplenote.swift */; };
 		B5283BD023B679C00085826F /* NSMutableAttributedString+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5283BCF23B679C00085826F /* NSMutableAttributedString+Simplenote.swift */; };
 		B5283BD123B679C00085826F /* NSMutableAttributedString+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5283BCF23B679C00085826F /* NSMutableAttributedString+Simplenote.swift */; };
+		B528D683257FF15000C1EEA4 /* MainWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B528D682257FF15000C1EEA4 /* MainWindowController.swift */; };
+		B528D684257FF15000C1EEA4 /* MainWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B528D682257FF15000C1EEA4 /* MainWindowController.swift */; };
 		B529F7B524586D8700B168F1 /* MarkdownViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B529F7B424586D8700B168F1 /* MarkdownViewController.swift */; };
 		B529F7B624586D8700B168F1 /* MarkdownViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B529F7B424586D8700B168F1 /* MarkdownViewController.swift */; };
 		B529F7B824586DF800B168F1 /* MarkdownViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = B529F7B724586DF800B168F1 /* MarkdownViewController.xib */; };
@@ -559,6 +561,7 @@
 		B5242E0D24C923B400437E40 /* tr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tr; path = tr.lproj/MainMenu.strings; sourceTree = "<group>"; };
 		B5242E0F24C923B600437E40 /* cy */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = cy; path = cy.lproj/MainMenu.strings; sourceTree = "<group>"; };
 		B5283BCF23B679C00085826F /* NSMutableAttributedString+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSMutableAttributedString+Simplenote.swift"; sourceTree = "<group>"; };
+		B528D682257FF15000C1EEA4 /* MainWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainWindowController.swift; sourceTree = "<group>"; };
 		B529F7B424586D8700B168F1 /* MarkdownViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownViewController.swift; sourceTree = "<group>"; };
 		B529F7B724586DF800B168F1 /* MarkdownViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = MarkdownViewController.xib; sourceTree = "<group>"; };
 		B52F203824C5FB1E00ABB43F /* NSWindow+Simplenote.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSWindow+Simplenote.swift"; sourceTree = "<group>"; };
@@ -1280,17 +1283,10 @@
 		B5C63353251E732600C8BF46 /* WindowControllers */ = {
 			isa = PBXGroup;
 			children = (
-				B5C63354251E733700C8BF46 /* Interlinks */,
+				B50FB213251BB2E00028DE25 /* InterlinkWindowController.swift */,
+				B528D682257FF15000C1EEA4 /* MainWindowController.swift */,
 			);
 			name = WindowControllers;
-			sourceTree = "<group>";
-		};
-		B5C63354251E733700C8BF46 /* Interlinks */ = {
-			isa = PBXGroup;
-			children = (
-				B50FB213251BB2E00028DE25 /* InterlinkWindowController.swift */,
-			);
-			name = Interlinks;
 			sourceTree = "<group>";
 		};
 		B5C63355251E734100C8BF46 /* Storyboards */ = {
@@ -1780,6 +1776,7 @@
 				B551187224E33BC2007B11E3 /* ClipView.swift in Sources */,
 				B5395E1D253F70E30068F1A6 /* MetricTableViewCell.swift in Sources */,
 				B5E061772450AEDA0076111A /* ToolbarView.swift in Sources */,
+				B528D683257FF15000C1EEA4 /* MainWindowController.swift in Sources */,
 				F998F3EB22853C29008C2B59 /* CrashLogging.swift in Sources */,
 				2614F1DF1405A0B10031AE94 /* Note.m in Sources */,
 				B586C062245CCD35009508EC /* SplitViewController.swift in Sources */,
@@ -2046,6 +2043,7 @@
 				B5CD5F7F241AC69900D0260F /* NSProcessInfo+Simplenote.swift in Sources */,
 				B5C620A3257EA526008359A9 /* NSView+Simplenote.swift in Sources */,
 				B59848811BCDB95A005EFBBE /* SPAutomatticTracker.m in Sources */,
+				B528D684257FF15000C1EEA4 /* MainWindowController.swift in Sources */,
 				37AE49C31FFEB92A00FCB165 /* SPMarkdownParser.m in Sources */,
 				B5CBB05D2419714B0003C271 /* NSAttributedStringToMarkdownConverter.swift in Sources */,
 				B5E96B671BDE732500D707F5 /* LoginWindowController.m in Sources */,

--- a/Simplenote/Base.lproj/MainMenu.xib
+++ b/Simplenote/Base.lproj/MainMenu.xib
@@ -3,7 +3,6 @@
     <dependencies>
         <deployment identifier="macosx"/>
         <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17506"/>
-        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="NSApplication">
@@ -713,29 +712,7 @@
             </connections>
             <point key="canvasLocation" x="-84" y="-325"/>
         </menu>
-        <window allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="SPWindow" animationBehavior="default" tabbingMode="disallowed" titlebarAppearsTransparent="YES" titleVisibility="hidden" id="371" customClass="Window" customModule="Simplenote" customModuleProvider="target">
-            <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES" fullSizeContentView="YES"/>
-            <windowCollectionBehavior key="collectionBehavior" fullScreenPrimary="YES"/>
-            <rect key="contentRect" x="199" y="95" width="900" height="618"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1025"/>
-            <value key="minSize" type="size" width="720" height="400"/>
-            <view key="contentView" id="372">
-                <rect key="frame" x="0.0" y="0.0" width="900" height="618"/>
-                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-            </view>
-            <userDefinedRuntimeAttributes>
-                <userDefinedRuntimeAttribute type="boolean" keyPath="excludedFromWindowsMenu" value="YES"/>
-            </userDefinedRuntimeAttributes>
-            <connections>
-                <outlet property="delegate" destination="494" id="1423"/>
-            </connections>
-            <point key="canvasLocation" x="138" y="262"/>
-        </window>
-        <customObject id="494" customClass="SimplenoteAppDelegate">
-            <connections>
-                <outlet property="window" destination="371" id="748"/>
-            </connections>
-        </customObject>
+        <customObject id="494" customClass="SimplenoteAppDelegate"/>
         <customObject id="420" customClass="NSFontManager"/>
     </objects>
 </document>

--- a/Simplenote/Main.storyboard
+++ b/Simplenote/Main.storyboard
@@ -873,6 +873,36 @@
             </objects>
             <point key="canvasLocation" x="830" y="220"/>
         </scene>
+        <!--Window Controller-->
+        <scene sceneID="JSU-Qr-9ys">
+            <objects>
+                <windowController storyboardIdentifier="MainWindowController" id="bDf-SG-cD5" customClass="MainWindowController" customModule="Simplenote" customModuleProvider="target" sceneMemberID="viewController">
+                    <window key="window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="SPWindow" animationBehavior="default" tabbingMode="disallowed" titlebarAppearsTransparent="YES" titleVisibility="hidden" id="Xk8-MH-eev" customClass="Window" customModule="Simplenote" customModuleProvider="target">
+                        <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES" fullSizeContentView="YES"/>
+                        <windowCollectionBehavior key="collectionBehavior" fullScreenPrimary="YES"/>
+                        <rect key="contentRect" x="245" y="301" width="900" height="618"/>
+                        <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1025"/>
+                        <value key="minSize" type="size" width="720" height="400"/>
+                        <view key="contentView" id="Azh-ap-G3a">
+                            <rect key="frame" x="0.0" y="0.0" width="900" height="618"/>
+                            <autoresizingMask key="autoresizingMask"/>
+                        </view>
+                        <userDefinedRuntimeAttributes>
+                            <userDefinedRuntimeAttribute type="boolean" keyPath="excludedFromWindowsMenu" value="YES"/>
+                        </userDefinedRuntimeAttributes>
+                        <connections>
+                            <outlet property="delegate" destination="bDf-SG-cD5" id="tTI-xt-6V4"/>
+                        </connections>
+                    </window>
+                    <connections>
+                        <outlet property="simplenoteWindow" destination="Xk8-MH-eev" id="UZU-US-aOB"/>
+                        <segue destination="pbQ-Wy-u9S" kind="relationship" relationship="window.shadowedContentViewController" id="k1U-SQ-ruR"/>
+                    </connections>
+                </windowController>
+                <customObject id="z6J-n3-huD" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="157" y="-690"/>
+        </scene>
         <!--Split View Controller-->
         <scene sceneID="ada-KS-Sgj">
             <objects>
@@ -890,7 +920,7 @@
                 </splitViewController>
                 <customObject id="ddL-k7-ABw" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="532" y="-696"/>
+            <point key="canvasLocation" x="1175" y="-690"/>
         </scene>
     </scenes>
     <resources>

--- a/Simplenote/Main.storyboard
+++ b/Simplenote/Main.storyboard
@@ -896,7 +896,7 @@
                     </window>
                     <connections>
                         <outlet property="simplenoteWindow" destination="Xk8-MH-eev" id="UZU-US-aOB"/>
-                        <segue destination="pbQ-Wy-u9S" kind="relationship" relationship="window.shadowedContentViewController" id="k1U-SQ-ruR"/>
+                        <segue destination="pbQ-Wy-u9S" kind="relationship" relationship="window.shadowedContentViewController" id="OXN-9V-bSk"/>
                     </connections>
                 </windowController>
                 <customObject id="z6J-n3-huD" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
@@ -907,16 +907,13 @@
         <scene sceneID="ada-KS-Sgj">
             <objects>
                 <splitViewController storyboardIdentifier="SplitViewController" id="pbQ-Wy-u9S" customClass="SplitViewController" customModule="Simplenote" customModuleProvider="target" sceneMemberID="viewController">
-                    <splitView key="splitView" dividerStyle="thin" vertical="YES" id="YYi-Tg-xfR">
+                    <splitView key="splitView" wantsLayer="YES" dividerStyle="thin" vertical="YES" id="YYi-Tg-xfR" customClass="SplitView" customModule="Simplenote" customModuleProvider="target">
                         <rect key="frame" x="0.0" y="0.0" width="900" height="618"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <connections>
                             <outlet property="delegate" destination="pbQ-Wy-u9S" id="Eic-Td-J46"/>
                         </connections>
                     </splitView>
-                    <connections>
-                        <outlet property="splitView" destination="YYi-Tg-xfR" id="0q9-5k-xxj"/>
-                    </connections>
                 </splitViewController>
                 <customObject id="ddL-k7-ABw" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
             </objects>

--- a/Simplenote/MainWindowController.swift
+++ b/Simplenote/MainWindowController.swift
@@ -1,0 +1,102 @@
+import Foundation
+
+
+// MARK: - MainWindowController
+//
+class MainWindowController: NSWindowController {
+
+    /// We can't have nice things: Someone decided to make `.window` an optional. Plus: we kinda need access to custom properties
+    ///
+    @IBOutlet private(set) var simplenoteWindow: Window!
+
+    // MARK: - Overridden Methods
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+
+    override func windowDidLoad() {
+        super.windowDidLoad()
+        setupMainWindow()
+        setupToolbar()
+        relocateSemaphoreButtons()
+        startListeningToFullscreenNotifications()
+    }
+}
+
+
+// MARK: - NSWindowDelegate
+//
+extension MainWindowController: NSWindowDelegate {
+
+    /// Let's autohide the Toolbar, since it causes a shaky animation
+    ///
+    func window(_ window: NSWindow, willUseFullScreenPresentationOptions proposedOptions: NSApplication.PresentationOptions = []) -> NSApplication.PresentationOptions {
+        [.autoHideToolbar, .autoHideMenuBar, .fullScreen]
+    }
+}
+
+
+// MARK: - Initialization
+//
+private extension MainWindowController {
+
+    /// Initalizes the Main Window
+    ///
+    func setupMainWindow() {
+        simplenoteWindow.setFrameAutosaveName(.mainWindow)
+    }
+
+    /// We're attaching empty Toolbar, which will increase the Window's Title Height
+    ///
+    func setupToolbar() {
+        let customToolbar = NSToolbar()
+        customToolbar.showsBaselineSeparator = false
+        simplenoteWindow.toolbar = customToolbar
+    }
+
+    /// We'll need to drop the Semaphore Workaround when entering Fullscreen
+    ///
+    func startListeningToFullscreenNotifications() {
+        let nc = NotificationCenter.default
+        nc.addObserver(self, selector: #selector(willEnterFullscreen), name: NSWindow.willEnterFullScreenNotification, object: simplenoteWindow)
+        nc.addObserver(self, selector: #selector(willExitFullscreen), name: NSWindow.willExitFullScreenNotification, object: simplenoteWindow)
+    }
+}
+
+
+// MARK: - Semaphore Workaround
+//
+private extension MainWindowController {
+
+    func relocateSemaphoreButtons() {
+        simplenoteWindow.semaphoreButtonOriginY = Metrics.semaphoreButtonPositionY
+    }
+
+    func disableSemaphoreButtonsWorkaround() {
+        simplenoteWindow.semaphoreButtonOriginY = nil
+    }
+}
+
+
+// MARK: - Notifications
+//
+extension MainWindowController {
+
+    @objc
+    func willEnterFullscreen() {
+        disableSemaphoreButtonsWorkaround()
+    }
+
+    @objc
+    func willExitFullscreen() {
+        relocateSemaphoreButtons()
+    }
+}
+
+
+// MARK: - Metrics
+//
+private enum Metrics {
+    static let semaphoreButtonPositionY: CGFloat = 4
+}

--- a/Simplenote/MainWindowController.swift
+++ b/Simplenote/MainWindowController.swift
@@ -71,10 +71,12 @@ private extension MainWindowController {
 
     func relocateSemaphoreButtons() {
         simplenoteWindow.semaphoreButtonOriginY = Metrics.semaphoreButtonPositionY
+        simplenoteWindow.semaphoreButtonPaddingX = Metrics.semaphoreButtonPaddingX
     }
 
     func disableSemaphoreButtonsWorkaround() {
         simplenoteWindow.semaphoreButtonOriginY = nil
+        simplenoteWindow.semaphoreButtonPaddingX = nil
     }
 }
 
@@ -99,4 +101,5 @@ extension MainWindowController {
 //
 private enum Metrics {
     static let semaphoreButtonPositionY: CGFloat = 4
+    static let semaphoreButtonPaddingX: CGFloat = 7
 }

--- a/Simplenote/SimplenoteAppDelegate+Swift.swift
+++ b/Simplenote/SimplenoteAppDelegate+Swift.swift
@@ -6,10 +6,11 @@ import Foundation
 extension SimplenoteAppDelegate {
 
     @objc
-    func configureSplitView() {
+    func configureMainInterface() {
         let storyboard = NSStoryboard(name: .main, bundle: nil)
 
-        let splitViewController = storyboard.instantiateViewController(ofType: SplitViewController.self)
+        let mainWindowController = storyboard.instantiateWindowController(ofType: MainWindowController.self)
+        let splitViewController = mainWindowController.contentViewController as! SplitViewController
         let tagListViewController = storyboard.instantiateViewController(ofType: TagListViewController.self)
         let notesViewController = storyboard.instantiateViewController(ofType: NoteListViewController.self)
         let editorViewController = storyboard.instantiateViewController(ofType: NoteEditorViewController.self)
@@ -22,6 +23,7 @@ extension SimplenoteAppDelegate {
         splitViewController.insertSplitViewItem(listSplitItem, kind: .notes)
         splitViewController.insertSplitViewItem(editorSplitItem, kind: .editor)
 
+        self.mainWindowController = mainWindowController
         self.splitViewController = splitViewController
         self.tagListViewController = tagListViewController
         self.noteListViewController = notesViewController
@@ -29,10 +31,8 @@ extension SimplenoteAppDelegate {
     }
 
     @objc
-    func configureWindow() {
-        window.contentViewController = splitViewController
+    func configureInitialResponder() {
         window.initialFirstResponder = noteEditorViewController.noteEditor
-        window.setFrameAutosaveName(.mainWindow)
     }
 
     @objc
@@ -45,6 +45,12 @@ extension SimplenoteAppDelegate {
         noteEditorViewController.tagActionsDelegate = tagListViewController
         noteEditorViewController.noteActionsDelegate = noteListViewController
         noteEditorViewController.searchDelegate = noteListViewController
+    }
+
+    @objc
+    var window: Window {
+        // TODO: Temporary workaround. Let's get rid of this? please? 🔥🔥🔥
+        mainWindowController.window as! Window
     }
 }
 

--- a/Simplenote/SimplenoteAppDelegate.h
+++ b/Simplenote/SimplenoteAppDelegate.h
@@ -10,6 +10,7 @@
 @import Simperium_OSX;
 
 
+@class MainWindowController;
 @class NoteListViewController;
 @class NoteEditorViewController;
 @class TagListViewController;
@@ -24,8 +25,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface SimplenoteAppDelegate : NSObject <NSApplicationDelegate, NSWindowDelegate>
 
-@property (strong, nonatomic, readonly) IBOutlet NSWindow                   *window;
-
 @property (strong, nonatomic, readonly) Simperium                           *simperium;
 @property (strong, nonatomic, readonly) NSPersistentStoreCoordinator        *persistentStoreCoordinator;
 @property (strong, nonatomic, readonly) NSManagedObjectModel                *managedObjectModel;
@@ -33,6 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (assign, nonatomic, readonly) BOOL                                exportUnlocked;
 
+@property (strong, nonatomic) MainWindowController                          *mainWindowController;
 @property (strong, nonatomic) SplitViewController                           *splitViewController;
 @property (strong, nonatomic) TagListViewController                         *tagListViewController;
 @property (strong, nonatomic) NoteListViewController                        *noteListViewController;
@@ -51,7 +51,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)selectAllNotesTag;
 - (void)selectNoteWithKey:(NSString *)simperiumKey;
-- (BOOL)isMainWindowVisible;
 
 @end
 

--- a/Simplenote/SimplenoteAppDelegate.m
+++ b/Simplenote/SimplenoteAppDelegate.m
@@ -43,7 +43,6 @@
 
 @interface SimplenoteAppDelegate () <SimperiumDelegate, SPBucketDelegate>
 
-@property (strong, nonatomic) IBOutlet NSWindow                 *window;
 @property (assign, nonatomic) BOOL                              exportUnlocked;
 
 @property (strong, nonatomic) NSWindowController                *aboutWindowController;
@@ -127,8 +126,8 @@
 {
     [SPTracker trackApplicationLaunched];
 
-    [self configureSplitView];
-    [self configureWindow];
+    [self configureMainInterface];
+    [self configureInitialResponder];
     [self hookWindowNotifications];
     [self applyStyle];
     
@@ -257,11 +256,6 @@
     [userDefaults synchronize];
     
     [self.noteListViewController setWaitingForIndex:YES];
-}
-
-- (BOOL)isMainWindowVisible
-{
-    return self.window.isVisible;
 }
 
 - (void)createWelcomeNote
@@ -466,8 +460,8 @@
         [[Options shared] reset];
 
         // Auth window won't show up until next run loop, so be careful not to close main window until then
-        [self->_window performSelector:@selector(orderOut:) withObject:self afterDelay:0.1f];
-        [self->_simperium authenticateIfNecessary];
+        [self.window performSelector:@selector(orderOut:) withObject:self afterDelay:0.1f];
+        [self.simperium authenticateIfNecessary];
     }];
 }
 

--- a/Simplenote/SplitViewController.swift
+++ b/Simplenote/SplitViewController.swift
@@ -24,8 +24,13 @@ class SplitViewController: NSSplitViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+
         // Note: we must manually set the `autosaveName`, otherwise divider location(s) won't be properly persisted
         splitView.autosaveName = "Please Save Me!"
+
+        /// Note: We'll enable Layer Backing, in order to fix this console message:
+        /// `WARNING: The SplitView is not layer-backed, but trying to use overlay sidebars` (...)
+        splitView.wantsLayer = true
     }
 }
 

--- a/Simplenote/Window.swift
+++ b/Simplenote/Window.swift
@@ -17,6 +17,10 @@ protocol ParentWindowDelegate {
 //
 class Window: NSWindow {
 
+    /// Allows us to adjust the Origin for the Semaphore Buttons (Close / Miniaturize / Zoom)
+    ///
+    var semaphoreButtonOriginY: CGFloat?
+
     // MARK: - Lifecycle
 
     deinit {
@@ -38,6 +42,15 @@ class Window: NSWindow {
         }
 
         super.sendEvent(event)
+    }
+
+    override func layoutIfNeeded() {
+        super.layoutIfNeeded()
+        guard let semaphoreOriginY = semaphoreButtonOriginY else {
+            return
+        }
+
+        relocateSemaphoreButtons(originY: semaphoreOriginY)
     }
 }
 
@@ -68,5 +81,21 @@ private extension Window {
         }
 
         appearance = NSAppearance.simplenoteAppearance
+    }
+}
+
+
+// MARK: - Sempahore
+//
+private extension Window {
+
+    func relocateSemaphoreButtons(originY: CGFloat) {
+        let buttons: [NSButton] = [.closeButton, .miniaturizeButton, .zoomButton].compactMap { type in
+            standardWindowButton(type)
+        }
+
+        for button in buttons {
+            button.frame.origin.y = originY
+        }
     }
 }

--- a/Simplenote/Window.swift
+++ b/Simplenote/Window.swift
@@ -17,9 +17,20 @@ protocol ParentWindowDelegate {
 //
 class Window: NSWindow {
 
+    /// Semaphore Buttons: Quick access reference to the Close / Minimize / Zoom buttons
+    ///
+    private lazy var buttons: [NSButton] = [.closeButton, .miniaturizeButton, .zoomButton].compactMap { type in
+        standardWindowButton(type)
+    }
+
     /// Allows us to adjust the Origin for the Semaphore Buttons (Close / Miniaturize / Zoom)
     ///
     var semaphoreButtonOriginY: CGFloat?
+
+    /// Horizontal Padding to be applied over all of the Semaphore Buttons
+    ///
+    var semaphoreButtonPaddingX: CGFloat?
+
 
     // MARK: - Lifecycle
 
@@ -46,11 +57,7 @@ class Window: NSWindow {
 
     override func layoutIfNeeded() {
         super.layoutIfNeeded()
-        guard let semaphoreOriginY = semaphoreButtonOriginY else {
-            return
-        }
-
-        relocateSemaphoreButtons(originY: semaphoreOriginY)
+        relocateSemaphoreButtonsIfNeeded()
     }
 }
 
@@ -89,13 +96,22 @@ private extension Window {
 //
 private extension Window {
 
-    func relocateSemaphoreButtons(originY: CGFloat) {
-        let buttons: [NSButton] = [.closeButton, .miniaturizeButton, .zoomButton].compactMap { type in
-            standardWindowButton(type)
+    func relocateSemaphoreButtonsIfNeeded() {
+        guard let semaphoreOriginY = semaphoreButtonOriginY, let semaphorePaddingX = semaphoreButtonPaddingX else {
+            return
         }
 
+        let directionalMultiplier: CGFloat = isRTL ? -1 : 1
+
         for button in buttons {
-            button.frame.origin.y = originY
+            var origin = button.frame.origin
+            guard origin.y != semaphoreOriginY else {
+                continue
+            }
+
+            origin.y = semaphoreOriginY
+            origin.x += semaphorePaddingX * directionalMultiplier
+            button.frame.origin = origin
         }
     }
 }


### PR DESCRIPTION
### Description
In this PR we're adjusting the main Window's Semaphore position (Maximize / Minimize / Close buttons) so that they align perfectly with regards of other UI elements.


@eshurakov Sending you over a REALLY cool PR!! Thank youuu!!

cc @SylvesterWilmott Looks suuuupeeeeeeeeeerrrrrr

Ref. #718

### Details
- **New MainWindowController**: Encapsulates the Semaphore workaround
- **Main Window** is no longer initialized via nib
- Main Interface initialization mechanism was also updated

### Test: Semaphore Alignment!
1. Launch Simplenote

- [x] Verify the Semaphore's vertical position is centered with regards to the Note List's Title
- [x] Verify that if you hide the Tags List (CMD + T) the Semaphore looks great (and aligned with regards to the List Title)
- [ ] Verify that pressing **Shift + CMD + F** gets you into Focus Mode, and the Semaphore is aligned with regards to the Sidebar Toolbar Button
- [ ] Verify that you can drag the Window from anywhere in the Toolbar area (please!!) 😄 

### Test: Fullscreen
1. Launch Simplenote
2. Click over the Window's Fullscreen button

- [x] Verify that the top area looks great (no flickers?)
- [x] Verify that moving the mouse upwards reveals the System Bar, and the Semaphore looks vertically centered in its container
- [x] Verify that exiting Fullscreen mode causes the main Window to look great (and the semaphore lights still properly aligned)

### Test: Autosave
1. Launch the app
2. Relocate / resize the main window
3. Press CMD + Q to quit
4. Relaunch Simplenote

- [x] Verify the last Window Frame is properly restored

### Release
These changes do not require release notes.

### Screenshots

Before|Now
-|-
<img width="300" alt="Old" src="https://user-images.githubusercontent.com/1195260/101528573-444cc600-396e-11eb-8574-11694dfc31ba.png">|<img width="300" alt="New" src="https://user-images.githubusercontent.com/1195260/101528581-457df300-396e-11eb-9ba3-ec6a9bfdeb31.png">
