### PR TITLE
Fixing Unexpected TagsList Jump

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -9,6 +9,7 @@
 - Notes List now display row separators #758
 - Fixed a bug that affected Multiple Selection in Big Sur #753
 - Notes List will now animate content changes #764
+- Fixed a bug that caused an unexpected jump in the Tags List #767
  
 2.5
 -----

--- a/Simplenote/NoteEditorViewController+Swift.swift
+++ b/Simplenote/NoteEditorViewController+Swift.swift
@@ -137,6 +137,18 @@ extension NoteEditorViewController {
     var isSelectingText: Bool {
         noteEditor.selectedRange().length != .zero
     }
+
+    /// Simperium 🖖
+    ///
+    var simperium: Simperium {
+        simplenoteAppDelegate.simperium
+    }
+
+    /// TODO: Let's decouple with dependency injection (OR) a delegate please!!
+    ///
+    var simplenoteAppDelegate: SimplenoteAppDelegate {
+        SimplenoteAppDelegate.shared()
+    }
 }
 
 
@@ -607,7 +619,42 @@ extension NoteEditorViewController: TagsFieldDelegate {
         //
         // For that reason, we'll filtering out duplicates.
         //
-        updateTags(withTokens: tokens.caseInsensitiveUnique)
+        guard let note = note else {
+            return
+        }
+
+        updateNoteTags(tokens: tokens.caseInsensitiveUnique, note: note)
+    }
+}
+
+
+// MARK: - Tags Processing
+//
+extension NoteEditorViewController {
+
+    /// TODO: Let's analyze and potentially build NotesController / TagsController
+    ///
+    func updateNoteTags(tokens: [String], note: Note) {
+        let newTags = tokens.filter { token in
+            simperium.searchTag(name: token) == nil && token.containsEmailAddress() == false
+        }
+
+        for newTag in newTags {
+            tagActionsDelegate?.editorController(self, didAddNewTag: newTag)
+        }
+
+        // Update Tags: Internally they're JSON Encoded!
+        let oldTags = note.tags
+        note.setTagsFromList(tokens)
+
+        guard note.tags != oldTags else {
+            return
+        }
+
+        save()
+
+        // Ensure the note remains onscreen
+        simplenoteAppDelegate.displayNote(simperiumKey: note.simperiumKey)
     }
 }
 

--- a/Simplenote/NoteEditorViewController.h
+++ b/Simplenote/NoteEditorViewController.h
@@ -85,7 +85,6 @@ typedef NS_ENUM(NSInteger, NoteFontSize) {
 - (void)didReceiveNewContent;
 - (void)willReceiveNewContent;
 - (void)fixChecklistColoring;
-- (void)updateTagsWithTokens:(NSArray<NSString *> *)tokens;
 - (NSUInteger)newCursorLocation:(NSString *)newText oldText:(NSString *)oldText currentLocation:(NSUInteger)cursorLocation;
 - (IBAction)deleteAction:(id)sender;
 - (IBAction)printAction:(id)sender;

--- a/Simplenote/NoteEditorViewController.m
+++ b/Simplenote/NoteEditorViewController.m
@@ -527,41 +527,6 @@ static NSString * const SPMarkdownPreferencesKey        = @"kMarkdownPreferences
 }
 
 
-
-#pragma mark - TagsField Helpers
-
-- (void)updateTagsWithTokens:(NSArray<NSString *> *)tokens
-{
-    SimplenoteAppDelegate *appDelegate  = [SimplenoteAppDelegate sharedDelegate];
-    Simperium *simperium                = appDelegate.simperium;
-    Note *note                          = self.note;
-    NSString *oldTags                   = note.tags;
-
-    // Create any new tags that don't already exist
-    for (NSString *token in tokens) {
-        Tag *tag = [simperium searchTagWithName:token];
-        if (!tag && ![token containsEmailAddress]) {
-            [self.tagActionsDelegate editorController:self didAddNewTag:token];
-        }
-    }
-
-    // Update Tags: Internally they're JSON Encoded!
-    [note setTagsFromList:tokens];
-
-    // Ensure the right Tag remains selected
-    if ([note hasTag:appDelegate.selectedTagName] == false) {
-        [appDelegate selectAllNotesTag];
-        [appDelegate selectNoteWithKey:note.simperiumKey];
-    }
-    
-    if ([self.note.tags isEqualToString:oldTags]) {
-        return;
-    }
-    
-    [self save];
-}
-
-
 #pragma mark - Fonts
 
 - (NSInteger)getFontSize

--- a/Simplenote/Simplenote-Bridging-Header.h
+++ b/Simplenote/Simplenote-Bridging-Header.h
@@ -25,5 +25,6 @@
 
 #import "Simperium+Simplenote.h"
 #import "NSString+Condensing.h"
+#import "NSString+Metadata.h"
 #import "NSNotification+Simplenote.h"
 #import "NSMutableAttributedString+Styling.h"


### PR DESCRIPTION
### Fix
In this PR we're fixing a bug that prevented users from selecting any Tags at the bottom of the screen, right after editing the Note's Tags.

cc @eshurakov (Thank youuuuu!!!)
Fixes #767

### Details
This bug was caused by this check:

```
[note hasTag:appDelegate.selectedTagName] == false
```

When the `All Notes` filter is selected, the `selectedTagName` will be null.
Since I was in the neighborhood, figured, Swifting is a neat idea!

### Test: Jumpy Scenario
1. Log into an account that has a Tags List long enough that it requires scrolling
2. Click over **All Notes** and select any notes in the list
3. In the Tags Editor area (below the text editor) type a new random tag name
4. Scroll all the way down in the Tags List
5. Click over any tags at the bottom of the list

- [ ] Verify the Tag you've clicked actually gets highlighted!
- [ ] Verify the Tag you've added in (3) shows up in the Tags List

### Test: Dropping a Tag
1. Click over any Tags that contain a note
2. Select any note
3. Remove the selected Tag Name from the Tags Editor

- [ ] Verify the app immediately jumps over to **All Notes**
- [ ] Verify the same note remains onscreen

### Release
`RELEASE-NOTES.txt` was updated in 247b24f with:

> Fixed a bug that caused an unexpected jump in the Tags List #767

### Demo: Buggy Behavior
![Bug](https://user-images.githubusercontent.com/1195260/103098770-bf5ae100-45ea-11eb-9a10-3e2c844e9209.gif)

### Demo: Fixed Behavior
![Fixed](https://user-images.githubusercontent.com/1195260/103098752-b23df200-45ea-11eb-8cfc-4b52e27424d6.gif)


