### PR TITLE
Refreshing Notes List on Tag Rename

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -10,6 +10,7 @@
 - Fixed a bug that affected Multiple Selection in Big Sur #753
 - Notes List will now animate content changes #764
 - Fixed a bug that caused an unexpected jump in the Tags List #767
+- Fixed a bug that caused the Tags List to go blank upon tag rename #344
  
 2.5
 -----

--- a/Simplenote/NoteListViewController.swift
+++ b/Simplenote/NoteListViewController.swift
@@ -573,6 +573,7 @@ extension NoteListViewController {
         // Notifications: Tags
         nc.addObserver(self, selector: #selector(didBeginViewingTag), name: .TagListDidBeginViewingTag, object: nil)
         nc.addObserver(self, selector: #selector(didBeginViewingTrash), name: .TagListDidBeginViewingTrash, object: nil)
+        nc.addObserver(self, selector: #selector(didUpdateTag), name: .TagListDidUpdateTag, object: nil)
 
         // Notifications: Settings
         nc.addObserver(self, selector: #selector(displayModeDidChange), name: .NoteListDisplayModeDidChange, object: nil)
@@ -610,6 +611,18 @@ extension NoteListViewController {
     @objc
     func didBeginViewingTrash(_ note: Notification) {
         SPTracker.trackListTrashPressed()
+        refreshEverything()
+    }
+
+    @objc
+    func didUpdateTag(_ note: Notification) {
+        guard case let .tag(name) = listController.filter,
+              let oldName = note.userInfo?[TagListDidUpdateTagOldNameKey] as? String,
+              name == oldName
+        else {
+            return
+        }
+
         refreshEverything()
     }
 }

--- a/Simplenote/TagListViewController.h
+++ b/Simplenote/TagListViewController.h
@@ -18,6 +18,8 @@ NS_ASSUME_NONNULL_BEGIN
 extern NSString * const TagListDidBeginViewingTagNotification;
 extern NSString * const TagListDidBeginViewingTrashNotification;
 extern NSString * const TagListDidUpdateTagNotification;
+extern NSString * const TagListDidUpdateTagOldNameKey;
+extern NSString * const TagListDidUpdateTagNewNameKey;
 extern NSString * const TagListDidEmptyTrashNotification;
 
 @interface TagListViewController : NSViewController <NSMenuDelegate,

--- a/Simplenote/TagListViewController.m
+++ b/Simplenote/TagListViewController.m
@@ -19,6 +19,8 @@
 
 NSString * const TagListDidBeginViewingTagNotification      = @"TagListDidBeginViewingTagNotification";
 NSString * const TagListDidUpdateTagNotification            = @"TagListDidUpdateTagNotification";
+NSString * const TagListDidUpdateTagOldNameKey              = @"OldTag";
+NSString * const TagListDidUpdateTagNewNameKey              = @"NewTag";
 NSString * const TagListDidBeginViewingTrashNotification    = @"TagListDidBeginViewingTrashNotification";
 NSString * const TagListDidEmptyTrashNotification           = @"TagListDidEmptyTrashNotification";
 CGFloat const TagListEstimatedRowHeight                     = 30;
@@ -255,9 +257,12 @@ CGFloat const TagListEstimatedRowHeight                     = 30;
     
     renamedTag.name = newTagName;
     [self.simperium save];
-    
-    NSDictionary *userInfo = @{@"tagName": newTagName};
-    [[NSNotificationCenter defaultCenter] postNotificationName:TagListDidUpdateTagNotification object:self userInfo:userInfo];
+
+
+    [[NSNotificationCenter defaultCenter] postNotificationName:TagListDidUpdateTagNotification object:self userInfo:@{
+        TagListDidUpdateTagNewNameKey: newTagName,
+        TagListDidUpdateTagOldNameKey: oldTagName
+    }];
 }
 
 - (void)deleteTag:(Tag *)tag
@@ -290,9 +295,10 @@ CGFloat const TagListEstimatedRowHeight                     = 30;
 	} else {
         [self selectTag:selectedTag];
 	}
-	
-    NSDictionary *userInfo = @{@"tagName": tagName};
-    [[NSNotificationCenter defaultCenter] postNotificationName:TagListDidUpdateTagNotification object:self userInfo:userInfo];
+
+    [[NSNotificationCenter defaultCenter] postNotificationName:TagListDidUpdateTagNotification object:self userInfo: @{
+        TagListDidUpdateTagOldNameKey: tagName
+    }];
 }
 
 


### PR DESCRIPTION
### Fix
In this PR we're fixing a bug that caused the Notes List to go blank, right after renaming a Tag.

@eshurakov One more!!

Thank yoouuu!!
Closes #344 

### Test
1. Open the tags sidebar and select a tag. Notice that the notes list shows notes with that tag.
2. Right-click and select "Rename tag."
3. Enter a new tag name and hit Enter

- [ ] Verify the contents of the Note List don't change
- [ ] Verify the Tags Editor area now reflects the new Tag Name

### Release
`RELEASE-NOTES.txt` was updated in fd6e46f with:

> Fixed a bug that caused the Tags List to go blank upon tag rename #344
