### PR TITLE
Empty Document: Line Height

### DIFF
--- a/External/Notepad/Storage.swift
+++ b/External/Notepad/Storage.swift
@@ -194,6 +194,17 @@ class Storage: NSTextStorage {
 }
 
 
+// MARK: - Typing Attributes
+//
+extension Storage {
+
+    @objc
+    var typingAttributes: [NSAttributedString.Key: Any] {
+        backingStore.length == .zero ? theme.headlineStyle.attributes : theme.bodyStyle.attributes
+    }
+}
+
+
 // MARK: - Helpers
 //
 private extension Storage {

--- a/External/Notepad/Theme.swift
+++ b/External/Notepad/Theme.swift
@@ -30,8 +30,9 @@ class Theme {
     ///
     private static let headlineSpacing = CGFloat.zero
 
-    /// The body style
+    /// Main Styles
     ///
+    let headlineStyle: Style
     let bodyStyle: Style
 
     /// All of the (other) Theme Styles
@@ -46,6 +47,7 @@ class Theme {
     /// Designated Initializer
     ///
     init(markdownEnabled: Bool) {
+        self.headlineStyle = Theme.headlineStyle
         self.bodyStyle = Theme.bodyStyle
         self.styles = markdownEnabled ? Theme.markdownStyles : Theme.regularStyles
         self.markdownEnabled = markdownEnabled
@@ -57,13 +59,17 @@ class Theme {
 //
 private extension Theme {
 
+    static var headlineStyle: Style {
+        return Style(element: .firstLine, attributes: headlineAttributes)
+    }
+
     static var bodyStyle: Style {
         return Style(element: .body, attributes: bodyAttributes)
     }
 
     static var regularStyles: [Style] {
         return [
-            Style(element: .firstLine, attributes: headlineAttributes)
+            headlineStyle
         ]
     }
 
@@ -71,7 +77,7 @@ private extension Theme {
         return [
             Style(element: .h1, attributes: headingAttributes),
             Style(element: .h2, attributes: headingAttributes),
-            Style(element: .firstLine, attributes: headlineAttributes),
+            headlineStyle,
             Style(element: .bold, attributes: boldAttributes),
             Style(element: .inlineCode, attributes: codeAttributes),
             Style(element: .italic, attributes: italicAttributes),

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,7 @@
 - New Notes List Sort Modes #33
 - Notes List now display row separators #758
 - Fixed a bug that affected Multiple Selection in Big Sur #753
+- Fixed the Line Height when editing an empty document #771
  
 2.5
 -----

--- a/Simplenote/SPTextView.m
+++ b/Simplenote/SPTextView.m
@@ -14,6 +14,16 @@
 
 @implementation SPTextView
 
+- (nullable Storage *)simplenoteStorage
+{
+    return [self.textStorage isKindOfClass:[Storage class]] ? (Storage *)self.textStorage : nil;
+}
+
+- (NSDictionary *)typingAttributes
+{
+    return (self.simplenoteStorage != nil) ? self.simplenoteStorage.typingAttributes : super.typingAttributes;
+}
+
 - (void)mouseDown:(NSEvent *)theEvent
 {
     if ([self checkForChecklistClick:theEvent]) {


### PR DESCRIPTION
### Fix
In this PR we're overriding the **typingAttributes** NSTextView API, so that when the document being edited is 100% empty, we use the Heading attributes.

As a result, the cursor's height (on empty documents) will match the first line's font size, at all times.

@eshurakov Spamming you with PRs!! 😂 
Closes #771

### Test
1. Add a new note
2. Notice the cursor's height
3. Type anything

- [ ] Verify the line height in (2) and (3) never changes!

### Release
`RELEASE-NOTES.txt` was updated in e5aa797 with:

> Fixed the Line Height when editing an empty document #771
