### PR TITLE
TagList: Cursor

### DIFF
--- a/Simplenote/TagTableCellView.swift
+++ b/Simplenote/TagTableCellView.swift
@@ -62,10 +62,6 @@ extension TagTableCellView {
     override func mouseExited(with event: NSEvent) {
         mouseInside = false
     }
-
-    override func resetCursorRects() {
-        addCursorRect(bounds, cursor: .pointingHand)
-    }
 }
 
 


### PR DESCRIPTION
### Fix
In this PR we're dropping the Ponting Hand cursor usage in the Tags List.

Ref. #718

cc @SylvesterWilmott 
@eshurakov Spamming you, yet again!

Thanks in advance!!

### Test
1. Launch the app
2. Hover the cursor over the Tags List

- [ ] Verify the OS no longer switches to the Ponting Hand cursor

### Release
These changes do not require release notes.
