### PR TITLE
Editor: Drops direct frame manipulation

### DIFF
--- a/Simplenote/NoteEditorViewController.m
+++ b/Simplenote/NoteEditorViewController.m
@@ -78,7 +78,6 @@ static NSString * const SPMarkdownPreferencesKey        = @"kMarkdownPreferences
 {
     [super viewDidLoad];
 
-    [self.noteEditor setFrameSize:NSMakeSize(self.noteEditor.frame.size.width-kMinEditorPadding/2, self.noteEditor.frame.size.height-kMinEditorPadding/2)];
     self.storage = [Storage new];
     [self.noteEditor.layoutManager replaceTextStorage:self.storage];
     [self.noteEditor.layoutManager setDefaultAttachmentScaling:NSImageScaleProportionallyDown];

--- a/Simplenote/SPTextView.h
+++ b/Simplenote/SPTextView.h
@@ -8,7 +8,6 @@
 
 #import <Cocoa/Cocoa.h>
 
-#define kMinEditorPadding 20
 
 @interface SPTextView : NSTextView
 

--- a/Simplenote/SPTextView.m
+++ b/Simplenote/SPTextView.m
@@ -10,7 +10,9 @@
 #import "NSMutableAttributedString+Styling.h"
 #import "Simplenote-Swift.h"
 
-#define kMaxEditorWidth 750 // Note: This matches the Electron apps max editor width
+// Note: This matches the Electron apps max editor width
+static CGFloat const SPTextViewMaximumWidth = 750;
+static CGFloat const SPTextViewMinimumPadding = 20;
 
 @implementation SPTextView
 
@@ -29,22 +31,25 @@
     [self processLinksInDocumentAsynchronously];
 }
 
-- (void)drawRect:(NSRect)dirtyRect {
+- (void)drawRect:(NSRect)dirtyRect
+{
     CGFloat viewWidth = self.frame.size.width;
-    CGFloat insetX = [self shouldCalculateInset:viewWidth] ? [self getAdjustedInsetX:viewWidth] : kMinEditorPadding;
-    [self setTextContainerInset: NSMakeSize(insetX, kMinEditorPadding)];
+    CGFloat insetX = [self shouldCalculateInset:viewWidth] ? [self getAdjustedInsetX:viewWidth] : SPTextViewMinimumPadding;
+    [self setTextContainerInset: NSMakeSize(insetX, SPTextViewMinimumPadding)];
     
     [super drawRect:dirtyRect];
 }
 
-- (BOOL)shouldCalculateInset: (CGFloat)viewWidth {
-    return viewWidth > kMaxEditorWidth && ![[Options shared] editorFullWidth];
+- (BOOL)shouldCalculateInset:(CGFloat)viewWidth
+{
+    return viewWidth > SPTextViewMaximumWidth && ![[Options shared] editorFullWidth];
 }
 
-- (CGFloat)getAdjustedInsetX: (CGFloat)viewWidth {
-    CGFloat adjustedInset = (viewWidth - kMaxEditorWidth) / 2;
+- (CGFloat)getAdjustedInsetX:(CGFloat)viewWidth
+{
+    CGFloat adjustedInset = (viewWidth - SPTextViewMaximumWidth) / 2;
     
-    return lroundf(adjustedInset) + kMinEditorPadding;
+    return lroundf(adjustedInset) + SPTextViewMinimumPadding;
 }
 
 - (BOOL)checkForChecklistClick:(NSEvent *)event


### PR DESCRIPTION
### Fix
In this PR we're dropping direct Frame Manipulation in the EditorViewController.

**Note:** 
- The current codebase clips, effectively, 10 points on the right hand side
- New changes drop such clipping
- YES gentlemen, the screenshots look slightly different
- As a user, I would expect the (new) UX rather than the old one

cc @SylvesterWilmott 
cc @eshurakov 

Thanks in advance!!

Ref. #762

### Test
- [ ] Verify the Editor looks great when `View > Line Length > Full` is toggled
- [ ] Verify the Editor also looks great with `View > Line Length > Narrow` enabled

### Release
These changes do not require release notes.

### Screenshots

Old Narrow|New Narrow
-|-
<img width="300" alt="Old Narrow" src="https://user-images.githubusercontent.com/1195260/103305015-da619280-49e8-11eb-879c-68e706e90ff9.png">|<img width="300" alt="New Narrow" src="https://user-images.githubusercontent.com/1195260/103305023-df264680-49e8-11eb-9702-f16d503ee422.png">

Old Full|New Full
-|-
<img width="300" alt="Old Full" src="https://user-images.githubusercontent.com/1195260/103305033-e6e5eb00-49e8-11eb-8755-9198bf6fca79.png">|<img width="300" alt="New Full" src="https://user-images.githubusercontent.com/1195260/103305038-eb120880-49e8-11eb-9b97-a01b66edf031.png">

