### PR TITLE
Updates SimplenoteFoundation

### DIFF
--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -2737,8 +2737,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "git@github.com:Automattic/SimplenoteFoundation-Swift.git";
 			requirement = {
-				kind = revision;
-				revision = 77346d7b4d3b2a5d7a0034be06a33e45fbc9d414;
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.3.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Simplenote.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Simplenote.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "git@github.com:Automattic/SimplenoteFoundation-Swift.git",
         "state": {
           "branch": null,
-          "revision": "77346d7b4d3b2a5d7a0034be06a33e45fbc9d414",
-          "version": null
+          "revision": "2731e4d28c42d394ddc62cd864d9f7ff96759228",
+          "version": "1.3.0"
         }
       },
       {


### PR DESCRIPTION
### Fix
In this PR we're referencing SimplenoteFoundation 1.3.0 by release (rather than by commit hash!)
No changes are introduced here. All of the SimplenoteFoundation (new) code was verified via #764.

cc @eshurakov  (Again, apologies about the spam!!)

### Test
- [ ] Verify the tests are green!

### Release
These changes do not require release notes.
