### PR TITLE
Editor: Resetting TagsEditor Offset

### DIFF
--- a/Simplenote/NoteEditorViewController+Swift.swift
+++ b/Simplenote/NoteEditorViewController+Swift.swift
@@ -218,6 +218,11 @@ extension NoteEditorViewController {
         tagsField.isSelectable = isEnabled
     }
 
+    @objc
+    func resetTagsFieldScrollOffset() {
+        tagsField.scroll(.zero)
+    }
+
     /// Refreshes the TagsField's Tokens
     ///
     private func refreshTagsFieldTokens() {

--- a/Simplenote/NoteEditorViewController.m
+++ b/Simplenote/NoteEditorViewController.m
@@ -209,6 +209,7 @@ static NSString * const SPMarkdownPreferencesKey        = @"kMarkdownPreferences
     
     [self refreshToolbarActions];
     [self refreshTagsField];
+    [self resetTagsFieldScrollOffset];
 
     if (selectedNote.content != nil) {
         // Force selection to start; not doing this can cause an NSTextStorage exception when


### PR DESCRIPTION
### Fix
In this PR we're ensuring the Tags Editor's offset is reset, whenever a new document is presented.

Definitely small fix! thanks for reporting @eshurakov !!

### Test
1. Add a lot of tags to any note
2. scroll horizontally so that you don't see "Add tag"
3. click on another note

- [ ] Verify the `Add Tag` placeholder (presented in the Tags Editor) is fully visible

### Release
These changes do not require release notes.
