### PR TITLE
Fixing Unexpected Jumpy Scroll

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -14,7 +14,8 @@
 - Notes List will now animate content changes #764
 - Fixed a bug that caused an unexpected jump in the Tags List #767
 - Fixed a bug that caused the Tags List to go blank upon tag rename #344
- 
+- Fixed a bug that caused the Editor Scroll Offset to jump #785
+
 2.5
 -----
 - Removed Main Window's Titlebar #719

--- a/Simplenote/NoteEditorViewController+Swift.swift
+++ b/Simplenote/NoteEditorViewController+Swift.swift
@@ -108,6 +108,9 @@ extension NoteEditorViewController {
 
         noteEditor.textContainerInset  = targetContainerInset
         container.containerSize        = targetContainerSize
+
+        /// Note: Disabling `widthTracksTextView` fixes jumpy Scroll Offsets on resize
+        /// Ref. https://github.com/Automattic/simplenote-macos/issues/536
         container.widthTracksTextView  = false
     }
 

--- a/Simplenote/NoteEditorViewController+Swift.swift
+++ b/Simplenote/NoteEditorViewController+Swift.swift
@@ -91,6 +91,47 @@ extension NoteEditorViewController {
 }
 
 
+// MARK: - Display Mode
+//
+extension NoteEditorViewController {
+
+    @objc
+    func refreshTextContainer() {
+        guard let container = noteEditor.textContainer else {
+            fatalError()
+        }
+
+        let superviewWidth              = view.frame.width
+        let targetMaximumTextWidth      = maximumTextWidth(for: superviewWidth)
+        let targetContainerInset        = textContainerInset(superviewWidth: superviewWidth, maximumTextWidth: targetMaximumTextWidth)
+        let targetContainerSize         = textContainerSize(superviewWidth: superviewWidth, textContainerInset: targetContainerInset)
+
+        noteEditor.textContainerInset  = targetContainerInset
+        container.containerSize        = targetContainerSize
+        container.widthTracksTextView  = false
+    }
+
+    private func maximumTextWidth(for superviewWidth: CGFloat) -> CGFloat {
+        Options.shared.editorFullWidth ? superviewWidth : min(EditorMetrics.maximumNarrowWidth, superviewWidth)
+    }
+
+    /// Whenever `SuperviewWidth > MaximumTextWidth` this API will return an Inset which will center onscreen the TextContainer
+    ///
+    private func textContainerInset(superviewWidth: CGFloat, maximumTextWidth: CGFloat) -> NSSize {
+        let width = max((superviewWidth - maximumTextWidth), .zero) * 0.5
+        return NSMakeSize(width + EditorMetrics.minimumPadding, EditorMetrics.minimumPadding)
+    }
+
+    /// # Note: Why not receiving the MaximumTextWidth instead?
+    /// Because in Narrow Display we intend to center the TextContainer, and such calculation is actually done in `textContainerInset`
+    ///
+    private func textContainerSize(superviewWidth: CGFloat, textContainerInset: NSSize) -> NSSize {
+        let width = superviewWidth - textContainerInset.width * 2
+        return NSSize(width: width, height: .greatestFiniteMagnitude)
+    }
+}
+
+
 // MARK: - Internal State
 //
 extension NoteEditorViewController {
@@ -860,4 +901,18 @@ private extension NoteEditorViewController {
 
         return interlinkWindowController
     }
+}
+
+
+// MARK: - EditorMetrics
+//
+private enum EditorMetrics {
+
+    /// Note: This matches the Electron apps max editor width
+    ///
+    static let maximumNarrowWidth = CGFloat(750)
+
+    /// Minimum Text Padding: To be applied Vertically / Horizontally
+    ///
+    static let minimumPadding = CGFloat(20)
 }

--- a/Simplenote/NoteEditorViewController+Swift.swift
+++ b/Simplenote/NoteEditorViewController+Swift.swift
@@ -101,17 +101,17 @@ extension NoteEditorViewController {
             fatalError()
         }
 
-        let superviewWidth              = view.frame.width
-        let targetMaximumTextWidth      = maximumTextWidth(for: superviewWidth)
-        let targetContainerInset        = textContainerInset(superviewWidth: superviewWidth, maximumTextWidth: targetMaximumTextWidth)
-        let targetContainerSize         = textContainerSize(superviewWidth: superviewWidth, textContainerInset: targetContainerInset)
+        let superviewWidth = view.frame.width
+        let targetMaxTextWidth = maximumTextWidth(for: superviewWidth)
+        let targetContainerInset = textContainerInset(superviewWidth: superviewWidth, maximumTextWidth: targetMaxTextWidth)
+        let targetContainerSize = textContainerSize(superviewWidth: superviewWidth, textContainerInset: targetContainerInset)
 
-        noteEditor.textContainerInset  = targetContainerInset
-        container.containerSize        = targetContainerSize
+        noteEditor.textContainerInset = targetContainerInset
+        container.containerSize = targetContainerSize
 
         /// Note: Disabling `widthTracksTextView` fixes jumpy Scroll Offsets on resize
         /// Ref. https://github.com/Automattic/simplenote-macos/issues/536
-        container.widthTracksTextView  = false
+        container.widthTracksTextView = false
     }
 
     private func maximumTextWidth(for superviewWidth: CGFloat) -> CGFloat {

--- a/Simplenote/NoteEditorViewController.m
+++ b/Simplenote/NoteEditorViewController.m
@@ -81,7 +81,7 @@ static NSString * const SPMarkdownPreferencesKey        = @"kMarkdownPreferences
     self.storage = [Storage new];
     [self.noteEditor.layoutManager replaceTextStorage:self.storage];
     [self.noteEditor.layoutManager setDefaultAttachmentScaling:NSImageScaleProportionallyDown];
-    
+
     // Set hyperlinks to be the same color as the app's highlight color
     [self.noteEditor setLinkTextAttributes: @{
        NSForegroundColorAttributeName: [NSColor simplenoteLinkColor],
@@ -129,6 +129,7 @@ static NSString * const SPMarkdownPreferencesKey        = @"kMarkdownPreferences
     [super viewWillLayout];
     [self refreshScrollInsets];
     [self refreshHeaderState];
+    [self refreshTextContainer];
 }
 
 - (void)save
@@ -281,7 +282,7 @@ static NSString * const SPMarkdownPreferencesKey        = @"kMarkdownPreferences
 
 - (void)displayModeWasUpdated:(NSNotification *)notification
 {
-    self.noteEditor.needsDisplay = YES;
+    self.view.needsLayout = YES;
 }
 
 - (NSUInteger)newCursorLocation:(NSString *)newText oldText:(NSString *)oldText currentLocation:(NSUInteger)location

--- a/Simplenote/SPTextView.m
+++ b/Simplenote/SPTextView.m
@@ -10,9 +10,6 @@
 #import "NSMutableAttributedString+Styling.h"
 #import "Simplenote-Swift.h"
 
-// Note: This matches the Electron apps max editor width
-static CGFloat const SPTextViewMaximumWidth = 750;
-static CGFloat const SPTextViewMinimumPadding = 20;
 
 @implementation SPTextView
 
@@ -39,27 +36,6 @@ static CGFloat const SPTextViewMinimumPadding = 20;
 {
     [super paste:sender];
     [self processLinksInDocumentAsynchronously];
-}
-
-- (void)drawRect:(NSRect)dirtyRect
-{
-    CGFloat viewWidth = self.frame.size.width;
-    CGFloat insetX = [self shouldCalculateInset:viewWidth] ? [self getAdjustedInsetX:viewWidth] : SPTextViewMinimumPadding;
-    [self setTextContainerInset: NSMakeSize(insetX, SPTextViewMinimumPadding)];
-    
-    [super drawRect:dirtyRect];
-}
-
-- (BOOL)shouldCalculateInset:(CGFloat)viewWidth
-{
-    return viewWidth > SPTextViewMaximumWidth && ![[Options shared] editorFullWidth];
-}
-
-- (CGFloat)getAdjustedInsetX:(CGFloat)viewWidth
-{
-    CGFloat adjustedInset = (viewWidth - SPTextViewMaximumWidth) / 2;
-    
-    return lroundf(adjustedInset) + SPTextViewMinimumPadding;
 }
 
 - (BOOL)checkForChecklistClick:(NSEvent *)event


### PR DESCRIPTION
### Fix
In this PR we're implementing the mechanism that gets the TextView's "Narrow Width" mode:

- **NSTextContainer.widthTracksTextView** is now disabled. This was the source of a jumpy behavior
- We're manually updating the TextContainer's size
- Insets are now being applied in a `layout` API, rather than in the `draw` override

@eshurakov WOW third PR of the year!! 😂 
Closes #536 

### Test
1. Open a long document
2. Press CMD + T repeatedly, at different scroll offsets

- [ ] Verify the Stroll Offset is always preserved
- [ ] Repeat for `Line Length > Full` and `Narrow` please!!

### Release
`RELEASE-NOTES.txt` was updated in 72a59f1 with:

> Fixed a bug that caused the Editor Scroll Offset to jump #785
