### PR TITLE
Window: Restoring DoubleClick on Titlebar behavior

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -15,7 +15,8 @@
 - Fixed a bug that caused Line Height to be inconsistent in Empty Documents #771
 - Fixed a bug that caused an unexpected jump in the Tags List #767
 - Fixed a bug that caused the Tags List to go blank upon tag rename #344
- 
+- Fixed a bug that prevented the Window from Maximizing / Minimizing on double click #786
+
 2.5
 -----
 - Removed Main Window's Titlebar #719

--- a/Simplenote/NSWindow+Simplenote.swift
+++ b/Simplenote/NSWindow+Simplenote.swift
@@ -55,4 +55,11 @@ extension NSWindow {
 
         return isRTL ? (frame.width - semaphoreBounds.minX) : semaphoreBounds.maxX
     }
+
+    /// Returns the Titlebar's Rect 
+    ///
+    var titlebarRect: NSRect {
+        let layoutRect = contentLayoutRect
+        return NSRect(x: layoutRect.minX, y: layoutRect.maxY, width: layoutRect.width, height: frame.height - layoutRect.height)
+    }
 }

--- a/Simplenote/Window.swift
+++ b/Simplenote/Window.swift
@@ -55,6 +55,11 @@ class Window: NSWindow {
         super.sendEvent(event)
     }
 
+    override func mouseUp(with event: NSEvent) {
+        processDoubleClickOnTitlebarIfNeeded(with: event)
+        super.mouseUp(with: event)
+    }
+
     override func layoutIfNeeded() {
         super.layoutIfNeeded()
         relocateSemaphoreButtonsIfNeeded()
@@ -113,5 +118,28 @@ private extension Window {
             origin.x += semaphorePaddingX * directionalMultiplier
             button.frame.origin = origin
         }
+    }
+}
+
+
+// MARK: - Titlebar / DoubleClick Workaround
+//
+private extension Window {
+
+    /// Whenever a NSWindow instance has the `.fullSizeContentView` mask, the system will simply no longer automatically process
+    /// double click events on the Titlebar Area.
+    ///
+    /// Ref. #1: https://github.com/Automattic/simplenote-macos/issues/773
+    /// Ref. #2: https://stackoverflow.com/questions/52150960/double-click-on-transparent-nswindow-title-does-not-maximize-the-window/61712229#61712229
+    ///
+    func processDoubleClickOnTitlebarIfNeeded(with event: NSEvent) {
+        guard styleMask.contains(.fullSizeContentView),
+              event.clickCount >= 2,
+              titlebarRect.contains(event.locationInWindow)
+        else {
+            return
+        }
+
+        self.performZoom(nil)
     }
 }


### PR DESCRIPTION
### Fix
In order to restore the default behavior whenever the user performs a Double Click on the Window's titlebar, in this PR we're introducing a small workaround.

Closes #773

cc @eshurakov (Thank yooouuu!!)

### Test
1. Log into your account
2. Double click on the Titlebar

- [ ] Verify the app Maximizes / Minimizes

### Release
`RELEASE-NOTES.txt` was updated in 18a9148 with:

> Fixed a bug that prevented the Window from Maximizing / Minimizing on double click #786
