### PR TITLE
Adjusting legacy macOS Window Semaphore Metrics

### DIFF
--- a/Simplenote/MainWindowController.swift
+++ b/Simplenote/MainWindowController.swift
@@ -100,6 +100,14 @@ extension MainWindowController {
 // MARK: - Metrics
 //
 private enum Metrics {
-    static let semaphoreButtonPositionY: CGFloat = 4
     static let semaphoreButtonPaddingX: CGFloat = 7
+    static var semaphoreButtonPositionY: CGFloat {
+        let bigSurPositionY: CGFloat = 4
+        let mojavePositionY: CGFloat = 3
+        guard #available(macOS 11, *) else {
+            return mojavePositionY
+        }
+
+        return bigSurPositionY
+    }
 }


### PR DESCRIPTION
### Fix
In this PR we're fine tunning the main Window's Semaphore location, in macOS 10.14 / 10.15.

@eshurakov First PR of the year!! 🥳 

Ref. #718

### Test
- [ ] Verify the Window Semaphore buttons (Maximize / Minimize / Close) look great when the Tag List is collapsed.

### Release
These changes do not require release notes.

### Screenshots
<img width="400" src="https://user-images.githubusercontent.com/1195260/103389161-f306a100-4aeb-11eb-9625-a7f800c9c4a0.jpg">

