### PR TITLE
Notes: Sort Date

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -8,6 +8,7 @@
 - Notes List now display row separators #758
 - Notes List will now animate content changes #764
 - Search Results are now global #760
+- Search Results will now display the Creation or Modification date when appropriate #790
 - Updated Color Palette #733
 - Entering Search Mode now displays automatically the Notes List #770
 - Full Width Line Length is now enabled by default #762

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -156,6 +156,8 @@
 		B518D37B2507BFA4006EA7F8 /* Note+Interlinks.swift in Sources */ = {isa = PBXBuildFile; fileRef = B518D37A2507BFA4006EA7F8 /* Note+Interlinks.swift */; };
 		B518D37C2507BFA4006EA7F8 /* Note+Interlinks.swift in Sources */ = {isa = PBXBuildFile; fileRef = B518D37A2507BFA4006EA7F8 /* Note+Interlinks.swift */; };
 		B518D37E2507C356006EA7F8 /* StringSimplenoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B518D37D2507C356006EA7F8 /* StringSimplenoteTests.swift */; };
+		B51D85F425A8B392005F08CE /* NoteListPrefixFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B51D85F325A8B392005F08CE /* NoteListPrefixFormatter.swift */; };
+		B51D85F525A8B392005F08CE /* NoteListPrefixFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B51D85F325A8B392005F08CE /* NoteListPrefixFormatter.swift */; };
 		B51E9FE122E615FA004F16B4 /* SPExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B51E9FE022E615FA004F16B4 /* SPExporter.swift */; };
 		B51E9FE222E615FA004F16B4 /* SPExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B51E9FE022E615FA004F16B4 /* SPExporter.swift */; };
 		B51E9FE522E644A0004F16B4 /* NSObject+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B51E9FE422E644A0004F16B4 /* NSObject+Helpers.swift */; };
@@ -552,6 +554,7 @@
 		B518D3772507BF1B006EA7F8 /* NSPasteboard+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSPasteboard+Simplenote.swift"; sourceTree = "<group>"; };
 		B518D37A2507BFA4006EA7F8 /* Note+Interlinks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Note+Interlinks.swift"; sourceTree = "<group>"; };
 		B518D37D2507C356006EA7F8 /* StringSimplenoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringSimplenoteTests.swift; sourceTree = "<group>"; };
+		B51D85F325A8B392005F08CE /* NoteListPrefixFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteListPrefixFormatter.swift; sourceTree = "<group>"; };
 		B51E9FE022E615FA004F16B4 /* SPExporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPExporter.swift; sourceTree = "<group>"; };
 		B51E9FE422E644A0004F16B4 /* NSObject+Helpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSObject+Helpers.swift"; sourceTree = "<group>"; };
 		B52197852541C65C00182928 /* NumberFormatter+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NumberFormatter+Simplenote.swift"; sourceTree = "<group>"; };
@@ -945,6 +948,7 @@
 				F998F3EA22853C29008C2B59 /* CrashLogging.swift */,
 				B57CB87A244DEC4A00BA7969 /* MigrationsHandler.swift */,
 				B51E9FE022E615FA004F16B4 /* SPExporter.swift */,
+				B51D85F325A8B392005F08CE /* NoteListPrefixFormatter.swift */,
 				B54F9A6924D0BDC100BCF754 /* TagTextFormatter.swift */,
 				37D4DD6920B3574C00C225EA /* WPAuthHandler.h */,
 				37D4DD6820B3574C00C225EA /* WPAuthHandler.m */,
@@ -1828,6 +1832,7 @@
 				B5A5AF7C244FA7BA0051D927 /* NoteEditorViewController+Swift.swift in Sources */,
 				B500993C24213B370037A431 /* String+Simplenote.swift in Sources */,
 				B5C9776C25408BD200702C10 /* SeparatorTableViewCell.swift in Sources */,
+				B51D85F425A8B392005F08CE /* NoteListPrefixFormatter.swift in Sources */,
 				B50FB214251BB2E00028DE25 /* InterlinkWindowController.swift in Sources */,
 				B58BBD2A2523D4CA0025135F /* Window.swift in Sources */,
 				3712FC8C1FE1ACAA008544AC /* Style.swift in Sources */,
@@ -2114,6 +2119,7 @@
 				B5C620A3257EA526008359A9 /* NSView+Simplenote.swift in Sources */,
 				B59848811BCDB95A005EFBBE /* SPAutomatticTracker.m in Sources */,
 				B5EF32BA258D07F00069EC7D /* NoteListController.swift in Sources */,
+				B51D85F525A8B392005F08CE /* NoteListPrefixFormatter.swift in Sources */,
 				B528D684257FF15000C1EEA4 /* MainWindowController.swift in Sources */,
 				37AE49C31FFEB92A00FCB165 /* SPMarkdownParser.m in Sources */,
 				B5CBB05D2419714B0003C271 /* NSAttributedStringToMarkdownConverter.swift in Sources */,

--- a/Simplenote/DateFormatter+Simplenote.swift
+++ b/Simplenote/DateFormatter+Simplenote.swift
@@ -14,6 +14,15 @@ extension DateFormatter {
         return formatter
     }()
 
+    /// Date Formatter for the Notes List
+    ///
+    static let notesFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .short
+        formatter.timeStyle = .none
+        return formatter
+    }()
+
     /// Date Formatter for History
     ///
     static let historyFormatter: DateFormatter = metricsFormatter

--- a/Simplenote/Note+Simplenote.swift
+++ b/Simplenote/Note+Simplenote.swift
@@ -5,6 +5,21 @@ import Foundation
 //
 extension Note {
 
+    /// Returns the Creation / Modification date for a given SortMode
+    ///
+    func date(for sortMode: SortMode) -> Date? {
+        switch sortMode {
+        case .alphabeticallyAscending, .alphabeticallyDescending:
+            return nil
+
+        case .createdNewest, .createdOldest:
+            return creationDate
+
+        case .modifiedNewest, .modifiedOldest:
+            return modificationDate
+        }
+    }
+
     /// Given a collection of Tag Names, this API will return the subset that's not already associated with the receiver.
     ///
     func filterUnassociatedTagNames(from names: [String]) -> [String] {

--- a/Simplenote/Note+Simplenote.swift
+++ b/Simplenote/Note+Simplenote.swift
@@ -5,21 +5,6 @@ import Foundation
 //
 extension Note {
 
-    /// Returns the Creation / Modification date for a given SortMode
-    ///
-    func date(for sortMode: SortMode) -> Date? {
-        switch sortMode {
-        case .alphabeticallyAscending, .alphabeticallyDescending:
-            return nil
-
-        case .createdNewest, .createdOldest:
-            return creationDate
-
-        case .modifiedNewest, .modifiedOldest:
-            return modificationDate
-        }
-    }
-
     /// Given a collection of Tag Names, this API will return the subset that's not already associated with the receiver.
     ///
     func filterUnassociatedTagNames(from names: [String]) -> [String] {

--- a/Simplenote/NoteListPrefixFormatter.swift
+++ b/Simplenote/NoteListPrefixFormatter.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+
+// MARK: - NoteListPrefixFormatter
+//
+struct NoteListPrefixFormatter {
+
+    /// Let's... reuse the formatter?
+    ///
+    static let shared = NoteListPrefixFormatter()
+
+
+    /// Returns a Prefix for the specified Note, matching a given SortMode
+    ///
+    func prefix(from note: Note, for sortMode: SortMode) -> String? {
+        guard let date = date(from: note, for: sortMode) else {
+            return nil
+        }
+
+        return DateFormatter.notesFormatter.string(from: date)
+    }
+
+    /// Returns the relevant Note Date field for the specified Sort Mode
+    ///
+    private func date(from note: Note, for sortMode: SortMode) -> Date? {
+        switch sortMode {
+        case .alphabeticallyAscending, .alphabeticallyDescending:
+            return nil
+
+        case .createdNewest, .createdOldest:
+            return note.creationDate
+
+        case .modifiedNewest, .modifiedOldest:
+            return note.modificationDate
+        }
+    }
+}

--- a/Simplenote/NoteListPrefixFormatter.swift
+++ b/Simplenote/NoteListPrefixFormatter.swift
@@ -5,11 +5,6 @@ import Foundation
 //
 struct NoteListPrefixFormatter {
 
-    /// Let's... reuse the formatter?
-    ///
-    static let shared = NoteListPrefixFormatter()
-
-
     /// Returns a Prefix for the specified Note, matching a given SortMode
     ///
     func prefix(from note: Note, for sortMode: SortMode) -> String? {

--- a/Simplenote/NoteListViewController.swift
+++ b/Simplenote/NoteListViewController.swift
@@ -528,7 +528,7 @@ private extension NoteListViewController {
             return nil
         }
 
-        return NoteListPrefixFormatter.shared.prefix(from: note, for: listController.sortMode)
+        return NoteListPrefixFormatter().prefix(from: note, for: listController.sortMode)
     }
 }
 

--- a/Simplenote/NoteListViewController.swift
+++ b/Simplenote/NoteListViewController.swift
@@ -515,11 +515,20 @@ private extension NoteListViewController {
         noteView.displaysSharedIndicator = note.published
         noteView.title = note.titlePreview
         noteView.body = note.bodyPreview
+        noteView.bodyPrefix = bodyPrefix(for: note)
         noteView.rendersInCondensedMode = Options.shared.notesListCondensed
 
         noteView.refreshStyle()
 
         return noteView
+    }
+
+    func bodyPrefix(for note: Note) -> String? {
+        guard isSearching, let date = note.date(for: listController.sortMode) else {
+            return nil
+        }
+
+        return DateFormatter.notesFormatter.string(from: date)
     }
 }
 

--- a/Simplenote/NoteListViewController.swift
+++ b/Simplenote/NoteListViewController.swift
@@ -524,11 +524,11 @@ private extension NoteListViewController {
     }
 
     func bodyPrefix(for note: Note) -> String? {
-        guard isSearching, let date = note.date(for: listController.sortMode) else {
+        guard isSearching else {
             return nil
         }
 
-        return DateFormatter.notesFormatter.string(from: date)
+        return NoteListPrefixFormatter.shared.prefix(from: note, for: listController.sortMode)
     }
 }
 

--- a/Simplenote/NoteTableCellView.swift
+++ b/Simplenote/NoteTableCellView.swift
@@ -86,6 +86,10 @@ class NoteTableCellView: NSTableCellView {
     ///
     var body: String?
 
+    /// Body's Prefix: Designed to display Dates (with a slightly different style) when appropriate.
+    ///
+    var bodyPrefix: String?
+
 
     // MARK: - Overridden Methods
 
@@ -116,15 +120,8 @@ extension NoteTableCellView {
     /// Refreshed the Label(s) Attributed Strings: Keywords, Bullets and the Body Prefix will be taken into consideration
     ///
     private func refreshAttributedStrings() {
-        let bodyColor: NSColor = selected ? .simplenoteTextColor : .simplenoteSecondaryTextColor
-
-        titleTextField.attributedStringValue = title.map {
-            NSAttributedString.previewString(text: $0, font: Fonts.title, color: .simplenoteTextColor)
-        } ?? NSAttributedString()
-
-        bodyTextField.attributedStringValue = body.map {
-            NSAttributedString.previewString(text: $0, font: Fonts.body, color: bodyColor)
-        } ?? NSAttributedString()
+        titleTextField.attributedStringValue = titleString
+        bodyTextField.attributedStringValue = bodyString
     }
 
     /// Refreshes the Accessory Icons tint color
@@ -136,6 +133,33 @@ extension NoteTableCellView {
 
         pinnedImageView.image = pinnedImageView.image?.tinted(with: pinnedColor)
         sharedImageView.image = sharedImageView.image?.tinted(with: sharedColor)
+    }
+}
+
+
+// MARK: - String Builders
+//
+private extension NoteTableCellView {
+
+    var titleString: NSAttributedString {
+        return title.map {
+            NSAttributedString.previewString(text: $0, font: Fonts.title, color: .simplenoteTextColor)
+        } ?? NSAttributedString()
+    }
+
+    var bodyString: NSAttributedString {
+        let bodyString = NSMutableAttributedString()
+        let bodyColor: NSColor = selected ? .simplenoteTextColor : .simplenoteSecondaryTextColor
+
+        if let bodyPrefix = bodyPrefix {
+            bodyString += NSAttributedString.previewString(text: bodyPrefix + String.space, font: Fonts.bodyPrefix, color: .simplenoteTextColor)
+        }
+
+        if let bodySuffix = body {
+            bodyString += NSAttributedString.previewString(text: bodySuffix, font: Fonts.body, color: bodyColor)
+        }
+
+        return bodyString
     }
 }
 
@@ -214,6 +238,7 @@ private enum Metrics {
 private enum Fonts {
     static let title = NSFont.systemFont(ofSize: 14, weight: .semibold)
     static let body = NSFont.systemFont(ofSize: 12)
+    static let bodyPrefix = NSFont.systemFont(ofSize: 12, weight: .semibold)
 }
 
 
@@ -234,4 +259,8 @@ extension NSAttributedString {
 
         return attrString
     }
+}
+
+func +=(lhs: NSMutableAttributedString, rhs: NSAttributedString) {
+    lhs.append(rhs)
 }


### PR DESCRIPTION
### Details
In this PR we're enhancing the Notes List so that when you're in Search Mode, and the selected Sort Mode is either **Created** / **Modified**, the associated Date will be prepended to the Note Body.

cc @eshurakov 
Thank you sir!!

Ref. #626 

### Test
1. Log into your account
2. Press the top right 🔍 icon
3. Click anywhere in the Sortbar (top of the Notes List)

- [x] Verify that selecting **Creation: Newest / Oldest** causes the Creation date to be prepended to the Note's Body (in the Notes List Area)
- [x] Repeat for **Modified: Newest / Oldest**
- [x] Verify that exiting the Search Mode removes the **Date** prefix

### Release
`RELEASE-NOTES.txt` was updated in 12770fd with:

> Search Results will now display the Creation or Modification date when appropriate #790

### Screenshot

![Screenshot](https://user-images.githubusercontent.com/1195260/103685746-7f8de500-4f6c-11eb-82b7-3baa86dce351.jpg)
