### PR TITLE
Notes: Extra Bottom Insets

### DIFF
--- a/Simplenote/NoteListViewController.swift
+++ b/Simplenote/NoteListViewController.swift
@@ -110,6 +110,7 @@ private extension NoteListViewController {
         let extraInsets: CGFloat = sortbarView.isHidden ? .zero : sortbarView.bounds.height
 
         clipView.contentInsets.top = SplitItemMetrics.listContentTopInset + extraInsets
+        clipView.contentInsets.bottom = SplitItemMetrics.listContentBottomInset
         scrollView.scrollerInsets.top = SplitItemMetrics.listScrollerTopInset + extraInsets
     }
 }

--- a/Simplenote/SplitItemMetrics.swift
+++ b/Simplenote/SplitItemMetrics.swift
@@ -24,10 +24,21 @@ enum SplitItemMetrics {
         return sidebarTopInsetBigSur
     }
 
-    /// List Insets: Content
+    /// List Insets: Content / Top
     ///
     static var listContentTopInset: CGFloat {
         sidebarTopInset
+    }
+
+    /// List Insets: Content / Bottom
+    ///
+    static var listContentBottomInset: CGFloat {
+        let bottomInsetBigSur: CGFloat = 10
+        guard #available(macOS 11, *) else {
+            return .zero
+        }
+
+        return bottomInsetBigSur
     }
 
     /// List Insets: Scroller


### PR DESCRIPTION
### Fix
In this PR we're adding a **bottom Inset** in the Notes List, when running macOS BigSur or higher.

cc @SylvesterWilmott 
cc @eshurakov 

Thanks in advance gentleman!!

Ref. #626

### Test
1. Log into your account
2. Resize the Window so that the Notes List requires scrolling
3. Scroll to the bottom of the list

- [x] Verify: In Mojave / Catalina there is no extra Insets at the bottom
- [ ] Verify: In Big Sur there's an Inset at the bottom

### Release
These changes do not require release notes.

### Screenshots
![Extra Insets](https://user-images.githubusercontent.com/1195260/103686802-1dce7a80-4f6e-11eb-8351-a4aeace81a88.jpg)
