### PR TITLE
Notes: Empty State

### DIFF
--- a/Simplenote/NoteListViewController.swift
+++ b/Simplenote/NoteListViewController.swift
@@ -288,6 +288,14 @@ private extension NoteListViewController {
     ///
     private func refreshPlaceholder() {
         statusField.isHidden = listController.numberOfNotes > .zero
+
+        statusField.stringValue = {
+            if isSearching {
+                return NSLocalizedString("No Results", comment: "No Search Results")
+            }
+
+            return NSLocalizedString("No Notes", comment: "No Notes Available")
+        }()
     }
 
     /// Refresh: Title


### PR DESCRIPTION
### Details
In this PR we're adjusting the Notes List's Empty State placeholder, so that when there are No Search Results the legend is different.

cc @eshurakov (Spamming again!!)
Ref. #626

### Test
1. Click over any Tag that contains no notes
2. Verify the Notes List displays a Label that reads **No Notes**
3. Click over the top right 🔍 Icon
4. Enter a Keyword that yields no results

- [ ] Verify the Notes List displays the **No Results** placeholder

### Release
These changes do not require release notes.
