### PR TITLE
New Toggle Sidebar Behavior

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -10,6 +10,7 @@
 - Search Results are now global #760
 - Updated Color Palette #733
 - Entering Search Mode now displays automatically the Notes List #770
+- Exiting Focus Mode will now restore the previous Sidebar State #742
 - Full Width Line Length is now enabled by default #762
 - Fixed a bug that affected Multiple Selection in Big Sur #753
 - Fixed a bug that caused an artifact to show up in the SplitView dividers #779

--- a/Simplenote/SplitViewController.swift
+++ b/Simplenote/SplitViewController.swift
@@ -89,8 +89,13 @@ private extension SplitViewController {
     }
 
     func refreshCollapsedItems(for state: SplitState) {
-        tagsSplitItem.animator().isCollapsed = state.isTagsCollapsed
-        notesSplitItem.animator().isCollapsed = state.isNotesCollapsed
+        if tagsSplitItem.isCollapsed != state.isTagsCollapsed {
+            tagsSplitItem.animator().isCollapsed = state.isTagsCollapsed
+        }
+
+        if notesSplitItem.isCollapsed != state.isNotesCollapsed {
+            notesSplitItem.animator().isCollapsed = state.isNotesCollapsed
+        }
     }
 
     func restorePreviousState() -> Bool {

--- a/Simplenote/SplitViewController.swift
+++ b/Simplenote/SplitViewController.swift
@@ -6,11 +6,24 @@ import Foundation
 @objc
 class SplitViewController: NSSplitViewController {
 
-    /// Indicates if the Notes List is collapsed
+    /// Indicates if we're in Focus Mode (Also known as Notes List is collapsed)
     ///
     var isFocusModeEnabled: Bool {
+        isNotesCollapsed
+    }
+
+    /// Indicates if the Tags List is collapsed
+    ///
+    var isTagsCollapsed: Bool {
+        splitViewItem(ofKind: .tags).isCollapsed
+    }
+
+    /// Indicates if the Notes List is collapsed
+    ///
+    var isNotesCollapsed: Bool {
         splitViewItem(ofKind: .notes).isCollapsed
     }
+
 
 
     // MARK: - Overridden Methods
@@ -86,16 +99,24 @@ extension SplitViewController {
 
     @IBAction
     func toggleSidebarAction(sender: Any) {
-        SPTracker.trackSidebarButtonPresed()
+        let tagsSplitItem = splitViewItem(ofKind: .tags)
+        let notesSplitItem = splitViewItem(ofKind: .notes)
 
-        // Stop focus mode when the sidebar button is pressed with focus mode active
-        if isFocusModeEnabled {
-            focusModeAction(sender: sender)
-            return
+        // State #0: Hide the Tags List
+        if !isTagsCollapsed {
+            tagsSplitItem.animator().isCollapsed = true
+
+        // State #1: Hide the Notes List
+        } else if !isNotesCollapsed {
+            notesSplitItem.animator().isCollapsed = true
+
+        // State #2: Show all the things
+        } else {
+            notesSplitItem.animator().isCollapsed = false
+            tagsSplitItem.animator().isCollapsed = false
         }
 
-        let tagsSplitItem = splitViewItem(ofKind: .tags)
-        tagsSplitItem.animator().isCollapsed = !tagsSplitItem.isCollapsed
+        SPTracker.trackSidebarButtonPresed()
     }
 
     @IBAction

--- a/Simplenote/SplitViewController.swift
+++ b/Simplenote/SplitViewController.swift
@@ -9,21 +9,8 @@ class SplitViewController: NSSplitViewController {
     /// Indicates if we're in Focus Mode (Also known as Notes List is collapsed)
     ///
     var isFocusModeEnabled: Bool {
-        isNotesCollapsed
+        notesSplitItem.isCollapsed
     }
-
-    /// Indicates if the Tags List is collapsed
-    ///
-    var isTagsCollapsed: Bool {
-        splitViewItem(ofKind: .tags).isCollapsed
-    }
-
-    /// Indicates if the Notes List is collapsed
-    ///
-    var isNotesCollapsed: Bool {
-        splitViewItem(ofKind: .notes).isCollapsed
-    }
-
 
 
     // MARK: - Overridden Methods
@@ -77,14 +64,12 @@ extension SplitViewController {
 //
 private extension SplitViewController {
 
-    var collapsibleItems: [NSSplitViewItem] {
-        SplitItemKind.allCases.compactMap { kind in
-            guard kind.isCollapsible else {
-                return nil
-            }
+    var tagsSplitItem: NSSplitViewItem {
+        splitViewItem(ofKind: .tags)
+    }
 
-            return splitViewItem(ofKind: kind)
-        }
+    var notesSplitItem: NSSplitViewItem {
+        splitViewItem(ofKind: .notes)
     }
 
     func splitViewItem(ofKind kind: SplitItemKind) -> NSSplitViewItem {
@@ -99,15 +84,15 @@ extension SplitViewController {
 
     @IBAction
     func toggleSidebarAction(sender: Any) {
-        let tagsSplitItem = splitViewItem(ofKind: .tags)
-        let notesSplitItem = splitViewItem(ofKind: .notes)
+        let tagsItem = tagsSplitItem
+        let notesItem = notesSplitItem
 
         // State #0: Hide the Tags List
-        if !isTagsCollapsed {
+        if !tagsItem.isCollapsed {
             tagsSplitItem.animator().isCollapsed = true
 
         // State #1: Hide the Notes List
-        } else if !isNotesCollapsed {
+        } else if !notesItem.isCollapsed {
             notesSplitItem.animator().isCollapsed = true
 
         // State #2: Show all the things
@@ -123,7 +108,7 @@ extension SplitViewController {
     func focusModeAction(sender: Any) {
         let nextState = !isFocusModeEnabled
 
-        for splitItem in collapsibleItems {
+        for splitItem in [tagsSplitItem, notesSplitItem] {
             splitItem.animator().isCollapsed = nextState
         }
     }
@@ -155,10 +140,6 @@ extension SplitItemKind {
 
     var index: Int {
         rawValue
-    }
-
-    var isCollapsible: Bool {
-        self != .editor
     }
 
     var minimumThickness: CGFloat {


### PR DESCRIPTION
### Fix
In this PR we're implementing a FSM in the SplitView, so that:

- Toggle Sidebar now cycles thru three states: Notes Hidden / Tags Hidden / Everything Onscreen
- Exiting Focus Mode restores the previous Tags List state

cc @SylvesterWilmott 
cc @eshurakov 

Thank you gentlemen!!

Closes #742


### Test: Toggle Sidebar
1. Launch Simplenote
- [x] Press CMD + T and verify the Tags List gets hidden
- [x] Press CMD + T and verify the Notes List gets hidden
- [x] Press CMD + T and verify all the things are presented again

### Test: Focus
1. Launch Simplenote

- [x] Press **CMD + Shift + F** and verify the editor gets into Focus Mode (Tags + Notes hidden)
- [x] Press **CMD + Shift + F** again and verify the Editor exits Focus mode (Tags + Notes visible)
- [x] Press **CMD + T** and verify the Tags List gets hidden
- [x] Press **CMD + Shift + F** and verify the editor gets in Focus Mode
- [x] Press **CMD + Shift + F** again and **verify only the Notes List** is visible

### Test: Focus toggles Editor
1. Launch Simplenote

- [x] Press **CMD + T** twice to hide the Notes and Tags lists
- [x] Press **CMD + Shift + F** and verify both the Notes + Tags List become visible

### Release
`RELEASE-NOTES.txt` was updated in 12b9970 with:

> Exiting Focus Mode will now restore the previous Sidebar State #742
