### PR TITLE
Editor: Fixes unexpected Notes Jump behavior

### DIFF
--- a/Simplenote/NoteEditorViewController+Swift.swift
+++ b/Simplenote/NoteEditorViewController+Swift.swift
@@ -665,9 +665,20 @@ extension NoteEditorViewController {
         }
 
         save()
+        ensureSelectedNoteIsVisible(oldTags: oldTags, newTags: note.tags, simperiumKey: note.simperiumKey)
+    }
 
-        // Ensure the note remains onscreen
-        simplenoteAppDelegate.displayNote(simperiumKey: note.simperiumKey)
+    /// Displays the current Note in the Notes List whenever we're filtering by Tag, and such String gets removed from the Tags collection
+    ///
+    private func ensureSelectedNoteIsVisible(oldTags: String?, newTags: String?, simperiumKey: String) {
+        guard case let .tag(selectedTag) = simplenoteAppDelegate.selectedTagFilter,
+              oldTags?.contains(selectedTag) == true,
+              newTags?.contains(selectedTag) == false
+        else {
+            return
+        }
+
+        simplenoteAppDelegate.displayNote(simperiumKey: simperiumKey)
     }
 }
 


### PR DESCRIPTION
### Fix
In this PR we're fixing a bug in which the Notes List would unexpectedly jump elsewhere.

cc @eshurakov (Thank yooou!!)
Closes #783

### Test: Bugfix
1. Select All notes
2. Start editing the Tags List
3. Type a random new Tag Name
4. Without clicking anywhere else, scroll all the way to the bottom of the Notes List
5. Click anywhere

- [x] Verify the note you've selected is now highlighted

### Test: Regressions
1. Select any tag that contains a note
2. Click over the Tags List area
3. Remove the current Tag from the note

- [x] Verify **All Notes** is now selected
- [x] Verify the same Note remains onscreen

### Release
These changes do not require release notes.
