### PR TITLE
Fixing SplitView Restoration

### DIFF
--- a/Simplenote/Main.storyboard
+++ b/Simplenote/Main.storyboard
@@ -889,7 +889,6 @@
                     </window>
                     <connections>
                         <outlet property="simplenoteWindow" destination="Xk8-MH-eev" id="UZU-US-aOB"/>
-                        <segue destination="pbQ-Wy-u9S" kind="relationship" relationship="window.shadowedContentViewController" id="OXN-9V-bSk"/>
                     </connections>
                 </windowController>
                 <customObject id="z6J-n3-huD" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>

--- a/Simplenote/MainWindowController.swift
+++ b/Simplenote/MainWindowController.swift
@@ -9,6 +9,16 @@ class MainWindowController: NSWindowController {
     ///
     @IBOutlet private(set) var simplenoteWindow: Window!
 
+    /// We can't have nice things (II): Autosave must be set **after** the contentViewController has been assigned. Otherwise it won't work
+    /// Ref.:  https://developer.apple.com/forums/thread/23453
+    ///
+    override var contentViewController: NSViewController? {
+        didSet {
+            setupAutosave()
+        }
+    }
+
+
     // MARK: - Overridden Methods
 
     deinit {
@@ -17,7 +27,6 @@ class MainWindowController: NSWindowController {
 
     override func windowDidLoad() {
         super.windowDidLoad()
-        setupMainWindow()
         setupToolbar()
         relocateSemaphoreButtons()
         startListeningToFullscreenNotifications()
@@ -41,9 +50,9 @@ extension MainWindowController: NSWindowDelegate {
 //
 private extension MainWindowController {
 
-    /// Initalizes the Main Window
+    /// Initalizes the Autosave: **MUST** happen after the content has been set!
     ///
-    func setupMainWindow() {
+    func setupAutosave() {
         simplenoteWindow.setFrameAutosaveName(.mainWindow)
     }
 

--- a/Simplenote/SimplenoteAppDelegate+Swift.swift
+++ b/Simplenote/SimplenoteAppDelegate+Swift.swift
@@ -33,14 +33,14 @@ extension SimplenoteAppDelegate {
         let storyboard = NSStoryboard(name: .main, bundle: nil)
 
         mainWindowController = storyboard.instantiateWindowController(ofType: MainWindowController.self)
-        splitViewController = mainWindowController.contentViewController as! SplitViewController
+        splitViewController = storyboard.instantiateViewController(ofType: SplitViewController.self)
         tagListViewController = storyboard.instantiateViewController(ofType: TagListViewController.self)
         noteListViewController = storyboard.instantiateViewController(ofType: NoteListViewController.self)
         noteEditorViewController = storyboard.instantiateViewController(ofType: NoteEditorViewController.self)
     }
 
     @objc
-    func configureSplitView() {
+    func configureSplitViewController() {
         let tagsSplitItem = NSSplitViewItem(sidebarWithViewController: tagListViewController)
         let listSplitItem = NSSplitViewItem(contentListWithViewController: noteListViewController)
         let editorSplitItem = NSSplitViewItem(viewController: noteEditorViewController)
@@ -51,8 +51,9 @@ extension SimplenoteAppDelegate {
     }
 
     @objc
-    func configureInitialResponder() {
-        window.initialFirstResponder = noteEditorViewController.noteEditor
+    func configureMainWindowController() {
+        mainWindowController.contentViewController = splitViewController
+        mainWindowController.simplenoteWindow.initialFirstResponder = noteEditorViewController.noteEditor
     }
 
     @objc

--- a/Simplenote/SimplenoteAppDelegate.m
+++ b/Simplenote/SimplenoteAppDelegate.m
@@ -94,8 +94,8 @@
 {
     [self configureSimperium];
     [self configureMainInterface];
-    [self configureSplitView];
-    [self configureInitialResponder];
+    [self configureSplitViewController];
+    [self configureMainWindowController];
     [self applyStyle];
 
     [self configureEditorController];


### PR DESCRIPTION
### Fix
In this PR we're fixing a regression that prevented the SplitView from properly persisting / restoring its state, across instances.

Closes #795

cc @eshurakov 
cc @Illusaen

Thanks in advance!!

### Details:
In PR #746 we've introduced **MainWindowController**, and wired the **SplitViewController** via a Storyboard Segue.
This IB initialization has the (sad) side effect of, essentially, breaking state restoration.

In this PR we're dropping the segue, in favor of manual programatical initialzation.

Please note that `NSWindow.frameAutosaveName` must be set **AFTER** the contentViewController gets assigned. For that reason, we've moved that setup in a `didSet` observer.

### Test
1. Launch the app
2. Adjust the Window Size
3. Resize the Tags / Notes list panels
4. Press CMD + Q
5. Relaunch the app

- [x] Verify the app restores its exact state

### Release
These changes do not require release notes.
