### PR TITLE
SortBar: Always visible

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,7 +1,10 @@
+2.8
+-----
+- SortBar is now always visible #831
+
 2.7
 -----
 - New account verification screen #800
-- SortBar is now always visible #831
 
 2.6
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 2.7
 -----
 - New account verification screen #800
+- SortBar is now always visible #831
 
 2.6
 -----

--- a/Simplenote/NoteListViewController.swift
+++ b/Simplenote/NoteListViewController.swift
@@ -50,12 +50,16 @@ class NoteListViewController: NSViewController {
 
         setupProgressIndicator()
         setupTableView()
-        setupSortbar()
         startListeningToNotifications()
         startListControllerSync()
 
         refreshStyle()
         refreshEverything()
+    }
+
+    override func viewWillAppear() {
+        super.viewWillAppear()
+        scrollView.scrollToTop(animated: false)
     }
 
     override func viewWillLayout() {
@@ -96,12 +100,6 @@ private extension NoteListViewController {
     func setupProgressIndicator() {
         progressIndicator.wantsLayer = true
         progressIndicator.alphaValue = AppKitConstants.alpha0_5
-    }
-
-    /// Setup: Sortbar
-    ///
-    func setupSortbar() {
-        sortbarView.isHidden = true
     }
 
     /// Refreshes the Top Content Insets: We'll match the Notes List Insets
@@ -272,7 +270,7 @@ private extension NoteListViewController {
     private func refreshListController() {
         let options = Options.shared
         listController.filter = nextListFilter()
-        listController.sortMode = isSearching ? options.notesSearchSortMode : options.notesListSortMode
+        listController.sortMode = options.notesListSortMode
         listController.performFetch()
 
         tableView.reloadData()
@@ -337,20 +335,7 @@ private extension NoteListViewController {
     /// Refresh: Sortbar
     ///
     func refreshSortBarTitle() {
-        sortbarView.sortModeDescription = Options.shared.notesSearchSortMode.description
-    }
-
-    /// Refresh: Sortbar Visibility
-    ///
-    func refreshSortBarVisibility(visible: Bool) {
-        let newHiddenState = !visible
-        guard sortbarView.isHidden != newHiddenState else {
-            return
-        }
-
-        sortbarView.isHidden = newHiddenState
-        refreshScrollInsets()
-        scrollView.scrollToTop(animated: false)
+        sortbarView.sortModeDescription = Options.shared.notesListSortMode.description
     }
 }
 
@@ -577,14 +562,13 @@ extension NoteListViewController: EditorControllerSearchDelegate {
     }
 
     public func editorControllerDidEndSearch(_ controller: NoteEditorViewController) {
-        refreshSortBarVisibility(visible: false)
+        // NO-OP
     }
 
     public func editorController(_ controller: NoteEditorViewController, didSearchKeyword keyword: String) {
         self.keyword = keyword
 
         refreshEverything()
-        refreshSortBarVisibility(visible: !keyword.isEmpty)
 
         SPTracker.trackListNotesSearched()
     }
@@ -659,7 +643,7 @@ extension NoteListViewController: NSMenuItemValidation {
             return false
         }
 
-        let isSelected = Options.shared.notesSearchSortMode == itemSortMode
+        let isSelected = Options.shared.notesListSortMode == itemSortMode
         item.state = isSelected ? .on : .off
         item.title = itemSortMode.description
         return true
@@ -813,7 +797,7 @@ extension NoteListViewController {
             return
         }
 
-        Options.shared.notesSearchSortMode = newSortMode
+        Options.shared.notesListSortMode = newSortMode
     }
 
     @IBAction

--- a/Simplenote/NoteListViewController.swift
+++ b/Simplenote/NoteListViewController.swift
@@ -798,6 +798,7 @@ extension NoteListViewController {
         }
 
         Options.shared.notesListSortMode = newSortMode
+        SPTracker.trackListSortBarModeChanged()
     }
 
     @IBAction

--- a/Simplenote/Options.swift
+++ b/Simplenote/Options.swift
@@ -112,20 +112,6 @@ extension Options {
         }
     }
 
-    /// Notes List: Sort Mode when Searching!
-    ///
-    var notesSearchSortMode: SortMode {
-        get {
-            return defaults.integer(forKey: .notesSearchSortMode).flatMap { mode in
-                SortMode(rawValue: mode)
-            } ?? notesListSortMode
-        }
-        set {
-            defaults.set(newValue.rawValue, forKey: .notesSearchSortMode)
-            NotificationCenter.default.post(name: .NoteListSortModeDidChange, object: nil)
-        }
-    }
-
     /// Theme Name: Null indicates that the system's default theme should be picked
     ///
     var themeName: String? {

--- a/Simplenote/SPTracker.h
+++ b/Simplenote/SPTracker.h
@@ -52,6 +52,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (void)trackListTrashEmptied;
 + (void)trackListNotesSearched;
 + (void)trackListTrashPressed;
++ (void)trackListSortBarModeChanged;
 
 #pragma mark - Preferences
 + (void)trackSettingsFontSizeUpdated;

--- a/Simplenote/SPTracker.m
+++ b/Simplenote/SPTracker.m
@@ -172,6 +172,10 @@
     [self trackAutomatticEventWithName:@"list_trash_viewed" properties:nil];
 }
 
++ (void)trackListSortBarModeChanged
+{
+    [self trackAutomatticEventWithName:@"list_sortbar_mode_changed" properties:nil];
+}
 
 
 #pragma mark - Preferences

--- a/Simplenote/UserDefaults+Simplenote.swift
+++ b/Simplenote/UserDefaults+Simplenote.swift
@@ -13,7 +13,6 @@ extension UserDefaults {
         case notesListCondensed = "kPreviewLinesPref"
         case notesListSortMode
         case notesListSortModeLegacy = "kAlphabeticalSortPreferencesKey"
-        case notesSearchSortMode
         case themeName = "VSThemeManagerThemePrefKey"
     }
 }


### PR DESCRIPTION
### Fix
In this PR we're adjusting the Search Bar, so that it's always visible.

cc @eshurakov (Thank youuu!!)
Ref. #626

### Test
- [x] Verify the Sort Bar is visible at launch (at the top of the Notes List)
- [x] Verify you can adjust the Sort Order (via the Sort Bar) at any time
- [x] Verify the Notes List's content offset is perfect at launch (nothing should get clipped!)

### Release
`RELEASE-NOTES.txt` was updated in 7c0f435 with:

> SortBar is now always visible #831
