### PR TITLE
Relocating Search Bar

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 - Search keywords are highlighted in the editor #835
 - Add search map to the editor #836
 - SortBar is now always visible #831
+- SearchBar has been relocated into the Notes List #838
 
 2.7
 -----

--- a/Simplenote/Main.storyboard
+++ b/Simplenote/Main.storyboard
@@ -366,6 +366,12 @@
                                             <userDefinedRuntimeAttribute type="boolean" keyPath="drawsBottomBorder" value="YES"/>
                                         </userDefinedRuntimeAttributes>
                                     </customView>
+                                    <customView translatesAutoresizingMaskIntoConstraints="NO" id="CAe-TX-MuL" userLabel="Bottom Divider View" customClass="BackgroundView" customModule="Simplenote" customModuleProvider="target">
+                                        <rect key="frame" x="0.0" y="0.0" width="294" height="28"/>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="boolean" keyPath="drawsBottomBorder" value="YES"/>
+                                        </userDefinedRuntimeAttributes>
+                                    </customView>
                                     <customView translatesAutoresizingMaskIntoConstraints="NO" id="Al7-ZM-ybK" userLabel="Actions View">
                                         <rect key="frame" x="16" y="28" width="262" height="52"/>
                                         <subviews>
@@ -475,6 +481,7 @@
                                 <constraints>
                                     <constraint firstItem="wpb-oV-A2U" firstAttribute="leading" secondItem="dMC-MU-RmS" secondAttribute="leading" id="BDw-oI-YFp"/>
                                     <constraint firstItem="DV3-ul-I2L" firstAttribute="leading" secondItem="Al7-ZM-ybK" secondAttribute="leading" id="BKi-ae-Xtg"/>
+                                    <constraint firstItem="CAe-TX-MuL" firstAttribute="top" secondItem="wpb-oV-A2U" secondAttribute="bottom" id="CBP-10-Wgq"/>
                                     <constraint firstItem="DV3-ul-I2L" firstAttribute="top" secondItem="Al7-ZM-ybK" secondAttribute="bottom" id="IAa-25-IXP"/>
                                     <constraint firstAttribute="trailing" secondItem="wpb-oV-A2U" secondAttribute="trailing" id="LKN-YZ-d4a"/>
                                     <constraint firstItem="Al7-ZM-ybK" firstAttribute="leading" secondItem="dMC-MU-RmS" secondAttribute="leading" constant="16" id="V7W-em-DYm"/>
@@ -482,8 +489,11 @@
                                     <constraint firstAttribute="trailing" secondItem="Al7-ZM-ybK" secondAttribute="trailing" constant="16" id="Xgn-Hb-470"/>
                                     <constraint firstItem="wpb-oV-A2U" firstAttribute="top" secondItem="Al7-ZM-ybK" secondAttribute="top" id="Xzh-Vr-wIZ"/>
                                     <constraint firstItem="wpb-oV-A2U" firstAttribute="bottom" secondItem="Al7-ZM-ybK" secondAttribute="bottom" id="aBa-sg-bu7"/>
+                                    <constraint firstAttribute="bottom" secondItem="CAe-TX-MuL" secondAttribute="bottom" id="cEy-T1-hqM"/>
                                     <constraint firstAttribute="bottom" secondItem="DV3-ul-I2L" secondAttribute="bottom" id="fND-lm-KYT"/>
                                     <constraint firstItem="DV3-ul-I2L" firstAttribute="trailing" secondItem="Al7-ZM-ybK" secondAttribute="trailing" id="v9L-7t-MRq"/>
+                                    <constraint firstItem="CAe-TX-MuL" firstAttribute="leading" secondItem="dMC-MU-RmS" secondAttribute="leading" id="vpD-c6-lOG"/>
+                                    <constraint firstAttribute="trailing" secondItem="CAe-TX-MuL" secondAttribute="trailing" id="y2I-X7-AuW"/>
                                 </constraints>
                             </customView>
                             <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="2I0-KH-uBu">
@@ -525,6 +535,7 @@
                         <outlet property="addNoteButton" destination="LGw-AF-2MK" id="s6O-Qf-p2T"/>
                         <outlet property="backgroundBox" destination="zXl-eL-J7J" id="Iu3-6M-C6x"/>
                         <outlet property="clipView" destination="zul-ko-TNO" id="WiT-34-HPY"/>
+                        <outlet property="headerBottomDividerView" destination="CAe-TX-MuL" id="286-dI-pZY"/>
                         <outlet property="headerContainerView" destination="dMC-MU-RmS" id="3K3-ly-nyU"/>
                         <outlet property="headerDividerView" destination="wpb-oV-A2U" id="n5Z-Rv-Jf2"/>
                         <outlet property="headerEffectView" destination="vxX-pk-HGm" id="kTl-9u-MLE"/>

--- a/Simplenote/Main.storyboard
+++ b/Simplenote/Main.storyboard
@@ -375,14 +375,6 @@
                                     <customView translatesAutoresizingMaskIntoConstraints="NO" id="Al7-ZM-ybK" userLabel="Title View">
                                         <rect key="frame" x="16" y="28" width="262" height="52"/>
                                         <subviews>
-                                            <textField horizontalHuggingPriority="1000" verticalHuggingPriority="750" horizontalCompressionResistancePriority="245" translatesAutoresizingMaskIntoConstraints="NO" id="sHv-fV-cSL">
-                                                <rect key="frame" x="-2" y="17" width="39" height="19"/>
-                                                <textFieldCell key="cell" lineBreakMode="truncatingTail" title="Title" id="VNw-0O-CIA">
-                                                    <font key="font" metaFont="systemBold" size="16"/>
-                                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                                </textFieldCell>
-                                            </textField>
                                             <button toolTip="Add Note" translatesAutoresizingMaskIntoConstraints="NO" id="LGw-AF-2MK" userLabel="NewNote">
                                                 <rect key="frame" x="240" y="15" width="22" height="22"/>
                                                 <constraints>
@@ -400,9 +392,6 @@
                                         </subviews>
                                         <constraints>
                                             <constraint firstAttribute="trailing" secondItem="LGw-AF-2MK" secondAttribute="trailing" id="0qP-3a-rqW"/>
-                                            <constraint firstItem="LGw-AF-2MK" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="sHv-fV-cSL" secondAttribute="trailing" constant="8" id="CLx-vg-kmF"/>
-                                            <constraint firstItem="sHv-fV-cSL" firstAttribute="centerY" secondItem="Al7-ZM-ybK" secondAttribute="centerY" id="CxI-qO-8jA"/>
-                                            <constraint firstItem="sHv-fV-cSL" firstAttribute="leading" secondItem="Al7-ZM-ybK" secondAttribute="leading" priority="249" id="keN-Tv-rKe"/>
                                             <constraint firstAttribute="height" constant="52" id="wkJ-yn-7qc"/>
                                             <constraint firstItem="LGw-AF-2MK" firstAttribute="centerY" secondItem="Al7-ZM-ybK" secondAttribute="centerY" id="x5v-n3-E6L"/>
                                         </constraints>
@@ -538,7 +527,6 @@
                         <outlet property="sortbarView" destination="DV3-ul-I2L" id="ZzI-lw-Y5Y"/>
                         <outlet property="statusField" destination="2I0-KH-uBu" id="aPg-Cf-8Zr"/>
                         <outlet property="tableView" destination="q9F-rT-PZ2" id="TRT-PA-LSa"/>
-                        <outlet property="titleLabel" destination="sHv-fV-cSL" id="gt3-Pp-KH6"/>
                         <outlet property="topDividerView" destination="wpb-oV-A2U" id="4jU-o3-DOg"/>
                         <outlet property="trashListMenu" destination="cOD-m3-0ET" id="LM7-S3-9Vt"/>
                     </connections>

--- a/Simplenote/Main.storyboard
+++ b/Simplenote/Main.storyboard
@@ -813,27 +813,10 @@
                                                             <outlet property="delegate" destination="mdt-4X-jeq" id="KIG-lf-uMu"/>
                                                         </connections>
                                                     </searchField>
-                                                    <button toolTip="Info" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Jfd-ze-2Lb" userLabel="SearchButton">
-                                                        <rect key="frame" x="200" y="3" width="22" height="22"/>
-                                                        <constraints>
-                                                            <constraint firstAttribute="width" constant="22" id="1iW-dq-nal"/>
-                                                            <constraint firstAttribute="height" constant="22" id="a2G-uF-0Aa"/>
-                                                        </constraints>
-                                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="button_search" imagePosition="only" alignment="center" imageScaling="proportionallyUpOrDown" inset="2" id="GyS-Ju-oCW">
-                                                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                                            <font key="font" metaFont="system"/>
-                                                        </buttonCell>
-                                                        <connections>
-                                                            <action selector="searchWasPressed:" target="mdt-4X-jeq" id="cHE-CJ-Xv7"/>
-                                                        </connections>
-                                                    </button>
                                                 </subviews>
                                                 <constraints>
                                                     <constraint firstAttribute="trailing" secondItem="YLv-zp-fRS" secondAttribute="trailing" id="123-Kk-B8G"/>
                                                     <constraint firstAttribute="bottom" secondItem="YLv-zp-fRS" secondAttribute="bottom" id="6n7-FL-RNE"/>
-                                                    <constraint firstItem="Jfd-ze-2Lb" firstAttribute="centerY" secondItem="rlY-4u-bgn" secondAttribute="centerY" id="Abj-9e-UWC"/>
-                                                    <constraint firstItem="Jfd-ze-2Lb" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="rlY-4u-bgn" secondAttribute="leading" id="Ad6-Ly-or9"/>
-                                                    <constraint firstAttribute="trailing" secondItem="Jfd-ze-2Lb" secondAttribute="trailing" id="Oan-fh-mFW"/>
                                                     <constraint firstItem="YLv-zp-fRS" firstAttribute="top" secondItem="rlY-4u-bgn" secondAttribute="top" id="UQ4-A2-nxq"/>
                                                     <constraint firstItem="YLv-zp-fRS" firstAttribute="leading" secondItem="rlY-4u-bgn" secondAttribute="leading" priority="999" id="bPK-G4-RHB"/>
                                                 </constraints>
@@ -877,10 +860,7 @@
                                     <outlet property="moreButton" destination="Z7O-L9-Q1P" id="nAT-Hn-2b2"/>
                                     <outlet property="previewButton" destination="TI9-l9-KN8" id="SLQ-gm-gUw"/>
                                     <outlet property="restoreButton" destination="W50-6o-QGr" id="hF8-xI-ouJ"/>
-                                    <outlet property="searchButton" destination="Jfd-ze-2Lb" id="7g1-aG-Ypt"/>
-                                    <outlet property="searchContainerView" destination="rlY-4u-bgn" id="bgl-gc-PhC"/>
                                     <outlet property="searchField" destination="YLv-zp-fRS" id="khj-QR-OsW"/>
-                                    <outlet property="searchFieldWidthConstraint" destination="yv6-TC-X7T" id="0Zi-bE-niz"/>
                                     <outlet property="sidebarButton" destination="Eki-Gw-aTk" id="i2B-I9-LMf"/>
                                     <outlet property="stackView" destination="8xD-dy-bio" id="ubf-Av-SAn"/>
                                 </connections>
@@ -1063,7 +1043,6 @@
         <image name="button_new_note" width="24" height="24"/>
         <image name="button_preview_off" width="24" height="24"/>
         <image name="button_restore" width="24" height="24"/>
-        <image name="button_search" width="24" height="24"/>
         <image name="button_tags_close" width="24" height="24"/>
         <image name="icon_chevron_down" width="16" height="16"/>
         <image name="icon_pin" width="16" height="16"/>

--- a/Simplenote/Main.storyboard
+++ b/Simplenote/Main.storyboard
@@ -379,6 +379,10 @@
                                                     <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                 </searchFieldCell>
+                                                <connections>
+                                                    <action selector="performSearch:" target="JtV-0Z-Zh8" id="wWj-Jf-LAH"/>
+                                                    <outlet property="delegate" destination="JtV-0Z-Zh8" id="vnb-XE-0zI"/>
+                                                </connections>
                                             </searchField>
                                             <button toolTip="Add Note" translatesAutoresizingMaskIntoConstraints="NO" id="LGw-AF-2MK" userLabel="NewNote">
                                                 <rect key="frame" x="240" y="15" width="22" height="22"/>

--- a/Simplenote/Main.storyboard
+++ b/Simplenote/Main.storyboard
@@ -360,21 +360,26 @@
                             <customView translatesAutoresizingMaskIntoConstraints="NO" id="dMC-MU-RmS" userLabel="Header View">
                                 <rect key="frame" x="0.0" y="538" width="294" height="80"/>
                                 <subviews>
-                                    <customView translatesAutoresizingMaskIntoConstraints="NO" id="wpb-oV-A2U" userLabel="Top Divider View" customClass="BackgroundView" customModule="Simplenote" customModuleProvider="target">
+                                    <customView translatesAutoresizingMaskIntoConstraints="NO" id="wpb-oV-A2U" userLabel="Divider View" customClass="BackgroundView" customModule="Simplenote" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="28" width="294" height="52"/>
                                         <userDefinedRuntimeAttributes>
                                             <userDefinedRuntimeAttribute type="boolean" keyPath="drawsBottomBorder" value="YES"/>
                                         </userDefinedRuntimeAttributes>
                                     </customView>
-                                    <customView translatesAutoresizingMaskIntoConstraints="NO" id="cpV-AA-3mi" userLabel="Bottom Divider View" customClass="BackgroundView" customModule="Simplenote" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="0.0" width="294" height="28"/>
-                                        <userDefinedRuntimeAttributes>
-                                            <userDefinedRuntimeAttribute type="boolean" keyPath="drawsBottomBorder" value="YES"/>
-                                        </userDefinedRuntimeAttributes>
-                                    </customView>
-                                    <customView translatesAutoresizingMaskIntoConstraints="NO" id="Al7-ZM-ybK" userLabel="Title View">
+                                    <customView translatesAutoresizingMaskIntoConstraints="NO" id="Al7-ZM-ybK" userLabel="Actions View">
                                         <rect key="frame" x="16" y="28" width="262" height="52"/>
                                         <subviews>
+                                            <searchField wantsLayer="YES" verticalHuggingPriority="750" tag="1" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="YLv-zp-fRS" userLabel="SearchField">
+                                                <rect key="frame" x="0.0" y="12" width="222" height="29"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="29" id="qWD-ui-HWt"/>
+                                                </constraints>
+                                                <searchFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" borderStyle="bezel" placeholderString="Search" usesSingleLineMode="YES" bezelStyle="round" id="aSI-77-VjM">
+                                                    <font key="font" metaFont="system"/>
+                                                    <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                </searchFieldCell>
+                                            </searchField>
                                             <button toolTip="Add Note" translatesAutoresizingMaskIntoConstraints="NO" id="LGw-AF-2MK" userLabel="NewNote">
                                                 <rect key="frame" x="240" y="15" width="22" height="22"/>
                                                 <constraints>
@@ -392,6 +397,9 @@
                                         </subviews>
                                         <constraints>
                                             <constraint firstAttribute="trailing" secondItem="LGw-AF-2MK" secondAttribute="trailing" id="0qP-3a-rqW"/>
+                                            <constraint firstItem="YLv-zp-fRS" firstAttribute="centerY" secondItem="Al7-ZM-ybK" secondAttribute="centerY" id="9lA-j7-B8N"/>
+                                            <constraint firstItem="YLv-zp-fRS" firstAttribute="leading" secondItem="Al7-ZM-ybK" secondAttribute="leading" priority="249" id="ZAI-kw-ua0"/>
+                                            <constraint firstItem="LGw-AF-2MK" firstAttribute="leading" secondItem="YLv-zp-fRS" secondAttribute="trailing" constant="18" id="m8s-ab-ePI"/>
                                             <constraint firstAttribute="height" constant="52" id="wkJ-yn-7qc"/>
                                             <constraint firstItem="LGw-AF-2MK" firstAttribute="centerY" secondItem="Al7-ZM-ybK" secondAttribute="centerY" id="x5v-n3-E6L"/>
                                         </constraints>
@@ -464,16 +472,12 @@
                                     <constraint firstItem="wpb-oV-A2U" firstAttribute="leading" secondItem="dMC-MU-RmS" secondAttribute="leading" id="BDw-oI-YFp"/>
                                     <constraint firstItem="DV3-ul-I2L" firstAttribute="leading" secondItem="Al7-ZM-ybK" secondAttribute="leading" id="BKi-ae-Xtg"/>
                                     <constraint firstItem="DV3-ul-I2L" firstAttribute="top" secondItem="Al7-ZM-ybK" secondAttribute="bottom" id="IAa-25-IXP"/>
-                                    <constraint firstItem="DV3-ul-I2L" firstAttribute="bottom" secondItem="cpV-AA-3mi" secondAttribute="bottom" id="KgE-71-308"/>
                                     <constraint firstAttribute="trailing" secondItem="wpb-oV-A2U" secondAttribute="trailing" id="LKN-YZ-d4a"/>
-                                    <constraint firstAttribute="trailing" secondItem="cpV-AA-3mi" secondAttribute="trailing" id="R1I-2m-Du1"/>
                                     <constraint firstItem="Al7-ZM-ybK" firstAttribute="leading" secondItem="dMC-MU-RmS" secondAttribute="leading" constant="16" id="V7W-em-DYm"/>
                                     <constraint firstItem="Al7-ZM-ybK" firstAttribute="top" secondItem="dMC-MU-RmS" secondAttribute="top" id="VTs-UB-jhP"/>
-                                    <constraint firstItem="cpV-AA-3mi" firstAttribute="leading" secondItem="dMC-MU-RmS" secondAttribute="leading" id="Xei-mL-k2W"/>
                                     <constraint firstAttribute="trailing" secondItem="Al7-ZM-ybK" secondAttribute="trailing" constant="16" id="Xgn-Hb-470"/>
                                     <constraint firstItem="wpb-oV-A2U" firstAttribute="top" secondItem="Al7-ZM-ybK" secondAttribute="top" id="Xzh-Vr-wIZ"/>
                                     <constraint firstItem="wpb-oV-A2U" firstAttribute="bottom" secondItem="Al7-ZM-ybK" secondAttribute="bottom" id="aBa-sg-bu7"/>
-                                    <constraint firstItem="DV3-ul-I2L" firstAttribute="top" secondItem="cpV-AA-3mi" secondAttribute="top" id="bIa-4f-dCN"/>
                                     <constraint firstAttribute="bottom" secondItem="DV3-ul-I2L" secondAttribute="bottom" id="fND-lm-KYT"/>
                                     <constraint firstItem="DV3-ul-I2L" firstAttribute="trailing" secondItem="Al7-ZM-ybK" secondAttribute="trailing" id="v9L-7t-MRq"/>
                                 </constraints>
@@ -516,18 +520,18 @@
                     <connections>
                         <outlet property="addNoteButton" destination="LGw-AF-2MK" id="s6O-Qf-p2T"/>
                         <outlet property="backgroundBox" destination="zXl-eL-J7J" id="Iu3-6M-C6x"/>
-                        <outlet property="bottomDividerView" destination="cpV-AA-3mi" id="NJl-dX-mqp"/>
                         <outlet property="clipView" destination="zul-ko-TNO" id="WiT-34-HPY"/>
                         <outlet property="headerContainerView" destination="dMC-MU-RmS" id="3K3-ly-nyU"/>
+                        <outlet property="headerDividerView" destination="wpb-oV-A2U" id="n5Z-Rv-Jf2"/>
                         <outlet property="headerEffectView" destination="vxX-pk-HGm" id="kTl-9u-MLE"/>
                         <outlet property="noteListMenu" destination="JPb-EX-UT9" id="1Ad-LU-3eM"/>
                         <outlet property="progressIndicator" destination="5oO-Ju-l1S" id="ZDk-V0-rXz"/>
                         <outlet property="scrollView" destination="JDR-c6-dqi" id="PCh-41-2RS"/>
+                        <outlet property="searchField" destination="YLv-zp-fRS" id="vqB-c6-e3u"/>
                         <outlet property="sortbarMenu" destination="gYa-0Y-UQ7" id="ztX-V1-UHE"/>
                         <outlet property="sortbarView" destination="DV3-ul-I2L" id="ZzI-lw-Y5Y"/>
                         <outlet property="statusField" destination="2I0-KH-uBu" id="aPg-Cf-8Zr"/>
                         <outlet property="tableView" destination="q9F-rT-PZ2" id="TRT-PA-LSa"/>
-                        <outlet property="topDividerView" destination="wpb-oV-A2U" id="4jU-o3-DOg"/>
                         <outlet property="trashListMenu" destination="cOD-m3-0ET" id="LM7-S3-9Vt"/>
                     </connections>
                 </viewController>
@@ -745,7 +749,7 @@
                                         </connections>
                                     </button>
                                     <stackView distribution="fill" orientation="horizontal" alignment="centerY" spacing="22" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="8xD-dy-bio">
-                                        <rect key="frame" x="114" y="0.0" width="398" height="52"/>
+                                        <rect key="frame" x="358" y="0.0" width="154" height="52"/>
                                         <subviews>
                                             <button toolTip="Preview Markdown" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="TI9-l9-KN8" userLabel="Markdown Button">
                                                 <rect key="frame" x="0.0" y="15" width="22" height="22"/>
@@ -794,33 +798,6 @@
                                                     <action selector="moreWasPressed:" target="owM-kh-Bm6" id="jNg-pL-Pc6"/>
                                                 </connections>
                                             </button>
-                                            <customView translatesAutoresizingMaskIntoConstraints="NO" id="rlY-4u-bgn">
-                                                <rect key="frame" x="176" y="12" width="222" height="29"/>
-                                                <subviews>
-                                                    <searchField wantsLayer="YES" verticalHuggingPriority="750" tag="1" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="YLv-zp-fRS" userLabel="SearchField">
-                                                        <rect key="frame" x="0.0" y="0.0" width="222" height="29"/>
-                                                        <constraints>
-                                                            <constraint firstAttribute="height" constant="29" id="qWD-ui-HWt"/>
-                                                            <constraint firstAttribute="width" constant="222" id="yv6-TC-X7T"/>
-                                                        </constraints>
-                                                        <searchFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" borderStyle="bezel" placeholderString="Search" usesSingleLineMode="YES" bezelStyle="round" id="aSI-77-VjM">
-                                                            <font key="font" metaFont="system"/>
-                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                                        </searchFieldCell>
-                                                        <connections>
-                                                            <action selector="performSearch:" target="mdt-4X-jeq" id="7xg-oL-34n"/>
-                                                            <outlet property="delegate" destination="mdt-4X-jeq" id="KIG-lf-uMu"/>
-                                                        </connections>
-                                                    </searchField>
-                                                </subviews>
-                                                <constraints>
-                                                    <constraint firstAttribute="trailing" secondItem="YLv-zp-fRS" secondAttribute="trailing" id="123-Kk-B8G"/>
-                                                    <constraint firstAttribute="bottom" secondItem="YLv-zp-fRS" secondAttribute="bottom" id="6n7-FL-RNE"/>
-                                                    <constraint firstItem="YLv-zp-fRS" firstAttribute="top" secondItem="rlY-4u-bgn" secondAttribute="top" id="UQ4-A2-nxq"/>
-                                                    <constraint firstItem="YLv-zp-fRS" firstAttribute="leading" secondItem="rlY-4u-bgn" secondAttribute="leading" priority="999" id="bPK-G4-RHB"/>
-                                                </constraints>
-                                            </customView>
                                         </subviews>
                                         <constraints>
                                             <constraint firstItem="hVc-Cl-DHn" firstAttribute="height" secondItem="TI9-l9-KN8" secondAttribute="height" id="2wO-UI-11h"/>
@@ -835,10 +812,8 @@
                                             <integer value="1000"/>
                                             <integer value="1000"/>
                                             <integer value="1000"/>
-                                            <integer value="1000"/>
                                         </visibilityPriorities>
                                         <customSpacing>
-                                            <real value="3.4028234663852886e+38"/>
                                             <real value="3.4028234663852886e+38"/>
                                             <real value="3.4028234663852886e+38"/>
                                             <real value="3.4028234663852886e+38"/>
@@ -860,7 +835,6 @@
                                     <outlet property="moreButton" destination="Z7O-L9-Q1P" id="nAT-Hn-2b2"/>
                                     <outlet property="previewButton" destination="TI9-l9-KN8" id="SLQ-gm-gUw"/>
                                     <outlet property="restoreButton" destination="W50-6o-QGr" id="hF8-xI-ouJ"/>
-                                    <outlet property="searchField" destination="YLv-zp-fRS" id="khj-QR-OsW"/>
                                     <outlet property="sidebarButton" destination="Eki-Gw-aTk" id="i2B-I9-LMf"/>
                                     <outlet property="stackView" destination="8xD-dy-bio" id="ubf-Av-SAn"/>
                                 </connections>

--- a/Simplenote/NoteEditorViewController+Swift.swift
+++ b/Simplenote/NoteEditorViewController+Swift.swift
@@ -288,11 +288,6 @@ extension NoteEditorViewController {
 extension NoteEditorViewController {
 
     @objc
-    func beginSearch() {
-        toolbarView.beginSearch()
-    }
-
-    @objc
     func ensureSearchIsDismissed() {
         toolbarView.endSearch()
     }

--- a/Simplenote/NoteEditorViewController+Swift.swift
+++ b/Simplenote/NoteEditorViewController+Swift.swift
@@ -289,7 +289,7 @@ extension NoteEditorViewController {
 
     @objc
     func ensureSearchIsDismissed() {
-        toolbarView.endSearch()
+//        toolbarView.endSearch()
     }
 }
 

--- a/Simplenote/NoteEditorViewController+Swift.swift
+++ b/Simplenote/NoteEditorViewController+Swift.swift
@@ -505,15 +505,7 @@ extension NoteEditorViewController {
     func displayMetricsPopover(from sourceView: NSView, for notes: [Note]) {
         let viewController = MetricsViewController(notes: notes)
         viewController.delegate = self
-
-        // Our SearchBar, if present, will freak out when presenting the Metrics Popover.
-        // We'll ensure it doesn't get dismissed (granted that it had no keywords!)
-        toolbarView.dismissSearchBarOnEndEditing = false
-
         present(viewController, asPopoverRelativeTo: sourceView.bounds, of: sourceView, preferredEdge: .maxY, behavior: .transient)
-
-        // You may proceed. Nothing happened here.
-        toolbarView.dismissSearchBarOnEndEditing = true
     }
 
     func displayPublishPopover(from sourceView: NSView, for note: Note) {

--- a/Simplenote/NoteEditorViewController+Swift.swift
+++ b/Simplenote/NoteEditorViewController+Swift.swift
@@ -283,17 +283,6 @@ extension NoteEditorViewController {
 }
 
 
-// MARK: - Search API
-//
-extension NoteEditorViewController {
-
-    @objc
-    func ensureSearchIsDismissed() {
-//        toolbarView.endSearch()
-    }
-}
-
-
 // MARK: - ToolbarDelegate
 //
 extension NoteEditorViewController: NoteListSearchDelegate {

--- a/Simplenote/NoteEditorViewController+Swift.swift
+++ b/Simplenote/NoteEditorViewController+Swift.swift
@@ -930,7 +930,7 @@ extension NoteEditorViewController {
     }
 
     private var searchQuery: SearchQuery {
-        SearchQuery(searchText: toolbarView.searchField.stringValue)
+        SearchQuery(searchText: "") //toolbarView.searchField.stringValue)
     }
 
     private var highlightedRanges: [NSRange] {

--- a/Simplenote/NoteEditorViewController+Swift.swift
+++ b/Simplenote/NoteEditorViewController+Swift.swift
@@ -296,9 +296,10 @@ extension NoteEditorViewController {
 
 // MARK: - ToolbarDelegate
 //
-extension NoteEditorViewController {
+extension NoteEditorViewController: NoteListSearchDelegate {
 
-    func toolbar(_ toolbar: ToolbarView, didSearch keyword: String) {
+    func notesListViewControllerDidSearch(_ query: SearchQuery?) {
+        searchQuery = query
         updateKeywordsHighlight()
     }
 }
@@ -897,6 +898,7 @@ private extension NoteEditorViewController {
 // MARK: - Content and Highlights
 //
 extension NoteEditorViewController {
+
     @objc
     func displayContent(_ content: String?) {
         noteEditor.displayNote(content: content ?? "")
@@ -910,18 +912,12 @@ extension NoteEditorViewController {
         }
     }
 
-    private var searchQuery: SearchQuery {
-        SearchQuery(searchText: "") //toolbarView.searchField.stringValue)
-    }
-
     private var highlightedRanges: [NSRange] {
-        let keywords = searchQuery.keywords
-
-        guard !noteEditor.isFirstResponder, !keywords.isEmpty else {
+        guard !noteEditor.isFirstResponder, let searchQuery = searchQuery as? SearchQuery, !searchQuery.keywords.isEmpty else {
             return []
         }
 
-        let slice = noteEditor.attributedString().string.contentSlice(matching: keywords)
+        let slice = noteEditor.attributedString().string.contentSlice(matching: searchQuery.keywords)
         return slice?.nsMatches ?? []
     }
 

--- a/Simplenote/NoteEditorViewController+Swift.swift
+++ b/Simplenote/NoteEditorViewController+Swift.swift
@@ -30,11 +30,6 @@ extension NoteEditorViewController {
     }
 
     @objc
-    func setupToolbarView() {
-        toolbarView.delegate = self
-    }
-
-    @objc
     func refreshScrollInsets() {
         clipView.contentInsets.top = SplitItemMetrics.editorContentTopInset
         scrollView.scrollerInsets.top = SplitItemMetrics.editorScrollerTopInset
@@ -306,18 +301,9 @@ extension NoteEditorViewController {
 
 // MARK: - ToolbarDelegate
 //
-extension NoteEditorViewController: ToolbarDelegate {
-
-    func toolbarDidBeginSearch() {
-        searchDelegate?.editorControllerDidBeginSearch(self)
-    }
-
-    func toolbarDidEndSearch() {
-        searchDelegate?.editorControllerDidEndSearch(self)
-    }
+extension NoteEditorViewController {
 
     func toolbar(_ toolbar: ToolbarView, didSearch keyword: String) {
-        searchDelegate?.editorController(self, didSearchKeyword: keyword)
         updateKeywordsHighlight()
     }
 }

--- a/Simplenote/NoteEditorViewController.h
+++ b/Simplenote/NoteEditorViewController.h
@@ -45,12 +45,6 @@ typedef NS_ENUM(NSInteger, NoteFontSize) {
 - (void)editorController:(NoteEditorViewController *)controller didAddNewTag:(NSString *)tag;
 @end
 
-@protocol EditorControllerSearchDelegate <NSObject>
-- (void)editorControllerDidBeginSearch:(NoteEditorViewController *)controller;
-- (void)editorControllerDidEndSearch:(NoteEditorViewController *)controller;
-- (void)editorController:(NoteEditorViewController *)controller didSearchKeyword:(NSString *)keyword;
-@end
-
 
 
 #pragma mark - NoteEditorViewController
@@ -79,7 +73,6 @@ typedef NS_ENUM(NSInteger, NoteFontSize) {
 @property (nonatomic,   weak) Note                                              *note;
 @property (nonatomic,   weak) id<EditorControllerNoteActionsDelegate>           noteActionsDelegate;
 @property (nonatomic,   weak) id<EditorControllerTagActionsDelegate>            tagActionsDelegate;
-@property (nonatomic,   weak) id<EditorControllerSearchDelegate>                searchDelegate;
 @property (nonatomic, strong, nullable) SearchMapView                           *searchMapView;
 
 - (IBAction)newNoteWasPressed:(id)sender;

--- a/Simplenote/NoteEditorViewController.h
+++ b/Simplenote/NoteEditorViewController.h
@@ -20,6 +20,7 @@
 @class ToolbarView;
 @class SPTextView;
 @class SearchMapView;
+@class SearchQuery;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -74,6 +75,9 @@ typedef NS_ENUM(NSInteger, NoteFontSize) {
 @property (nonatomic,   weak) id<EditorControllerNoteActionsDelegate>           noteActionsDelegate;
 @property (nonatomic,   weak) id<EditorControllerTagActionsDelegate>            tagActionsDelegate;
 @property (nonatomic, strong, nullable) SearchMapView                           *searchMapView;
+
+// TODO: Switch NSObject >> SearchQuery. ObjC compiler isn't picking up the Swift Package =(
+@property (nonatomic, strong, nullable) NSObject                                *searchQuery;
 
 - (IBAction)newNoteWasPressed:(id)sender;
 - (void)save;

--- a/Simplenote/NoteEditorViewController.m
+++ b/Simplenote/NoteEditorViewController.m
@@ -257,7 +257,6 @@ static NSString * const SPMarkdownPreferencesKey        = @"kMarkdownPreferences
     [self refreshEditorActions];
     [self refreshToolbarActions];
     [self refreshTagsFieldActions];
-    [self ensureSearchIsDismissed];
 }
 
 - (void)tagsDidLoad:(NSNotification *)notification
@@ -266,7 +265,6 @@ static NSString * const SPMarkdownPreferencesKey        = @"kMarkdownPreferences
     [self refreshEditorActions];
     [self refreshToolbarActions];
     [self refreshTagsFieldActions];
-    [self ensureSearchIsDismissed];
 }
 
 - (void)tagUpdated:(NSNotification *)notification
@@ -455,15 +453,15 @@ static NSString * const SPMarkdownPreferencesKey        = @"kMarkdownPreferences
 {
     [SPTracker trackEditorNoteCreated];
 
-    
     // Save current note first
     self.note.content = [self.noteEditor plainTextContent];
     [self save];
 
     SimplenoteAppDelegate *appDelegate = [SimplenoteAppDelegate sharedDelegate];
     [appDelegate ensureMainWindowIsVisible:nil];
-    
-    Note *newNote = [NSEntityDescription insertNewObjectForEntityForName:@"Note" inManagedObjectContext:appDelegate.simperium.managedObjectContext];
+
+    Simperium *simperium = appDelegate.simperium;
+    Note *newNote = [simperium.notesBucket insertNewObject];
     newNote.modificationDate = [NSDate date];
     newNote.creationDate = [NSDate date];
     newNote.markdown = [[NSUserDefaults standardUserDefaults] boolForKey:SPMarkdownPreferencesKey];
@@ -473,10 +471,9 @@ static NSString * const SPMarkdownPreferencesKey        = @"kMarkdownPreferences
         [newNote addTag:currentTag];
     }
 
-    [self ensureSearchIsDismissed];
-    [self displayNote:newNote];
-    [self save];
+    [simperium save];
 
+    [self displayNote:newNote];
     [self.noteActionsDelegate editorController:self addedNoteWithSimperiumKey:newNote.simperiumKey];
 
     [self.view.window makeFirstResponder:self.noteEditor];

--- a/Simplenote/NoteEditorViewController.m
+++ b/Simplenote/NoteEditorViewController.m
@@ -99,7 +99,6 @@ static NSString * const SPMarkdownPreferencesKey        = @"kMarkdownPreferences
     [self setupScrollView];
     [self setupStatusImageView];
     [self setupTagsField];
-    [self setupToolbarView];
 
     // Preload Markdown Preview
     self.markdownViewController = [MarkdownViewController new];

--- a/Simplenote/NoteListViewController.swift
+++ b/Simplenote/NoteListViewController.swift
@@ -2,6 +2,13 @@ import Foundation
 import SimplenoteSearch
 
 
+// MARK: - NoteListSearchDelegate
+//
+protocol NoteListSearchDelegate: class {
+    func notesListViewControllerDidSearch(_ query: SearchQuery?)
+}
+
+
 // MARK: - NoteListViewController
 //
 class NoteListViewController: NSViewController {
@@ -34,13 +41,21 @@ class NoteListViewController: NSViewController {
 
     /// Search Query
     ///
-    private var searchQuery: SearchQuery?
+    private var searchQuery: SearchQuery? {
+        didSet {
+            searchDelegate?.notesListViewControllerDidSearch(searchQuery)
+        }
+    }
 
     /// TODO: Work in Progress. Decouple with a delegate please
     ///
     private var noteEditorViewController: NoteEditorViewController {
         SimplenoteAppDelegate.shared().noteEditorViewController
     }
+
+    /// Search Listener
+    ///
+    weak var searchDelegate: NoteListSearchDelegate?
 
 
     // MARK: - ViewController Lifecycle
@@ -560,7 +575,7 @@ extension NoteListViewController: EditorControllerNoteActionsDelegate {
 }
 
 
-// MARK: - Search API
+// MARK: - Public Search API
 //
 extension NoteListViewController {
 

--- a/Simplenote/NoteListViewController.swift
+++ b/Simplenote/NoteListViewController.swift
@@ -16,14 +16,17 @@ class NoteListViewController: NSViewController {
     @IBOutlet private var tableView: SPTableView!
     @IBOutlet private var headerEffectView: NSVisualEffectView!
     @IBOutlet private var headerContainerView: NSView!
-    @IBOutlet private var topDividerView: BackgroundView!
-    @IBOutlet private var bottomDividerView: BackgroundView!
+    @IBOutlet private var headerDividerView: BackgroundView!
+    @IBOutlet private var searchField: NSSearchField!
     @IBOutlet private var addNoteButton: NSButton!
     @IBOutlet private var sortbarView: SortBarView!
     @IBOutlet private var sortbarMenu: NSMenu!
     @IBOutlet private var noteListMenu: NSMenu!
     @IBOutlet private var trashListMenu: NSMenu!
-    @IBOutlet private var titleSemaphoreLeadingConstraint: NSLayoutConstraint!
+
+    /// Layout
+    ///
+    private var searchFieldSemaphoreLeadingConstraint: NSLayoutConstraint!
 
     /// ListController
     ///
@@ -125,8 +128,7 @@ extension NoteListViewController {
     func refreshStyle() {
         backgroundBox.boxType = .simplenoteSidebarBoxType
         backgroundBox.fillColor = .simplenoteSecondaryBackgroundColor
-        topDividerView.borderColor = .simplenoteDividerColor
-        bottomDividerView.borderColor = .simplenoteSecondaryDividerColor
+        headerDividerView.borderColor = .simplenoteDividerColor
         addNoteButton.contentTintColor = .simplenoteActionButtonTintColor
         statusField.textColor = .simplenoteSecondaryTextColor
 
@@ -152,7 +154,7 @@ extension NoteListViewController {
     /// Indicates if the Semaphore Leading hasn't been initialized
     ///
     private var mustSetupSemaphoreLeadingConstraint: Bool {
-        titleSemaphoreLeadingConstraint == nil
+        searchFieldSemaphoreLeadingConstraint == nil
     }
 
     /// # Semaphore Leading:
@@ -167,10 +169,10 @@ extension NoteListViewController {
             return
         }
 
-//        let newConstraint = titleLabel.leadingAnchor.constraint(greaterThanOrEqualTo: contentLayoutGuide.leadingAnchor)
-//        newConstraint.priority = .defaultLow
-//        newConstraint.isActive = true
-//        titleSemaphoreLeadingConstraint = newConstraint
+        let newConstraint = searchField.leadingAnchor.constraint(greaterThanOrEqualTo: contentLayoutGuide.leadingAnchor)
+        newConstraint.priority = .defaultLow
+        newConstraint.isActive = true
+        searchFieldSemaphoreLeadingConstraint = newConstraint
     }
 
     /// Refreshes the Semaphore Leading
@@ -180,7 +182,7 @@ extension NoteListViewController {
             return
         }
 
-        titleSemaphoreLeadingConstraint?.constant = semaphorePaddingX + SplitItemMetrics.toolbarSemaphorePaddingX
+        searchFieldSemaphoreLeadingConstraint?.constant = semaphorePaddingX + SplitItemMetrics.toolbarSemaphorePaddingX
     }
 }
 
@@ -421,7 +423,7 @@ private extension NoteListViewController {
 
     func refreshHeaderState() {
         let newAlpha = alphaForHeader
-        topDividerView.alphaValue = newAlpha
+        headerDividerView.alphaValue = newAlpha
         headerEffectView.alphaValue = newAlpha
         headerEffectView.state = newAlpha > SplitItemMetrics.headerAlphaActiveThreshold ? .active : .inactive
     }

--- a/Simplenote/NoteListViewController.swift
+++ b/Simplenote/NoteListViewController.swift
@@ -560,13 +560,20 @@ extension NoteListViewController: EditorControllerNoteActionsDelegate {
 }
 
 
+
+extension NoteListViewController {
+    /// Enters Search Mode whenever the current Toolbar State allows
+    ///
+    func beginSearch() {
+        SimplenoteAppDelegate.shared().ensureNotesListIsVisible()
+        view.window?.makeFirstResponder(searchField)
+    }
+}
+
+
 // MARK: - NSSearchFieldDelegate
 //
 extension NoteListViewController: NSSearchFieldDelegate {
-
-    public func editorControllerDidBeginSearch(_ controller: NoteEditorViewController) {
-        SimplenoteAppDelegate.shared().ensureNotesListIsVisible()
-    }
 
     public func controlTextDidEndEditing(_ obj: Notification) {
 //        delegate?.toolbarDidEndSearch()
@@ -575,9 +582,7 @@ extension NoteListViewController: NSSearchFieldDelegate {
     @IBAction
     public func performSearch(_ sender: Any) {
         searchQuery = SearchQuery(searchText: searchField.stringValue)
-
         refreshEverything()
-
         SPTracker.trackListNotesSearched()
     }
 }

--- a/Simplenote/NoteListViewController.swift
+++ b/Simplenote/NoteListViewController.swift
@@ -560,13 +560,22 @@ extension NoteListViewController: EditorControllerNoteActionsDelegate {
 }
 
 
-
+// MARK: - Search API
+//
 extension NoteListViewController {
+
     /// Enters Search Mode whenever the current Toolbar State allows
     ///
     func beginSearch() {
         SimplenoteAppDelegate.shared().ensureNotesListIsVisible()
         view.window?.makeFirstResponder(searchField)
+    }
+
+    /// Ends Search whenever the SearchBar was actually visible
+    ///
+    func endSearch() {
+        searchField.cancelSearch()
+        searchField.resignFirstResponder()
     }
 }
 
@@ -574,10 +583,6 @@ extension NoteListViewController {
 // MARK: - NSSearchFieldDelegate
 //
 extension NoteListViewController: NSSearchFieldDelegate {
-
-    public func controlTextDidEndEditing(_ obj: Notification) {
-//        delegate?.toolbarDidEndSearch()
-    }
 
     @IBAction
     public func performSearch(_ sender: Any) {

--- a/Simplenote/NoteListViewController.swift
+++ b/Simplenote/NoteListViewController.swift
@@ -560,20 +560,21 @@ extension NoteListViewController: EditorControllerNoteActionsDelegate {
 }
 
 
-// MARK: - EditorControllerSearchDelegate
+// MARK: - NSSearchFieldDelegate
 //
-extension NoteListViewController {
+extension NoteListViewController: NSSearchFieldDelegate {
 
     public func editorControllerDidBeginSearch(_ controller: NoteEditorViewController) {
         SimplenoteAppDelegate.shared().ensureNotesListIsVisible()
     }
 
-    public func editorControllerDidEndSearch(_ controller: NoteEditorViewController) {
-        // NO-OP
+    public func controlTextDidEndEditing(_ obj: Notification) {
+//        delegate?.toolbarDidEndSearch()
     }
 
-    public func editorController(_ controller: NoteEditorViewController, didSearchKeyword keyword: String) {
-        searchQuery = SearchQuery(searchText: keyword)
+    @IBAction
+    public func performSearch(_ sender: Any) {
+        searchQuery = SearchQuery(searchText: searchField.stringValue)
 
         refreshEverything()
 

--- a/Simplenote/NoteListViewController.swift
+++ b/Simplenote/NoteListViewController.swift
@@ -553,7 +553,7 @@ extension NoteListViewController: EditorControllerNoteActionsDelegate {
 
 // MARK: - EditorControllerSearchDelegate
 //
-extension NoteListViewController: EditorControllerSearchDelegate {
+extension NoteListViewController {
 
     public func editorControllerDidBeginSearch(_ controller: NoteEditorViewController) {
         SimplenoteAppDelegate.shared().ensureNotesListIsVisible()

--- a/Simplenote/NoteListViewController.swift
+++ b/Simplenote/NoteListViewController.swift
@@ -182,7 +182,7 @@ extension NoteListViewController {
     }
 
     /// # Semaphore Leading:
-    /// We REALLY need to avoid collisions between the TitleLabel and the Window's Semaphore (Zoom / Close buttons).
+    /// # We REALLY need to avoid collisions between the SearchField and the Window's Semaphore (Zoom / Close buttons).
     ///
     /// - Important:
     ///     `priority` is set to `defaultLow` (250) for the constraint between TitleLabel and Window.contentLayoutGuide, whereas the regular `leading` is set to (249).

--- a/Simplenote/NoteListViewController.swift
+++ b/Simplenote/NoteListViewController.swift
@@ -554,6 +554,7 @@ private extension NoteListViewController {
 extension NoteListViewController: EditorControllerNoteActionsDelegate {
 
     public func editorController(_ controller: NoteEditorViewController, addedNoteWithSimperiumKey simperiumKey: String) {
+        dismissSearch()
         displayAndSelectNote(with: simperiumKey)
     }
 
@@ -588,7 +589,8 @@ extension NoteListViewController {
 
     /// Ends Search whenever the SearchBar was actually visible
     ///
-    func endSearch() {
+    @objc
+    func dismissSearch() {
         searchField.cancelSearch()
         searchField.resignFirstResponder()
     }
@@ -732,12 +734,16 @@ extension NoteListViewController {
     @objc
     func didBeginViewingTag(_ note: Notification) {
         SPTracker.trackTagRowPressed()
+
+        dismissSearch()
         refreshEverything()
     }
 
     @objc
     func didBeginViewingTrash(_ note: Notification) {
         SPTracker.trackListTrashPressed()
+
+        dismissSearch()
         refreshEverything()
     }
 

--- a/Simplenote/NoteListViewController.swift
+++ b/Simplenote/NoteListViewController.swift
@@ -24,6 +24,7 @@ class NoteListViewController: NSViewController {
     @IBOutlet private var headerEffectView: NSVisualEffectView!
     @IBOutlet private var headerContainerView: NSView!
     @IBOutlet private var headerDividerView: BackgroundView!
+    @IBOutlet private var headerBottomDividerView: BackgroundView!
     @IBOutlet private var searchField: NSSearchField!
     @IBOutlet private var addNoteButton: NSButton!
     @IBOutlet private var sortbarView: SortBarView!
@@ -151,6 +152,7 @@ extension NoteListViewController {
         backgroundBox.boxType = .simplenoteSidebarBoxType
         backgroundBox.fillColor = .simplenoteSecondaryBackgroundColor
         headerDividerView.borderColor = .simplenoteDividerColor
+        headerBottomDividerView.borderColor = .simplenoteSecondaryDividerColor
         searchField.textColor = .simplenoteTextColor
         searchField.placeholderAttributedString = Settings.searchBarPlaceholder
         addNoteButton.contentTintColor = .simplenoteActionButtonTintColor

--- a/Simplenote/NoteListViewController.swift
+++ b/Simplenote/NoteListViewController.swift
@@ -53,6 +53,7 @@ class NoteListViewController: NSViewController {
         super.viewDidLoad()
 
         setupProgressIndicator()
+        setupSearchField()
         setupTableView()
         startListeningToNotifications()
         startListControllerSync()
@@ -106,6 +107,12 @@ private extension NoteListViewController {
         progressIndicator.alphaValue = AppKitConstants.alpha0_5
     }
 
+    /// Setup: Search Field
+    ///
+    func setupSearchField() {
+        searchField.centersPlaceholder = false
+    }
+
     /// Refreshes the Top Content Insets: We'll match the Notes List Insets
     ///
     func refreshScrollInsets() {
@@ -129,6 +136,8 @@ extension NoteListViewController {
         backgroundBox.boxType = .simplenoteSidebarBoxType
         backgroundBox.fillColor = .simplenoteSecondaryBackgroundColor
         headerDividerView.borderColor = .simplenoteDividerColor
+        searchField.textColor = .simplenoteTextColor
+        searchField.placeholderAttributedString = Settings.searchBarPlaceholder
         addNoteButton.contentTintColor = .simplenoteActionButtonTintColor
         statusField.textColor = .simplenoteSecondaryTextColor
 
@@ -809,5 +818,17 @@ extension NoteListViewController {
         let menuOrigin = NSPoint(x: clickLocation.x, y: sortbarView.frame.minY)
 
         sortbarMenu.popUp(positioning: nil, at: menuOrigin, in: headerContainerView)
+    }
+}
+
+
+// MARK: - Settings
+//
+private enum Settings {
+    static var searchBarPlaceholder: NSAttributedString {
+        NSAttributedString(string: NSLocalizedString("Search", comment: "Search Field Placeholder"), attributes: [
+            .font: NSFont.simplenoteSecondaryTextFont,
+            .foregroundColor: NSColor.simplenoteSecondaryTextColor
+        ])
     }
 }

--- a/Simplenote/NoteListViewController.swift
+++ b/Simplenote/NoteListViewController.swift
@@ -9,7 +9,6 @@ class NoteListViewController: NSViewController {
     /// Storyboard Outlets
     ///
     @IBOutlet private var backgroundBox: NSBox!
-    @IBOutlet private var titleLabel: NSTextField!
     @IBOutlet private var statusField: NSTextField!
     @IBOutlet private var progressIndicator: NSProgressIndicator!
     @IBOutlet private var scrollView: NSScrollView!
@@ -130,7 +129,6 @@ extension NoteListViewController {
         bottomDividerView.borderColor = .simplenoteSecondaryDividerColor
         addNoteButton.contentTintColor = .simplenoteActionButtonTintColor
         statusField.textColor = .simplenoteSecondaryTextColor
-        titleLabel.textColor = .simplenoteTextColor
 
         sortbarView.refreshStyle()
         tableView.reloadAndPreserveSelection()
@@ -169,10 +167,10 @@ extension NoteListViewController {
             return
         }
 
-        let newConstraint = titleLabel.leadingAnchor.constraint(greaterThanOrEqualTo: contentLayoutGuide.leadingAnchor)
-        newConstraint.priority = .defaultLow
-        newConstraint.isActive = true
-        titleSemaphoreLeadingConstraint = newConstraint
+//        let newConstraint = titleLabel.leadingAnchor.constraint(greaterThanOrEqualTo: contentLayoutGuide.leadingAnchor)
+//        newConstraint.priority = .defaultLow
+//        newConstraint.isActive = true
+//        titleSemaphoreLeadingConstraint = newConstraint
     }
 
     /// Refreshes the Semaphore Leading
@@ -262,7 +260,6 @@ private extension NoteListViewController {
     func refreshEverything() {
         refreshListController()
         refreshEnabledActions()
-        refreshTitle()
         refreshPlaceholder()
         refreshSortBarTitle()
         displayAndSelectFirstNote()
@@ -298,13 +295,6 @@ private extension NoteListViewController {
 
             return NSLocalizedString("No Notes", comment: "No Notes Available")
         }()
-    }
-
-    /// Refresh: Title
-    /// - Important: Update the ListController first!!
-    ///
-    private func refreshTitle() {
-        titleLabel.stringValue = listController.filter.title
     }
 
     /// Although we refresh the Editor in `tableViewSelectionDidChange`, whenever we manually update the ListController and the resulting collection is empty,

--- a/Simplenote/NoteListViewController.swift
+++ b/Simplenote/NoteListViewController.swift
@@ -734,7 +734,6 @@ extension NoteListViewController {
     @objc
     func didBeginViewingTag(_ note: Notification) {
         SPTracker.trackTagRowPressed()
-
         dismissSearch()
         refreshEverything()
     }
@@ -742,7 +741,6 @@ extension NoteListViewController {
     @objc
     func didBeginViewingTrash(_ note: Notification) {
         SPTracker.trackListTrashPressed()
-
         dismissSearch()
         refreshEverything()
     }

--- a/Simplenote/SPApplication.m
+++ b/Simplenote/SPApplication.m
@@ -15,7 +15,7 @@
     if ([event type] == NSEventTypeKeyDown) {
         if (([event modifierFlags] & NSEventModifierFlagDeviceIndependentFlagsMask) == NSEventModifierFlagCommand) {
             if ([[event charactersIgnoringModifiers] isEqualToString:@"l"]) {
-                if ([self sendAction:@selector(searchAction:) to:nil from:self])
+                if ([self sendAction:@selector(searchWasPressed:) to:nil from:self])
                     return;
             }
         }

--- a/Simplenote/SimplenoteAppDelegate+Swift.swift
+++ b/Simplenote/SimplenoteAppDelegate+Swift.swift
@@ -75,6 +75,11 @@ extension SimplenoteAppDelegate {
     }
 
     @objc
+    func configureNotesController() {
+        noteListViewController.searchDelegate = noteEditorViewController
+    }
+
+    @objc
     func configureEditorController() {
         noteEditorViewController.tagActionsDelegate = tagListViewController
         noteEditorViewController.noteActionsDelegate = noteListViewController

--- a/Simplenote/SimplenoteAppDelegate+Swift.swift
+++ b/Simplenote/SimplenoteAppDelegate+Swift.swift
@@ -78,7 +78,6 @@ extension SimplenoteAppDelegate {
     func configureEditorController() {
         noteEditorViewController.tagActionsDelegate = tagListViewController
         noteEditorViewController.noteActionsDelegate = noteListViewController
-        noteEditorViewController.searchDelegate = noteListViewController
     }
 
     @objc

--- a/Simplenote/SimplenoteAppDelegate+Swift.swift
+++ b/Simplenote/SimplenoteAppDelegate+Swift.swift
@@ -212,7 +212,7 @@ extension SimplenoteAppDelegate {
 
     @IBAction
     func searchWasPressed(_ sender: Any) {
-        noteEditorViewController.beginSearch()
+        noteListViewController.beginSearch()
     }
 
     @IBAction

--- a/Simplenote/SimplenoteAppDelegate.m
+++ b/Simplenote/SimplenoteAppDelegate.m
@@ -375,13 +375,6 @@
     }];
 }
 
-- (void)searchAction:(id)sender
-{
-    // Needs to be here because this class is the window's delegate, and SPApplication uses sendEvent:
-    // to override a search keyboard shortcut...which ends up calling searchAction: here
-    [self.noteEditorViewController beginSearch];
-}
-
 - (IBAction)toggleSidebarAction:(id)sender
 {
     [self.splitViewController toggleSidebarActionWithSender:sender];

--- a/Simplenote/SimplenoteAppDelegate.m
+++ b/Simplenote/SimplenoteAppDelegate.m
@@ -361,7 +361,7 @@
     // Remove WordPress token
     [SPKeychain deletePasswordForService:SPWPServiceName account:self.simperium.user.email];
     
-    [self.noteEditorViewController ensureSearchIsDismissed];
+    [self.noteListViewController endSearch];
     [self.noteEditorViewController displayNote:nil];
     [self.tagListViewController reset];
     [self.noteListViewController setWaitingForIndex:YES];

--- a/Simplenote/SimplenoteAppDelegate.m
+++ b/Simplenote/SimplenoteAppDelegate.m
@@ -99,6 +99,7 @@
     [self configureMainWindowController];
     [self applyStyle];
 
+    [self configureNotesController];
     [self configureEditorController];
     [self configureVerificationCoordinator];
     [self configureVersionsController];

--- a/Simplenote/SimplenoteAppDelegate.m
+++ b/Simplenote/SimplenoteAppDelegate.m
@@ -361,7 +361,7 @@
     // Remove WordPress token
     [SPKeychain deletePasswordForService:SPWPServiceName account:self.simperium.user.email];
     
-    [self.noteListViewController endSearch];
+    [self.noteListViewController dismissSearch];
     [self.noteEditorViewController displayNote:nil];
     [self.tagListViewController reset];
     [self.noteListViewController setWaitingForIndex:YES];

--- a/Simplenote/SplitViewController.swift
+++ b/Simplenote/SplitViewController.swift
@@ -222,7 +222,7 @@ private enum Metrics {
     static let tagsMinWidth: CGFloat = 150
     static let tagsMaxWidth: CGFloat = 300
 
-    static let listMinWidth: CGFloat = 200
+    static let listMinWidth: CGFloat = 300
     static let listMaxWidth: CGFloat = 500
 
     static let mainMinWidth: CGFloat = 300

--- a/Simplenote/ToolbarState.swift
+++ b/Simplenote/ToolbarState.swift
@@ -59,10 +59,6 @@ extension ToolbarState {
         !isViewingTrash
     }
 
-    var isSearchActionHidden: Bool {
-        isViewingTrash
-    }
-
     var previewActionImage: NSImage? {
         let name: NSImage.Name = isDisplayingMarkdown ? .previewOff : .previewOn
         return NSImage(named: name)

--- a/Simplenote/ToolbarView.swift
+++ b/Simplenote/ToolbarView.swift
@@ -1,15 +1,6 @@
 import Foundation
 
 
-// MARK: - ToolbarDelegate
-//
-protocol ToolbarDelegate: NSObject {
-    func toolbarDidBeginSearch()
-    func toolbarDidEndSearch()
-    func toolbar(_ toolbar: ToolbarView, didSearch keyword: String)
-}
-
-
 // MARK: - ToolbarView
 //
 @objcMembers
@@ -30,10 +21,6 @@ class ToolbarView: NSView {
     /// Search Field
     ///
 //    @IBOutlet private(set) var searchField: NSSearchField!
-
-    /// Toolbar Delegate
-    ///
-    weak var delegate: ToolbarDelegate?
 
     /// Represents the Toolbar's State
     ///
@@ -155,7 +142,7 @@ extension ToolbarView {
     ///
     func beginSearch() {
 //        window?.makeFirstResponder(self.searchField)
-        delegate?.toolbarDidBeginSearch()
+//        delegate?.toolbarDidBeginSearch()
     }
 
     /// Ends Search whenever the SearchBar was actually visible
@@ -163,7 +150,7 @@ extension ToolbarView {
     func endSearch() {
 //        searchField.cancelSearch()
 //        searchField.resignFirstResponder()
-        delegate?.toolbarDidEndSearch()
+//        delegate?.toolbarDidEndSearch()
     }
 }
 
@@ -173,7 +160,7 @@ extension ToolbarView {
 extension ToolbarView: NSSearchFieldDelegate {
 
     public func controlTextDidEndEditing(_ obj: Notification) {
-        delegate?.toolbarDidEndSearch()
+//        delegate?.toolbarDidEndSearch()
     }
 
     @IBAction

--- a/Simplenote/ToolbarView.swift
+++ b/Simplenote/ToolbarView.swift
@@ -29,7 +29,7 @@ class ToolbarView: NSView {
 
     /// Search Field
     ///
-    @IBOutlet private(set) var searchField: NSSearchField!
+//    @IBOutlet private(set) var searchField: NSSearchField!
 
     /// Toolbar Delegate
     ///
@@ -53,7 +53,7 @@ class ToolbarView: NSView {
     override func awakeFromNib() {
         super.awakeFromNib()
         setupActionButtons()
-        setupSearchField()
+//        setupSearchField()
         refreshStyle()
         startListeningToNotifications()
     }
@@ -113,8 +113,8 @@ private extension ToolbarView {
             button.contentTintColor = .simplenoteActionButtonTintColor
         }
 
-        searchField.textColor = .simplenoteTextColor
-        searchField.placeholderAttributedString = Settings.searchBarPlaceholder
+//        searchField.textColor = .simplenoteTextColor
+//        searchField.placeholderAttributedString = Settings.searchBarPlaceholder
     }
 
     func setupActionButtons() {
@@ -130,9 +130,9 @@ private extension ToolbarView {
         }
     }
 
-    func setupSearchField() {
-        searchField.centersPlaceholder = false
-    }
+//    func setupSearchField() {
+//        searchField.centersPlaceholder = false
+//    }
 }
 
 
@@ -154,15 +154,15 @@ extension ToolbarView {
     /// Enters Search Mode whenever the current Toolbar State allows
     ///
     func beginSearch() {
-        window?.makeFirstResponder(self.searchField)
+//        window?.makeFirstResponder(self.searchField)
         delegate?.toolbarDidBeginSearch()
     }
 
     /// Ends Search whenever the SearchBar was actually visible
     ///
     func endSearch() {
-        searchField.cancelSearch()
-        searchField.resignFirstResponder()
+//        searchField.cancelSearch()
+//        searchField.resignFirstResponder()
         delegate?.toolbarDidEndSearch()
     }
 }
@@ -178,7 +178,7 @@ extension ToolbarView: NSSearchFieldDelegate {
 
     @IBAction
     public func performSearch(_ sender: Any) {
-        delegate?.toolbar(self, didSearch: searchField.stringValue)
+//        delegate?.toolbar(self, didSearch: searchField.stringValue)
     }
 }
 

--- a/Simplenote/ToolbarView.swift
+++ b/Simplenote/ToolbarView.swift
@@ -109,17 +109,3 @@ private extension ToolbarView {
         }
     }
 }
-
-
-// MARK: - Search Bar Public API
-//
-extension ToolbarView {
-
-    /// Ends Search whenever the SearchBar was actually visible
-    ///
-    func endSearch() {
-//        searchField.cancelSearch()
-//        searchField.resignFirstResponder()
-//        delegate?.toolbarDidEndSearch()
-    }
-}

--- a/Simplenote/ToolbarView.swift
+++ b/Simplenote/ToolbarView.swift
@@ -115,13 +115,6 @@ private extension ToolbarView {
 //
 extension ToolbarView {
 
-    /// Enters Search Mode whenever the current Toolbar State allows
-    ///
-    func beginSearch() {
-//        window?.makeFirstResponder(self.searchField)
-//        delegate?.toolbarDidBeginSearch()
-    }
-
     /// Ends Search whenever the SearchBar was actually visible
     ///
     func endSearch() {

--- a/Simplenote/ToolbarView.swift
+++ b/Simplenote/ToolbarView.swift
@@ -40,7 +40,6 @@ class ToolbarView: NSView {
     override func awakeFromNib() {
         super.awakeFromNib()
         setupActionButtons()
-//        setupSearchField()
         refreshStyle()
         startListeningToNotifications()
     }
@@ -99,9 +98,6 @@ private extension ToolbarView {
         for button in allButtons {
             button.contentTintColor = .simplenoteActionButtonTintColor
         }
-
-//        searchField.textColor = .simplenoteTextColor
-//        searchField.placeholderAttributedString = Settings.searchBarPlaceholder
     }
 
     func setupActionButtons() {
@@ -116,10 +112,6 @@ private extension ToolbarView {
             cell.highlightsBy = .pushInCellMask
         }
     }
-
-//    func setupSearchField() {
-//        searchField.centersPlaceholder = false
-//    }
 }
 
 
@@ -166,18 +158,5 @@ extension ToolbarView: NSSearchFieldDelegate {
     @IBAction
     public func performSearch(_ sender: Any) {
 //        delegate?.toolbar(self, didSearch: searchField.stringValue)
-    }
-}
-
-
-// MARK: - Settings
-//
-private enum Settings {
-    static let searchBarFullWidth = CGFloat(222)
-    static var searchBarPlaceholder: NSAttributedString {
-        NSAttributedString(string: NSLocalizedString("Search", comment: "Search Field Placeholder"), attributes: [
-            .font: NSFont.simplenoteSecondaryTextFont,
-            .foregroundColor: NSColor.simplenoteSecondaryTextColor
-        ])
     }
 }

--- a/Simplenote/ToolbarView.swift
+++ b/Simplenote/ToolbarView.swift
@@ -26,27 +26,14 @@ class ToolbarView: NSView {
     @IBOutlet private(set) var moreButton: NSButton!
     @IBOutlet private(set) var previewButton: NSButton!
     @IBOutlet private(set) var restoreButton: NSButton!
-    @IBOutlet private(set) var searchButton: NSButton!
-
-    /// Search Container
-    ///
-    @IBOutlet private(set) var searchContainerView: NSView!
 
     /// Search Field
     ///
     @IBOutlet private(set) var searchField: NSSearchField!
 
-    /// Layout Constraints
-    ///
-    @IBOutlet private(set) var searchFieldWidthConstraint: NSLayoutConstraint!
-
     /// Toolbar Delegate
     ///
     weak var delegate: ToolbarDelegate?
-
-    /// Indicates if the Search Mode should be dismissed whenever the SearchBar stops being First Responder  (and there is no Search Keyword!)
-    ///
-    var dismissSearchBarOnEndEditing = true
 
     /// Represents the Toolbar's State
     ///
@@ -66,7 +53,6 @@ class ToolbarView: NSView {
     override func awakeFromNib() {
         super.awakeFromNib()
         setupActionButtons()
-        setupLayoutConstraintsForInitialState()
         setupSearchField()
         refreshStyle()
         startListeningToNotifications()
@@ -109,8 +95,6 @@ private extension ToolbarView {
 
         restoreButton.isEnabled = state.isRestoreActionEnabled
         restoreButton.isHidden = state.isRestoreActionHidden
-
-        searchContainerView.isHidden = state.isSearchActionHidden
     }
 }
 
@@ -120,7 +104,7 @@ private extension ToolbarView {
 private extension ToolbarView {
 
     var allButtons: [NSButton] {
-        [sidebarButton, metricsButton, moreButton, previewButton, restoreButton, searchButton]
+        [sidebarButton, metricsButton, moreButton, previewButton, restoreButton]
     }
 
     @objc
@@ -138,17 +122,12 @@ private extension ToolbarView {
         moreButton.toolTip = NSLocalizedString("More", comment: "Tooltip: More Actions")
         previewButton.toolTip = NSLocalizedString("Markdown Preview", comment: "Tooltip: Markdown Preview")
         restoreButton.toolTip = NSLocalizedString("Restore", comment: "Tooltip: Restore a trashed note")
-        searchButton.toolTip =  NSLocalizedString("Search", comment: "Tooltip: Search Action")
         sidebarButton.toolTip = NSLocalizedString("Toggle Sidebar", comment: "Tooltip: Restore a trashed note")
 
         let cells = allButtons.compactMap { $0.cell as? NSButtonCell }
         for cell in cells {
             cell.highlightsBy = .pushInCellMask
         }
-    }
-
-    func setupLayoutConstraintsForInitialState() {
-        searchFieldWidthConstraint.constant = .zero
     }
 
     func setupSearchField() {
@@ -175,34 +154,16 @@ extension ToolbarView {
     /// Enters Search Mode whenever the current Toolbar State allows
     ///
     func beginSearch() {
-        if state.isSearchActionHidden {
-            return
-        }
-
-        /// **Workaround:**  We're getting spurious `controlTextDidEndEditing` callbacks, which may yield to really uncool animation glitches.
-        dismissSearchBarOnEndEditing = false
-
-        /// Ensure the SearchBar is visible + Move the focus
-        updateSearchBarIfNeeded(visible: true) {
-
-            /// Note: Not waiting for the Animation's completion causes rendering issues in macOS < 11
-            self.window?.makeFirstResponder(self.searchField)
-
-            /// **Workaround:** Back to normal please
-            self.dismissSearchBarOnEndEditing = true
-        }
+        window?.makeFirstResponder(self.searchField)
+        delegate?.toolbarDidBeginSearch()
     }
 
     /// Ends Search whenever the SearchBar was actually visible
     ///
     func endSearch() {
-        guard isSearchBarVisible else {
-            return
-        }
-
         searchField.cancelSearch()
         searchField.resignFirstResponder()
-        updateSearchBarIfNeeded(visible: false)
+        delegate?.toolbarDidEndSearch()
     }
 }
 
@@ -212,73 +173,12 @@ extension ToolbarView {
 extension ToolbarView: NSSearchFieldDelegate {
 
     public func controlTextDidEndEditing(_ obj: Notification) {
-        guard dismissSearchBarOnEndEditing, searchField.stringValue.isEmpty else {
-            return
-        }
-
-        updateSearchBarIfNeeded(visible: false)
+        delegate?.toolbarDidEndSearch()
     }
 
     @IBAction
     public func performSearch(_ sender: Any) {
         delegate?.toolbar(self, didSearch: searchField.stringValue)
-    }
-}
-
-
-// MARK: - Search Bar State Management
-//
-private extension ToolbarView {
-
-    var isSearchBarVisible: Bool {
-        searchFieldWidthConstraint.constant != 0
-    }
-
-    func updateSearchBarIfNeeded(visible: Bool, completionHandler: (() -> Void)? = nil) {
-        guard isSearchBarVisible != visible else {
-            completionHandler?()
-            return
-        }
-
-        updateSearchBar(visible: visible, completionHandler: completionHandler)
-        notifySearchStateWasChanged(visible: visible)
-    }
-
-    func updateSearchBar(visible: Bool, completionHandler: (() -> Void)? = nil) {
-        let newBarWidth     = visible ? Settings.searchBarFullWidth : .zero
-        let newButtonAlpha  = visible ? AppKitConstants.alpha0_0 : AppKitConstants.alpha1_0
-
-        let delayForAlpha   = visible ? AppKitConstants.delay0_0 : AppKitConstants.delay0_15
-        let delayForResize  = visible ? AppKitConstants.delay0_15 : AppKitConstants.delay0_0
-
-        searchButton.isHidden = false
-
-        /// Phase #1: Fade In / Out the Search Action Button
-        ///
-        NSAnimationContext.runAnimationGroup(after: delayForAlpha) { context in
-            context.duration = AppKitConstants.duration0_2
-            self.searchButton.animator().alphaValue = newButtonAlpha
-        } completionHandler: {
-            self.searchButton.isHidden = visible
-        }
-
-        /// Phase #2: Resize the SearchBar itself
-        ///
-        NSAnimationContext.runAnimationGroup(after: delayForResize) { context in
-            context.duration = AppKitConstants.duration0_2
-            self.searchFieldWidthConstraint.animator().constant = newBarWidth
-            self.layoutSubtreeIfNeeded()
-        } completionHandler: {
-            completionHandler?()
-        }
-    }
-
-    func notifySearchStateWasChanged(visible: Bool) {
-        if visible {
-            delegate?.toolbarDidBeginSearch()
-        } else {
-            delegate?.toolbarDidEndSearch()
-        }
     }
 }
 

--- a/Simplenote/ToolbarView.swift
+++ b/Simplenote/ToolbarView.swift
@@ -111,17 +111,6 @@ private extension ToolbarView {
 }
 
 
-// MARK: - Actions
-//
-extension ToolbarView {
-
-    @IBAction
-    func searchWasPressed(_ sender: Any) {
-        beginSearch()
-    }
-}
-
-
 // MARK: - Search Bar Public API
 //
 extension ToolbarView {

--- a/Simplenote/ToolbarView.swift
+++ b/Simplenote/ToolbarView.swift
@@ -18,10 +18,6 @@ class ToolbarView: NSView {
     @IBOutlet private(set) var previewButton: NSButton!
     @IBOutlet private(set) var restoreButton: NSButton!
 
-    /// Search Field
-    ///
-//    @IBOutlet private(set) var searchField: NSSearchField!
-
     /// Represents the Toolbar's State
     ///
     var state: ToolbarState  = .default {
@@ -143,20 +139,5 @@ extension ToolbarView {
 //        searchField.cancelSearch()
 //        searchField.resignFirstResponder()
 //        delegate?.toolbarDidEndSearch()
-    }
-}
-
-
-// MARK: - NSSearchFieldDelegate
-//
-extension ToolbarView: NSSearchFieldDelegate {
-
-    public func controlTextDidEndEditing(_ obj: Notification) {
-//        delegate?.toolbarDidEndSearch()
-    }
-
-    @IBAction
-    public func performSearch(_ sender: Any) {
-//        delegate?.toolbar(self, didSearch: searchField.stringValue)
     }
 }


### PR DESCRIPTION
### Details
In this PR we're relocating the Search Bar back into the Notes List.

cc @eshurakov Ready for 👀 sir!! Thanks in advance!!
cc @SylvesterWilmott 

Ref. #626

### Test: Searching
- [x] Verify entering any keyword in the Search Bar yields global results
- [x] Verify the Minimap reflects search results
- [x] Verify the Editor's Keyword Highlight works super
- [x] Verify clicking over the Editor when Search is active causes the Highlights to be dropped
- [x] Verify clearing the Search Bar's contents causes the Notes List to display the documents associated to the current selection

### Test: Dismissal
- [x] Verify clicking over any Tag / Trash causes the Search to be dismissed
- [x] Verify that clicking over the `+` New Note button causes the Search to be dismissed

### Test: Logout
1. Enter any random keyword in the search field
2. Logout
3. Log in again

- [x] Verify the Search Field is cleared out

### Release
`RELEASE-NOTES.txt` was updated in b08d1665dc276da8e2a640440549b10b0d57df21 with:

> SearchBar has been relocated into the Notes List #838
