### PR TITLE
Updating Sort Bar UX

### DIFF
--- a/Simplenote/Base.lproj/MainMenu.xib
+++ b/Simplenote/Base.lproj/MainMenu.xib
@@ -465,19 +465,19 @@
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <menu key="submenu" title="Note Sorting" systemMenu="font" id="YpJ-fs-p4p">
                                     <items>
-                                        <menuItem title="Alphabetically: A-Z" identifier="noteSortAlphaAscMenuItem" id="AuW-hU-J6R">
+                                        <menuItem title="Name: A-Z" identifier="noteSortAlphaAscMenuItem" id="XEL-Qt-3Ik">
                                             <modifierMask key="keyEquivalentModifierMask"/>
                                             <attributedString key="userComments">
                                                 <fragment content="Toggles Alphabetical Note Sort Order"/>
                                             </attributedString>
                                             <connections>
-                                                <action selector="notesSortModeWasPressed:" target="494" id="s0n-Ud-VNS"/>
+                                                <action selector="notesSortModeWasPressed:" target="494" id="ox3-Cu-8NL"/>
                                             </connections>
                                         </menuItem>
-                                        <menuItem title="Alphabetically: Z-A" identifier="noteSortAlphaDescMenuItem" id="riY-RT-IN8">
+                                        <menuItem title="Name: Z-A" identifier="noteSortAlphaDescMenuItem" id="BFX-rl-bcH">
                                             <modifierMask key="keyEquivalentModifierMask"/>
                                             <connections>
-                                                <action selector="notesSortModeWasPressed:" target="494" id="Jem-Lt-NMh"/>
+                                                <action selector="notesSortModeWasPressed:" target="494" id="IR5-AJ-8nP"/>
                                             </connections>
                                         </menuItem>
                                         <menuItem title="Created: Newest" identifier="noteSortCreateNewestMenuItem" id="Z0V-Oz-ijh">

--- a/Simplenote/Main.storyboard
+++ b/Simplenote/Main.storyboard
@@ -412,26 +412,26 @@
                                         <rect key="frame" x="16" y="0.0" width="262" height="28"/>
                                         <subviews>
                                             <stackView distribution="fill" orientation="horizontal" alignment="centerY" spacing="4" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="8D5-zn-kyD">
-                                                <rect key="frame" x="0.0" y="0.0" width="160" height="28"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="172" height="28"/>
                                                 <subviews>
                                                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="ffx-55-RlY">
-                                                        <rect key="frame" x="-2" y="7" width="32" height="15"/>
-                                                        <textFieldCell key="cell" lineBreakMode="clipping" title="Sort:" id="REi-2x-g6N">
+                                                        <rect key="frame" x="-2" y="7" width="46" height="15"/>
+                                                        <textFieldCell key="cell" lineBreakMode="clipping" title="Sort by" id="REi-2x-g6N">
                                                             <font key="font" metaFont="cellTitle"/>
                                                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                         </textFieldCell>
                                                     </textField>
                                                     <textField horizontalHuggingPriority="252" verticalHuggingPriority="750" horizontalCompressionResistancePriority="748" translatesAutoresizingMaskIntoConstraints="NO" id="hao-b3-D5s">
-                                                        <rect key="frame" x="30" y="7" width="116" height="15"/>
+                                                        <rect key="frame" x="44" y="7" width="114" height="15"/>
                                                         <textFieldCell key="cell" lineBreakMode="clipping" title="Alphabetically A-Z" id="EvQ-V8-rEa">
-                                                            <font key="font" metaFont="systemBold" size="12"/>
+                                                            <font key="font" metaFont="systemSemibold" size="12"/>
                                                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                         </textFieldCell>
                                                     </textField>
                                                     <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="qKt-ft-2oz" userLabel="Arrow">
-                                                        <rect key="frame" x="148" y="8" width="12" height="12"/>
+                                                        <rect key="frame" x="160" y="8" width="12" height="12"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="12" id="FZT-8V-05L"/>
                                                             <constraint firstAttribute="width" constant="12" id="las-mC-CP5"/>

--- a/Simplenote/Main.storyboard
+++ b/Simplenote/Main.storyboard
@@ -412,7 +412,7 @@
                                         <rect key="frame" x="16" y="0.0" width="262" height="28"/>
                                         <subviews>
                                             <stackView distribution="fill" orientation="horizontal" alignment="centerY" spacing="4" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="8D5-zn-kyD">
-                                                <rect key="frame" x="0.0" y="0.0" width="172" height="28"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="156" height="28"/>
                                                 <subviews>
                                                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="ffx-55-RlY">
                                                         <rect key="frame" x="-2" y="7" width="46" height="15"/>
@@ -430,14 +430,6 @@
                                                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                         </textFieldCell>
                                                     </textField>
-                                                    <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="qKt-ft-2oz" userLabel="Arrow">
-                                                        <rect key="frame" x="160" y="8" width="12" height="12"/>
-                                                        <constraints>
-                                                            <constraint firstAttribute="height" constant="12" id="FZT-8V-05L"/>
-                                                            <constraint firstAttribute="width" constant="12" id="las-mC-CP5"/>
-                                                        </constraints>
-                                                        <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="icon_chevron_down" id="o8z-AK-8yf"/>
-                                                    </imageView>
                                                 </subviews>
                                                 <gestureRecognizers>
                                                     <clickGestureRecognizer delaysPrimaryMouseButtonEvents="YES" numberOfClicksRequired="1" id="PLi-zb-9Na">
@@ -449,10 +441,8 @@
                                                 <visibilityPriorities>
                                                     <integer value="1000"/>
                                                     <integer value="1000"/>
-                                                    <integer value="1000"/>
                                                 </visibilityPriorities>
                                                 <customSpacing>
-                                                    <real value="3.4028234663852886e+38"/>
                                                     <real value="3.4028234663852886e+38"/>
                                                     <real value="3.4028234663852886e+38"/>
                                                 </customSpacing>
@@ -466,7 +456,6 @@
                                             <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="8D5-zn-kyD" secondAttribute="trailing" id="ckG-M9-jJD"/>
                                         </constraints>
                                         <connections>
-                                            <outlet property="chevronImageView" destination="qKt-ft-2oz" id="Hkx-uJ-ICi"/>
                                             <outlet property="sortModeLabel" destination="hao-b3-D5s" id="xlb-Kx-6Nc"/>
                                             <outlet property="titleLabel" destination="ffx-55-RlY" id="8QJ-j1-8my"/>
                                         </connections>
@@ -1022,7 +1011,6 @@
         <image name="button_preview_off" width="24" height="24"/>
         <image name="button_restore" width="24" height="24"/>
         <image name="button_tags_close" width="24" height="24"/>
-        <image name="icon_chevron_down" width="16" height="16"/>
         <image name="icon_pin" width="16" height="16"/>
         <image name="icon_shared" width="16" height="16"/>
     </resources>

--- a/Simplenote/SortBarView.swift
+++ b/Simplenote/SortBarView.swift
@@ -10,7 +10,6 @@ class SortBarView: NSView {
     ///
     @IBOutlet private var titleLabel: NSTextField!
     @IBOutlet private var sortModeLabel: NSTextField!
-    @IBOutlet private var chevronImageView: NSImageView!
 
     /// Wraps up access around the SortMode Label
     ///

--- a/Simplenote/SortBarView.swift
+++ b/Simplenote/SortBarView.swift
@@ -27,7 +27,7 @@ class SortBarView: NSView {
 
     override func awakeFromNib() {
         super.awakeFromNib()
-        titleLabel.stringValue = NSLocalizedString("Sort", comment: "Sortbar Title")
+        titleLabel.stringValue = NSLocalizedString("Sort by", comment: "Sortbar Title")
     }
 
     func refreshStyle() {

--- a/Simplenote/SortMode.swift
+++ b/Simplenote/SortMode.swift
@@ -29,9 +29,9 @@ extension SortMode {
     var description: String {
         switch self {
         case .alphabeticallyAscending:
-            return NSLocalizedString("Alphabetically: A-Z", comment: "Sort Mode: Alphabetically, ascending")
+            return NSLocalizedString("Name: A-Z", comment: "Sort Mode: Alphabetically, ascending")
         case .alphabeticallyDescending:
-            return NSLocalizedString("Alphabetically: Z-A", comment: "Sort Mode: Alphabetically, descending")
+            return NSLocalizedString("Name: Z-A", comment: "Sort Mode: Alphabetically, descending")
         case .createdNewest:
             return NSLocalizedString("Created: Newest", comment: "Sort Mode: Creation Date, descending")
         case .createdOldest:


### PR DESCRIPTION
### Fix
In this PR we're adjusting the Sort Bar's UX.

cc @eshurakov 
cc @SylvesterWilmott 

Ref. #626 

### Test
- [x] Verify the Sort Bar now reads `Sort By` rather than `Sort:`
- [x] Verify the top two options are `Name: A-Z` and `Name: Z-A` rather than `Alphabetically:...`
- [x] Verify the Menu `View > Note Sorting` matches the Sort Bar menu

### Release
These changes do not require release notes.
