### PR TITLE
Merge finalize version 2.7 into develop

### DIFF
--- a/config/Version.public.xcconfig
+++ b/config/Version.public.xcconfig
@@ -2,8 +2,8 @@ VERSION_SHORT=2.7
 
 // Public long version. Example: 2.0.0.0. The last 0 means the first build for
 // version 2.0.0
-VERSION_LONG=2.7.0.1
+VERSION_LONG=2.7.0.2
 
 // This is the value for the CFBundleVersion it should be incremented on every
 // build that gets distributed
-BUILD_NUMBER=11216
+BUILD_NUMBER=11217


### PR DESCRIPTION
This has no change in the translations because the recent https://github.com/Automattic/simplenote-macos/pull/837 already contains translations updates. There mustn't have been changes since then, which is understandable since we're at the very end of the code freeze.

---

Note that the name of the branch is messed up because I'm experimenting with a Bash command combo to generate it. It has nothing to do with the content of the branch itself. 

You can verify this by [comparing `release/2.7` against this branch](https://github.com/Automattic/simplenote-macos/compare/merge/release-2.7-sparkle-via-cocoapods-into-develop...release/2.7): there are no changes.