### PR TITLE
Update pin color on the note row

### DIFF
--- a/Simplenote/NoteTableCellView.swift
+++ b/Simplenote/NoteTableCellView.swift
@@ -132,7 +132,7 @@ extension NoteTableCellView {
     ///
     func refreshAccessoryIcons() {
         // We *don't wanna use* `imageView.contentTintColor` since on highlight it's automatically changing the tintColor!
-        let pinnedColor: NSColor = selected ? .simplenoteTextColor : .simplenoteAccessoryTintColor
+        let pinnedColor: NSColor = .simplenoteAccessoryTintColor
         let sharedColor: NSColor = selected ? .simplenoteTextColor : .simplenoteSecondaryTextColor
 
         pinnedImageView.image = pinnedImageView.image?.tinted(with: pinnedColor)


### PR DESCRIPTION
### Details
This PR updates pin color on the selected note row from being the same color as text to blue color.

### Screenshots
|Before|After|
|-|-|
|<img width="986" alt="Screenshot 2021-02-05 at 08 51 47" src="https://user-images.githubusercontent.com/54751/107005217-b59ece80-678f-11eb-8bcc-e95feb40d585.png">|<img width="986" alt="Screenshot 2021-02-05 at 08 47 14" src="https://user-images.githubusercontent.com/54751/107005220-b6376500-678f-11eb-9f0b-a73361bab91b.png">|
|<img width="986" alt="Screenshot 2021-02-05 at 08 51 52" src="https://user-images.githubusercontent.com/54751/107005237-bdf70980-678f-11eb-84ef-0011d2f6127e.png">|<img width="986" alt="Screenshot 2021-02-05 at 08 47 10" src="https://user-images.githubusercontent.com/54751/107005242-bf283680-678f-11eb-8320-13aee7e982c7.png">|


### Test
- [ ] Check pin icon in both dark and light modes

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
> These changes do not require release notes.
