### PR TITLE
Improve text view performance

### DIFF
--- a/External/Notepad/Storage.h
+++ b/External/Notepad/Storage.h
@@ -8,9 +8,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property(nonatomic, strong, readonly) NSMutableAttributedString *backingStore;
 @property(nonatomic, strong, readonly) Theme *theme;
-@property(nonatomic, assign) BOOL skipRestyling;
 
 - (void)refreshStyleWithMarkdownEnabled:(BOOL)markdownEnabled NS_SWIFT_NAME(refreshStyle(markdownEnabled:));
+
+- (void)endEditingWithoutRestyling;
 
 @end
 

--- a/External/Notepad/Storage.h
+++ b/External/Notepad/Storage.h
@@ -1,0 +1,17 @@
+#import <Cocoa/Cocoa.h>
+
+@class Theme;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface Storage : NSTextStorage
+
+@property(nonatomic, strong, readonly) NSMutableAttributedString *backingStore;
+@property(nonatomic, strong, readonly) Theme *theme;
+@property(nonatomic, assign) BOOL skipRestyling;
+
+- (void)refreshStyleWithMarkdownEnabled:(BOOL)markdownEnabled NS_SWIFT_NAME(refreshStyle(markdownEnabled:));
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/External/Notepad/Storage.m
+++ b/External/Notepad/Storage.m
@@ -1,0 +1,70 @@
+#import "Storage.h"
+#import "Simplenote-Swift.h"
+
+@interface Storage ()
+@property(nonatomic, strong) NSMutableAttributedString *backingStore;
+@property(nonatomic, strong) Theme *theme;
+@end
+
+@implementation Storage
+
+- (instancetype)init
+{
+    self = [super init];
+    if (self) {
+        self.backingStore = [[NSMutableAttributedString alloc] init];
+        [self configure];
+    }
+    return self;
+}
+
+- (instancetype)initWithAttributedString:(NSAttributedString *)attrStr
+{
+    self = [super initWithAttributedString:attrStr];
+    if (self) {
+        self.backingStore = [[NSMutableAttributedString alloc] initWithAttributedString:attrStr];
+        [self configure];
+    }
+    return self;
+}
+
+- (void)configure
+{
+    self.theme = [[Theme alloc] initWithMarkdownEnabled:NO];
+}
+
+- (NSString *)string {
+    return self.backingStore.string;
+}
+
+- (NSDictionary<NSAttributedStringKey,id> *)attributesAtIndex:(NSUInteger)location effectiveRange:(NSRangePointer)range
+{
+    return [self.backingStore attributesAtIndex:location effectiveRange:range];
+}
+
+/// Refreshes the receiver's Attributes. We must always do this since `Markdown` isn't the only variable: FontSize might have been also updated!
+///
+- (void)refreshStyleWithMarkdownEnabled:(BOOL)markdownEnabled
+{
+    self.theme = [[Theme alloc] initWithMarkdownEnabled:markdownEnabled];
+    [self resetStyles];
+}
+
+/// Processes any edits made to the text in the editor.
+///
+- (void)processEditing
+{
+    if (self.skipRestyling) {
+        [super processEditing];
+        return;
+    }
+
+    NSRange lineRange = [[self string] lineRangeForRange:NSMakeRange(NSMaxRange(self.editedRange), 0)];
+    NSRange extendedRange = NSUnionRange(self.editedRange, lineRange);
+
+    [self applyStyles:extendedRange];
+
+    [super processEditing];
+}
+
+@end

--- a/External/Notepad/Storage.m
+++ b/External/Notepad/Storage.m
@@ -4,6 +4,7 @@
 @interface Storage ()
 @property(nonatomic, strong) NSMutableAttributedString *backingStore;
 @property(nonatomic, strong) Theme *theme;
+@property(nonatomic, assign) BOOL skipRestyling;
 @end
 
 @implementation Storage
@@ -65,6 +66,12 @@
     [self applyStyles:extendedRange];
 
     [super processEditing];
+}
+
+- (void)endEditingWithoutRestyling {
+    self.skipRestyling = YES;
+    [self endEditing];
+    self.skipRestyling = NO;
 }
 
 @end

--- a/External/Notepad/Theme.swift
+++ b/External/Notepad/Theme.swift
@@ -12,7 +12,8 @@ import AppKit
 
 // MARK: - Theme
 //
-class Theme {
+@objc
+class Theme: NSObject {
 
     /// Default Font Size
     ///
@@ -46,6 +47,7 @@ class Theme {
 
     /// Designated Initializer
     ///
+    @objc
     init(markdownEnabled: Bool) {
         self.headlineStyle = Theme.headlineStyle
         self.bodyStyle = Theme.bodyStyle

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -112,6 +112,7 @@
 		714BA66E14D4AE6300A6CCC1 /* DateTransformer.m in Sources */ = {isa = PBXBuildFile; fileRef = 714BA66D14D4AE6200A6CCC1 /* DateTransformer.m */; };
 		7154811714E5A9E800CB8964 /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7154811614E5A9E800CB8964 /* WebKit.framework */; };
 		71DCEBE7152E2ED1002744C0 /* NSMutableAttributedString+Styling.m in Sources */ = {isa = PBXBuildFile; fileRef = 71DCEBE6152E2ED1002744C0 /* NSMutableAttributedString+Styling.m */; };
+		A6084B2C25D1B77000DDFAB2 /* Storage.m in Sources */ = {isa = PBXBuildFile; fileRef = A6084B2B25D1B77000DDFAB2 /* Storage.m */; };
 		A6672FB325C7F12F00090DE3 /* NoteContentHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6672FB225C7F12F00090DE3 /* NoteContentHelper.swift */; };
 		A6672FB825C7F1BB00090DE3 /* ContentSlice.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6672FB725C7F1BB00090DE3 /* ContentSlice.swift */; };
 		A6672FBE25C7F77000090DE3 /* StringContentSliceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6672FBC25C7F77000090DE3 /* StringContentSliceTests.swift */; };
@@ -548,6 +549,8 @@
 		8C902F8C22D3EE350018D654 /* Version.public.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Version.public.xcconfig; path = config/Version.public.xcconfig; sourceTree = "<group>"; };
 		8C902F8E22D3EFE60018D654 /* Simplenote.debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Simplenote.debug.xcconfig; path = config/Simplenote.debug.xcconfig; sourceTree = "<group>"; };
 		9F3E61907F329B466EEE619E /* Pods-Automattic-Simplenote-AppStore.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Automattic-Simplenote-AppStore.release.xcconfig"; path = "Target Support Files/Pods-Automattic-Simplenote-AppStore/Pods-Automattic-Simplenote-AppStore.release.xcconfig"; sourceTree = "<group>"; };
+		A6084B2A25D1B77000DDFAB2 /* Storage.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Storage.h; sourceTree = "<group>"; };
+		A6084B2B25D1B77000DDFAB2 /* Storage.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Storage.m; sourceTree = "<group>"; };
 		A6672FB225C7F12F00090DE3 /* NoteContentHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NoteContentHelper.swift; sourceTree = "<group>"; };
 		A6672FB725C7F1BB00090DE3 /* ContentSlice.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContentSlice.swift; sourceTree = "<group>"; };
 		A6672FBC25C7F77000090DE3 /* StringContentSliceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StringContentSliceTests.swift; sourceTree = "<group>"; };
@@ -932,6 +935,8 @@
 			children = (
 				373B50DC20179DFE000568A6 /* Extensions.swift */,
 				3712FC701FE1ACA9008544AC /* Storage.swift */,
+				A6084B2A25D1B77000DDFAB2 /* Storage.h */,
+				A6084B2B25D1B77000DDFAB2 /* Storage.m */,
 				3712FC721FE1ACA9008544AC /* Element.swift */,
 				3712FC751FE1ACA9008544AC /* Style.swift */,
 				3712FC761FE1ACA9008544AC /* Theme.swift */,
@@ -2060,6 +2065,7 @@
 				B59848801BCDB95A005EFBBE /* SPAutomatticTracker.m in Sources */,
 				B5B1CBCD256EE72C0040726C /* NSScrollView+Simplenote.swift in Sources */,
 				37AE49C21FFEB92A00FCB165 /* SPMarkdownParser.m in Sources */,
+				A6084B2C25D1B77000DDFAB2 /* Storage.m in Sources */,
 				B5CBB05C2419714B0003C271 /* NSAttributedStringToMarkdownConverter.swift in Sources */,
 				B5E96B661BDE732500D707F5 /* LoginWindowController.m in Sources */,
 				B5EB3AD42458C48D0089858D /* SimplenoteAppDelegate+Swift.swift in Sources */,

--- a/Simplenote/NSTextView+Simplenote.swift
+++ b/Simplenote/NSTextView+Simplenote.swift
@@ -165,7 +165,6 @@ extension NSTextView {
 
         /// Issue #472: Linkification should not be undoable
         undoManager?.disableUndoRegistration()
-        checkTextInDocument(nil)
 
         if let layoutManager = layoutManager,
            let textContainer = textContainer,

--- a/Simplenote/NSTextView+Simplenote.swift
+++ b/Simplenote/NSTextView+Simplenote.swift
@@ -166,6 +166,21 @@ extension NSTextView {
         /// Issue #472: Linkification should not be undoable
         undoManager?.disableUndoRegistration()
         checkTextInDocument(nil)
+
+        if let layoutManager = layoutManager,
+           let textContainer = textContainer,
+           let textStorage = textStorage as? Storage {
+
+            // checkTextInDocument calculate bounds for links and we need to ensure that layout is current before calling beginEditing
+            // otherwise it will crash trying to update layout inside beginEditing / endEditing block
+            layoutManager.ensureLayout(for: textContainer)
+            textStorage.beginEditing()
+            checkTextInDocument(nil)
+            textStorage.endEditingWithoutRestyling()
+        } else {
+            checkTextInDocument(nil)
+        }
+
         undoManager?.enableUndoRegistration()
 
         /// Restore the Delegate

--- a/Simplenote/NoteEditorViewController+Swift.swift
+++ b/Simplenote/NoteEditorViewController+Swift.swift
@@ -891,7 +891,9 @@ extension NoteEditorViewController {
     @objc
     func displayContent(_ content: String?) {
         noteEditor.displayNote(content: content ?? "")
-        updateKeywordsHighlight()
+        DispatchQueue.main.async { [weak self] in
+            self?.updateKeywordsHighlight()
+        }
     }
 
     @objc

--- a/Simplenote/SPTextView.swift
+++ b/Simplenote/SPTextView.swift
@@ -26,7 +26,9 @@ class SPTextView: NSTextView {
                 textStorage.addAttribute(.backgroundColor, value: NSColor.simplenoteEditorSearchHighlightColor, range: range)
             }
 
-            textStorage.endEditingWithoutRestyling()
+            textStorage.skipRestyling = true
+            textStorage.endEditing()
+            textStorage.skipRestyling = false
         }
     }
 

--- a/Simplenote/SPTextView.swift
+++ b/Simplenote/SPTextView.swift
@@ -26,9 +26,7 @@ class SPTextView: NSTextView {
                 textStorage.addAttribute(.backgroundColor, value: NSColor.simplenoteEditorSearchHighlightColor, range: range)
             }
 
-            textStorage.skipRestyling = true
-            textStorage.endEditing()
-            textStorage.skipRestyling = false
+            textStorage.endEditingWithoutRestyling()
         }
     }
 

--- a/Simplenote/Simplenote-Bridging-Header.h
+++ b/Simplenote/Simplenote-Bridging-Header.h
@@ -19,7 +19,7 @@
 #import "SPTableView.h"
 #import "SPTracker.h"
 #import "TagListViewController.h"
-
+#import "Storage.h"
 
 #pragma mark - Extensions
 


### PR DESCRIPTION
### Details
I've updated a few things in this PR.

#### Convert part of Storage.swift to ObjC
Yes, we've converted some code back to objc as it cuts some processing time. In case text has a lot of attributes bridging swift to objc becomes expensive.
My rough benchmark on a note with 40k characters, highlighting 2k words in it.
`noteEditor.highlightedRanges = ranges` line was taking:
Before: 0.1 sec
After: 0.014 sec

#### Wrap `checkTextInDocument` in begin / end editing
`checkTextInDocument` is used to render links and in some notes with a lot of links it takes a lot of time.
My rough benchmark on a note with 90k characters containing only links.
Measuring `processLinksInDocument`:
Before: 2.44 sec
After: 0.33 sec

### Test
Do a quick smoke test around note editor and working with links.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
> These changes do not require release notes.
