### PR TITLE
Issue/update simplenote search version

### DIFF
--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -414,6 +414,7 @@
 		B5F807CD2481982B0048CBD7 /* Note+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5F807CB2481982B0048CBD7 /* Note+Simplenote.swift */; };
 		B5F807CF2481A2010048CBD7 /* Simperium+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5F807CE2481A2010048CBD7 /* Simperium+Simplenote.swift */; };
 		B5F807D02481A2010048CBD7 /* Simperium+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5F807CE2481A2010048CBD7 /* Simperium+Simplenote.swift */; };
+		BAA4854A25D5E22000F3BDB9 /* SearchQuery+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAA4854925D5E22000F3BDB9 /* SearchQuery+Simplenote.swift */; };
 		CD6BC8FB4B8661C30318208C /* Pods_Automattic_SimplenoteTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 22D95A169BF4BF7DEABC4021 /* Pods_Automattic_SimplenoteTests.framework */; };
 		D0A1D693931CD24A56140DF7 /* Pods_Automattic_Simplenote.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0F7AA366214AF89DB7A1C687 /* Pods_Automattic_Simplenote.framework */; };
 		F998F3EB22853C29008C2B59 /* CrashLogging.swift in Sources */ = {isa = PBXBuildFile; fileRef = F998F3EA22853C29008C2B59 /* CrashLogging.swift */; };
@@ -767,6 +768,7 @@
 		B5F50914247319360042FA1D /* SplitView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplitView.swift; sourceTree = "<group>"; };
 		B5F807CB2481982B0048CBD7 /* Note+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Note+Simplenote.swift"; sourceTree = "<group>"; };
 		B5F807CE2481A2010048CBD7 /* Simperium+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Simperium+Simplenote.swift"; sourceTree = "<group>"; };
+		BAA4854925D5E22000F3BDB9 /* SearchQuery+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SearchQuery+Simplenote.swift"; sourceTree = "<group>"; };
 		F998F3EA22853C29008C2B59 /* CrashLogging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashLogging.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -1166,6 +1168,7 @@
 				B5009936242130F70037A431 /* UnicodeScalar+Simplenote.swift */,
 				B547285B250920CA00D823BA /* URL+Interlink.swift */,
 				B57CB876244DEBCE00BA7969 /* UserDefaults+Simplenote.swift */,
+				BAA4854925D5E22000F3BDB9 /* SearchQuery+Simplenote.swift */,
 			);
 			name = Extensions;
 			sourceTree = "<group>";
@@ -2021,6 +2024,7 @@
 				B51374F61AC0591900825FCC /* SPConstants.m in Sources */,
 				B52197862541C65C00182928 /* NumberFormatter+Simplenote.swift in Sources */,
 				B5E086382448EE9D00DEF476 /* NSTableView+Simplenote.swift in Sources */,
+				BAA4854A25D5E22000F3BDB9 /* SearchQuery+Simplenote.swift in Sources */,
 				3712FC861FE1ACAA008544AC /* Element.swift in Sources */,
 				B5F04FD021594B6D004B1AA0 /* Simperium+Simplenote.m in Sources */,
 				B5469FCA2587DE3F007ED7BE /* SortMode.swift in Sources */,

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -2851,8 +2851,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "git@github.com:Automattic/SimplenoteSearch-Swift.git";
 			requirement = {
-				branch = "issue/860-localize-tag-search";
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.3.0;
 			};
 		};
 		B5609AEE24EF171D0097777A /* XCRemoteSwiftPackageReference "SimplenoteFoundation-Swift" */ = {

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -2847,8 +2847,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "git@github.com:Automattic/SimplenoteSearch-Swift.git";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 1.2.0;
+				branch = "issue/860-localize-tag-search";
+				kind = branch;
 			};
 		};
 		B5609AEE24EF171D0097777A /* XCRemoteSwiftPackageReference "SimplenoteFoundation-Swift" */ = {

--- a/Simplenote.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Simplenote.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -23,9 +23,9 @@
         "package": "SimplenoteSearch",
         "repositoryURL": "git@github.com:Automattic/SimplenoteSearch-Swift.git",
         "state": {
-          "branch": null,
-          "revision": "a876c38aa0511f34fea85d93886e588c71b8b231",
-          "version": "1.2.0"
+          "branch": "issue/860-localize-tag-search",
+          "revision": "53d1e19f4cdcaef88b811d84c2c8e1c035b32318",
+          "version": null
         }
       }
     ]

--- a/Simplenote.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Simplenote.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -23,9 +23,9 @@
         "package": "SimplenoteSearch",
         "repositoryURL": "git@github.com:Automattic/SimplenoteSearch-Swift.git",
         "state": {
-          "branch": "issue/860-localize-tag-search",
-          "revision": "53d1e19f4cdcaef88b811d84c2c8e1c035b32318",
-          "version": null
+          "branch": null,
+          "revision": "499d2809d169fcbeb9ff75568d9f1f937f290ffc",
+          "version": "1.3.0"
         }
       }
     ]

--- a/Simplenote/NoteListViewController.swift
+++ b/Simplenote/NoteListViewController.swift
@@ -605,7 +605,7 @@ extension NoteListViewController: NSSearchFieldDelegate {
 
     @IBAction
     public func performSearch(_ sender: Any) {
-        searchQuery = SearchQuery(searchText: searchField.stringValue, settings: SearchQuerySettings.default)
+        searchQuery = SearchQuery(searchText: searchField.stringValue)
         refreshEverything()
         SPTracker.trackListNotesSearched()
     }
@@ -852,13 +852,6 @@ extension NoteListViewController {
         sortbarMenu.popUp(positioning: nil, at: menuOrigin, in: headerContainerView)
     }
 }
-
-extension SearchQuerySettings {
-     static var `default`: SearchQuerySettings {
-         let localizedKeyword = NSLocalizedString("tag:", comment: "Search Operator for tags. Please preserve the semicolons")
-         return SearchQuerySettings(tagsKeyword: "tag:", localizedTagKeyword: localizedKeyword)
-     }
- }
 
 // MARK: - Settings
 //

--- a/Simplenote/NoteListViewController.swift
+++ b/Simplenote/NoteListViewController.swift
@@ -605,7 +605,7 @@ extension NoteListViewController: NSSearchFieldDelegate {
 
     @IBAction
     public func performSearch(_ sender: Any) {
-        searchQuery = SearchQuery(searchText: searchField.stringValue)
+        searchQuery = SearchQuery(searchText: searchField.stringValue, settings: SearchQuerySettings.default)
         refreshEverything()
         SPTracker.trackListNotesSearched()
     }
@@ -853,6 +853,12 @@ extension NoteListViewController {
     }
 }
 
+extension SearchQuerySettings {
+     static var `default`: SearchQuerySettings {
+         let localizedKeyword = NSLocalizedString("tag:", comment: "Search Operator for tags. Please preserve the semicolons")
+         return SearchQuerySettings(tagsKeyword: "tag:", localizedTagKeyword: localizedKeyword)
+     }
+ }
 
 // MARK: - Settings
 //

--- a/Simplenote/SearchQuery+Simplenote.swift
+++ b/Simplenote/SearchQuery+Simplenote.swift
@@ -1,0 +1,16 @@
+import Foundation
+import SimplenoteSearch
+
+
+extension SearchQuery {
+    convenience init(searchText: String) {
+        self.init(searchText: searchText, settings: .default)
+    }
+}
+
+extension SearchQuerySettings {
+     static var `default`: SearchQuerySettings {
+         let localizedKeyword = NSLocalizedString("tag:", comment: "Search Operator for tags. Please preserve the semicolons")
+         return SearchQuerySettings(tagsKeyword: "tag:", localizedTagKeyword: localizedKeyword)
+     }
+ }

--- a/SimplenoteTests/NoteListControllerTests.swift
+++ b/SimplenoteTests/NoteListControllerTests.swift
@@ -116,7 +116,7 @@ extension NoteListControllerTests {
         storage.save()
         XCTAssertEqual(noteListController.numberOfNotes, 2)
 
-        noteListController.filter = .search(query: SearchQuery(searchText: "34"))
+        noteListController.filter = .search(query: SearchQuery(searchText: "34", settings: SearchQuerySettings.default))
         noteListController.performFetch()
 
         XCTAssertEqual(noteListController.numberOfNotes, 1)
@@ -129,7 +129,7 @@ extension NoteListControllerTests {
         note.deleted = true
         storage.save()
 
-        noteListController.filter = .search(query: SearchQuery(searchText: "Here"))
+        noteListController.filter = .search(query: SearchQuery(searchText: "Here", settings: SearchQuerySettings.default))
         noteListController.performFetch()
         XCTAssertEqual(noteListController.numberOfNotes, .zero)
     }
@@ -161,7 +161,7 @@ extension NoteListControllerTests {
         storage.save()
 
         // This is a specific keyword contained by eeeevery siiiiinnnnngle entity!
-        noteListController.filter = .search(query: SearchQuery(searchText: "0"))
+        noteListController.filter = .search(query: SearchQuery(searchText: "0", settings: SearchQuerySettings.default))
         noteListController.performFetch()
 
         for (index, payload) in expected.enumerated() {
@@ -176,7 +176,7 @@ extension NoteListControllerTests {
         insertSampleNotes(count: 100)
         storage.save()
 
-        noteListController.filter = .search(query: SearchQuery(searchText: "055"))
+        noteListController.filter = .search(query: SearchQuery(searchText: "055", settings: SearchQuerySettings.default))
         noteListController.performFetch()
         XCTAssertEqual(noteListController.numberOfNotes, 1)
 
@@ -209,7 +209,7 @@ extension NoteListControllerTests {
         storage.save()
 
         // This is a specific keyword contained by eeeevery siiiiinnnnngle entity!
-        noteListController.filter = .search(query: SearchQuery(searchText: "0"))
+        noteListController.filter = .search(query: SearchQuery(searchText: "0", settings: SearchQuerySettings.default))
         noteListController.performFetch()
 
         for (index, note) in notes.enumerated() {
@@ -292,7 +292,7 @@ extension NoteListControllerTests {
             IndexPath(index: .zero)
         ]))
 
-        noteListController.filter = .search(query: SearchQuery(searchText: "Test"))
+        noteListController.filter = .search(query: SearchQuery(searchText: "Test", settings: SearchQuerySettings.default))
         noteListController.performFetch()
 
         storage.insertSampleNote(contents: "Test")
@@ -311,7 +311,7 @@ extension NoteListControllerTests {
             IndexPath(index: .zero)
         ]))
 
-        noteListController.filter = .search(query: SearchQuery(searchText: "Test"))
+        noteListController.filter = .search(query: SearchQuery(searchText: "Test", settings: SearchQuerySettings.default))
         note.content = "Test Updated"
         storage.save()
 
@@ -328,7 +328,7 @@ extension NoteListControllerTests {
             IndexPath(index: .zero)
         ]))
 
-        noteListController.filter = .search(query: SearchQuery(searchText: "Test"))
+        noteListController.filter = .search(query: SearchQuery(searchText: "Test", settings: SearchQuerySettings.default))
         storage.delete(note)
         storage.save()
 

--- a/SimplenoteTests/NoteListControllerTests.swift
+++ b/SimplenoteTests/NoteListControllerTests.swift
@@ -116,7 +116,7 @@ extension NoteListControllerTests {
         storage.save()
         XCTAssertEqual(noteListController.numberOfNotes, 2)
 
-        noteListController.filter = .search(query: SearchQuery(searchText: "34", settings: SearchQuerySettings.default))
+        noteListController.filter = .search(query: SearchQuery(searchText: "34", settings: .default))
         noteListController.performFetch()
 
         XCTAssertEqual(noteListController.numberOfNotes, 1)
@@ -129,7 +129,7 @@ extension NoteListControllerTests {
         note.deleted = true
         storage.save()
 
-        noteListController.filter = .search(query: SearchQuery(searchText: "Here", settings: SearchQuerySettings.default))
+        noteListController.filter = .search(query: SearchQuery(searchText: "Here", settings: .default))
         noteListController.performFetch()
         XCTAssertEqual(noteListController.numberOfNotes, .zero)
     }
@@ -161,7 +161,7 @@ extension NoteListControllerTests {
         storage.save()
 
         // This is a specific keyword contained by eeeevery siiiiinnnnngle entity!
-        noteListController.filter = .search(query: SearchQuery(searchText: "0", settings: SearchQuerySettings.default))
+        noteListController.filter = .search(query: SearchQuery(searchText: "0", settings: .default))
         noteListController.performFetch()
 
         for (index, payload) in expected.enumerated() {
@@ -176,7 +176,7 @@ extension NoteListControllerTests {
         insertSampleNotes(count: 100)
         storage.save()
 
-        noteListController.filter = .search(query: SearchQuery(searchText: "055", settings: SearchQuerySettings.default))
+        noteListController.filter = .search(query: SearchQuery(searchText: "055", settings: .default))
         noteListController.performFetch()
         XCTAssertEqual(noteListController.numberOfNotes, 1)
 
@@ -209,7 +209,7 @@ extension NoteListControllerTests {
         storage.save()
 
         // This is a specific keyword contained by eeeevery siiiiinnnnngle entity!
-        noteListController.filter = .search(query: SearchQuery(searchText: "0", settings: SearchQuerySettings.default))
+        noteListController.filter = .search(query: SearchQuery(searchText: "0", settings: .default))
         noteListController.performFetch()
 
         for (index, note) in notes.enumerated() {
@@ -292,7 +292,7 @@ extension NoteListControllerTests {
             IndexPath(index: .zero)
         ]))
 
-        noteListController.filter = .search(query: SearchQuery(searchText: "Test", settings: SearchQuerySettings.default))
+        noteListController.filter = .search(query: SearchQuery(searchText: "Test", settings: .default))
         noteListController.performFetch()
 
         storage.insertSampleNote(contents: "Test")
@@ -311,7 +311,7 @@ extension NoteListControllerTests {
             IndexPath(index: .zero)
         ]))
 
-        noteListController.filter = .search(query: SearchQuery(searchText: "Test", settings: SearchQuerySettings.default))
+        noteListController.filter = .search(query: SearchQuery(searchText: "Test", settings: .default))
         note.content = "Test Updated"
         storage.save()
 
@@ -328,7 +328,7 @@ extension NoteListControllerTests {
             IndexPath(index: .zero)
         ]))
 
-        noteListController.filter = .search(query: SearchQuery(searchText: "Test", settings: SearchQuerySettings.default))
+        noteListController.filter = .search(query: SearchQuery(searchText: "Test", settings: .default))
         storage.delete(note)
         storage.save()
 

--- a/SimplenoteTests/NoteListControllerTests.swift
+++ b/SimplenoteTests/NoteListControllerTests.swift
@@ -116,7 +116,7 @@ extension NoteListControllerTests {
         storage.save()
         XCTAssertEqual(noteListController.numberOfNotes, 2)
 
-        noteListController.filter = .search(query: SearchQuery(searchText: "34", settings: .default))
+        noteListController.filter = .search(query: SearchQuery(searchText: "34"))
         noteListController.performFetch()
 
         XCTAssertEqual(noteListController.numberOfNotes, 1)
@@ -129,7 +129,7 @@ extension NoteListControllerTests {
         note.deleted = true
         storage.save()
 
-        noteListController.filter = .search(query: SearchQuery(searchText: "Here", settings: .default))
+        noteListController.filter = .search(query: SearchQuery(searchText: "Here"))
         noteListController.performFetch()
         XCTAssertEqual(noteListController.numberOfNotes, .zero)
     }
@@ -161,7 +161,7 @@ extension NoteListControllerTests {
         storage.save()
 
         // This is a specific keyword contained by eeeevery siiiiinnnnngle entity!
-        noteListController.filter = .search(query: SearchQuery(searchText: "0", settings: .default))
+        noteListController.filter = .search(query: SearchQuery(searchText: "0"))
         noteListController.performFetch()
 
         for (index, payload) in expected.enumerated() {
@@ -176,7 +176,7 @@ extension NoteListControllerTests {
         insertSampleNotes(count: 100)
         storage.save()
 
-        noteListController.filter = .search(query: SearchQuery(searchText: "055", settings: .default))
+        noteListController.filter = .search(query: SearchQuery(searchText: "055"))
         noteListController.performFetch()
         XCTAssertEqual(noteListController.numberOfNotes, 1)
 
@@ -209,7 +209,7 @@ extension NoteListControllerTests {
         storage.save()
 
         // This is a specific keyword contained by eeeevery siiiiinnnnngle entity!
-        noteListController.filter = .search(query: SearchQuery(searchText: "0", settings: .default))
+        noteListController.filter = .search(query: SearchQuery(searchText: "0"))
         noteListController.performFetch()
 
         for (index, note) in notes.enumerated() {
@@ -292,7 +292,7 @@ extension NoteListControllerTests {
             IndexPath(index: .zero)
         ]))
 
-        noteListController.filter = .search(query: SearchQuery(searchText: "Test", settings: .default))
+        noteListController.filter = .search(query: SearchQuery(searchText: "Test"))
         noteListController.performFetch()
 
         storage.insertSampleNote(contents: "Test")
@@ -311,7 +311,7 @@ extension NoteListControllerTests {
             IndexPath(index: .zero)
         ]))
 
-        noteListController.filter = .search(query: SearchQuery(searchText: "Test", settings: .default))
+        noteListController.filter = .search(query: SearchQuery(searchText: "Test"))
         note.content = "Test Updated"
         storage.save()
 
@@ -328,7 +328,7 @@ extension NoteListControllerTests {
             IndexPath(index: .zero)
         ]))
 
-        noteListController.filter = .search(query: SearchQuery(searchText: "Test", settings: .default))
+        noteListController.filter = .search(query: SearchQuery(searchText: "Test"))
         storage.delete(note)
         storage.save()
 


### PR DESCRIPTION
### Fix
This is a quick PR to prepare Simplenote Mac for the most recent changes to SimplenoteSearch.

All that is being changed here is the addition of a default value for SearchQuerySettings.default and updating one search method call to include the use of the settings, and update the NoteList  tests to use the settings as well.

### Test
***(Required)*** List the steps to test the behavior.  For example:
This update should not modify the functionality of the app.
Make sure to test that searching in the app and tag searches still work

### Review
***(Required)*** Add instructions for reviewers.  For example:
one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.
