### PR TITLE
Build App Store target on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - setup_environment
       - run:
-          name: Build
+          name: Build & Test
           # We've seen some builds timeout because CircleCI didn't receive
           # output for 10m. Making it wait for 20m instead should address that.
           #
@@ -44,11 +44,13 @@ jobs:
           no_output_timeout: 20m
           command: |
             # Build without code signing to avoid missing cert errors
-            xcodebuild COMPILER_INDEX_STORE_ENABLE=NO CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO \
-                       -workspace 'Simplenote.xcworkspace' \
-                       -scheme 'Simplenote' \
-                       -configuration 'Debug' \
-                       test
+            xcodebuild clean test \
+                -workspace 'Simplenote.xcworkspace' \
+                -scheme 'Simplenote' \
+                -configuration 'Debug' \
+                COMPILER_INDEX_STORE_ENABLE=NO \
+                CODE_SIGN_IDENTITY="" \
+                CODE_SIGNING_REQUIRED=NO
 
 workflows:
   simplenote_macos:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,26 @@ jobs:
                 CODE_SIGN_IDENTITY="" \
                 CODE_SIGNING_REQUIRED=NO
 
+  Build App Store Target:
+    executor:
+      name: ios/default
+      xcode-version: "12.0"
+    steps:
+      - setup_environment
+      - run:
+          name: Build App Store Target
+          command: |
+            # Build without code signing to avoid missing cert errors
+            xcodebuild clean build \
+                -workspace 'Simplenote.xcworkspace' \
+                -scheme 'Simplenote-AppStore' \
+                -configuration 'Release' \
+                COMPILER_INDEX_STORE_ENABLE=NO \
+                CODE_SIGN_IDENTITY="" \
+                CODE_SIGNING_REQUIRED=NO
+
 workflows:
   simplenote_macos:
     jobs:
       - Test
+      - Build App Store Target

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,24 +4,33 @@ orbs:
   # This uses the Orbs located at https://github.com/wordpress-mobile/circleci-orbs
   ios: wordpress-mobile/ios@1.0
 
+# Reusable sets of steps
+commands:
+  setup_environment:
+    steps:
+      - checkout
+      - run:
+          name: Copy Demo SPCredentials
+          command: |
+            mkdir -p Simplenote/Credentials
+            cp Simplenote/SPCredentials-demo.swift Simplenote/Credentials/SPCredentials.swift
+      - ios/install-dependencies:
+          bundle-install: true
+          pod-install: true
+      - run:
+          # See https://support.circleci.com/hc/en-us/articles/360044709573-Swift-Package-Manager-fails-to-clone-from-private-Git-repositories
+          name: Workaround for Swift Package Manager and xcodebuild
+          command: |
+            rm ~/.ssh/id_rsa
+            for ip in $(dig @8.8.8.8 github.com +short); do ssh-keyscan github.com,$ip; ssh-keyscan $ip; done 2>/dev/null >> ~/.ssh/known_hosts || true
+
 jobs:
   Test:
     executor:
       name: ios/default
       xcode-version: "12.0"
     steps:
-      - checkout
-      - run:
-          name: Copy Demo SPCredentials
-          command: mkdir -p Simplenote/Credentials && cp Simplenote/SPCredentials-demo.swift Simplenote/Credentials/SPCredentials.swift
-      - ios/install-dependencies:
-          bundle-install: true
-          pod-install: true
-      # Start: Swift Package Manager Workaround
-      # Ref. https://support.circleci.com/hc/en-us/articles/360044709573-Swift-Package-Manager-fails-to-clone-from-private-Git-repositories
-      - run: rm ~/.ssh/id_rsa
-      - run: for ip in $(dig @8.8.8.8 github.com +short); do ssh-keyscan github.com,$ip; ssh-keyscan $ip; done 2>/dev/null >> ~/.ssh/known_hosts || true
-      # END: Swift Package Manager Workaround
+      - setup_environment
       - run:
           name: Build
           # We've seen some builds timeout because CircleCI didn't receive


### PR DESCRIPTION
With two different targets, it can sometime happen to forget to add new source files to the target that's not currently selected.

The long term solution to this problem is to consolidate the two targets in favor of a new build configuration (#853) but while we wait for that to happen, let's make sure the App Store target can build on CI.

Based off `release/2.8` because `develop` doesn't build at the moment. #854 will fix that.

### Test

You can see the CI build working [here](https://app.circleci.com/pipelines/github/Automattic/simplenote-macos/1989/workflows/925e6a55-0f0d-44b6-9167-c487867f8e34).

<img width="775" alt="Screen Shot 2021-02-16 at 2 52 03 pm" src="https://user-images.githubusercontent.com/1218433/108016411-9133d380-7066-11eb-9633-c936e74bb031.png">

### Review

Only one developer required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.