### PR TITLE
Pinning SimplenoteSearch to Mk 1.2.0

### DIFF
--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -2869,8 +2869,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "git@github.com:Automattic/SimplenoteSearch-Swift.git";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 1.2.0;
+				kind = exactVersion;
+				version = 1.2.0;
 			};
 		};
 		B5609AEE24EF171D0097777A /* XCRemoteSwiftPackageReference "SimplenoteFoundation-Swift" */ = {


### PR DESCRIPTION
### Fix
In this PR we're pinning Simplenote to Mk 1.2.0 (since 1.3.0 breaks Simplenote 2.8).

### Test
- [x] Verify the app builds correctly!

### Release
These changes do not require release notes.
