### PR TITLE
Decoupling PopoverWindowController: Mk 2

### DIFF
--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -195,6 +195,8 @@
 		B5395E1E253F70E30068F1A6 /* MetricTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5395E1C253F70E30068F1A6 /* MetricTableViewCell.swift */; };
 		B53ACDE425DD47BB00CF527A /* InterlinkViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = B53ACDE325DD47BB00CF527A /* InterlinkViewController.xib */; };
 		B53ACDE525DD47BB00CF527A /* InterlinkViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = B53ACDE325DD47BB00CF527A /* InterlinkViewController.xib */; };
+		B53ACE0E25DD7DF900CF527A /* InterlinkProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53ACE0D25DD7DF900CF527A /* InterlinkProcessor.swift */; };
+		B53ACE0F25DD7DF900CF527A /* InterlinkProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53ACE0D25DD7DF900CF527A /* InterlinkProcessor.swift */; };
 		B53ACE1325DD7E6C00CF527A /* SearchQuery+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAA4854925D5E22000F3BDB9 /* SearchQuery+Simplenote.swift */; };
 		B53BF19C24ABDE7C00938C34 /* DateFormatter+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53BF19B24ABDE7C00938C34 /* DateFormatter+Simplenote.swift */; };
 		B53BF19D24ABDE7C00938C34 /* DateFormatter+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53BF19B24ABDE7C00938C34 /* DateFormatter+Simplenote.swift */; };
@@ -627,6 +629,7 @@
 		B535014A249D5908003837C8 /* HorizontalScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HorizontalScrollView.swift; sourceTree = "<group>"; };
 		B5395E1C253F70E30068F1A6 /* MetricTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetricTableViewCell.swift; sourceTree = "<group>"; };
 		B53ACDE325DD47BB00CF527A /* InterlinkViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = InterlinkViewController.xib; sourceTree = "<group>"; };
+		B53ACE0D25DD7DF900CF527A /* InterlinkProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterlinkProcessor.swift; sourceTree = "<group>"; };
 		B53BF19B24ABDE7C00938C34 /* DateFormatter+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DateFormatter+Simplenote.swift"; sourceTree = "<group>"; };
 		B53BF19F24AC1FB800938C34 /* Version.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Version.swift; sourceTree = "<group>"; };
 		B53BF1A324AC38C100938C34 /* VersionsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VersionsController.swift; sourceTree = "<group>"; };
@@ -1431,6 +1434,7 @@
 			children = (
 				B5C63336251E6A5A00C8BF46 /* InterlinkViewController.swift */,
 				B53ACDE325DD47BB00CF527A /* InterlinkViewController.xib */,
+				B53ACE0D25DD7DF900CF527A /* InterlinkProcessor.swift */,
 			);
 			name = Interlinks;
 			sourceTree = "<group>";
@@ -2075,6 +2079,7 @@
 				B57CB87E244DED2300BA7969 /* Bundle+Simplenote.swift in Sources */,
 				3712FC821FE1ACAA008544AC /* Storage.swift in Sources */,
 				375D293421E033D1007AB25A /* autolink.c in Sources */,
+				B53ACE0E25DD7DF900CF527A /* InterlinkProcessor.swift in Sources */,
 				B5F3150924496A970036872D /* TableRowView.swift in Sources */,
 				B5CD5F7E241AC69900D0260F /* NSProcessInfo+Simplenote.swift in Sources */,
 				B59848801BCDB95A005EFBBE /* SPAutomatticTracker.m in Sources */,
@@ -2233,6 +2238,7 @@
 				B53BF19D24ABDE7C00938C34 /* DateFormatter+Simplenote.swift in Sources */,
 				B58942FB24E5EE8E006EC232 /* NSWindowFrameAutosaveName+Simplenote.swift in Sources */,
 				B53BF1A124AC1FB800938C34 /* Version.swift in Sources */,
+				B53ACE0F25DD7DF900CF527A /* InterlinkProcessor.swift in Sources */,
 				B5B1CBCE256EE72C0040726C /* NSScrollView+Simplenote.swift in Sources */,
 				B547285D250920CA00D823BA /* URL+Interlink.swift in Sources */,
 				B57CB882244E421400BA7969 /* SPTextField.swift in Sources */,

--- a/Simplenote/InterlinkProcessor.swift
+++ b/Simplenote/InterlinkProcessor.swift
@@ -1,0 +1,137 @@
+import Foundation
+
+
+// MARK: - InterlinkProcessor
+//
+class InterlinkProcessor: NSObject {
+
+    /// Interlink Popover
+    ///
+    private lazy var interlinkWindowController: PopoverWindowController = {
+        let popoverWindowController = PopoverWindowController()
+        popoverWindowController.contentViewController = interlinkViewController
+        return popoverWindowController
+    }()
+
+    /// Interlink ViewController!
+    ///
+    private lazy var interlinkViewController = InterlinkViewController()
+
+    /// Hosting TextView
+    ///
+    private let parentTextView: SPTextView
+
+
+    /// Designated Initialier
+    ///
+    init(parentTextView: SPTextView) {
+        self.parentTextView = parentTextView
+    }
+
+
+    /// Displays the Interlink Lookup Window at the cursor's location when all of the following are **true**:
+    ///
+    ///     1. We're not performing an Undo OP
+    ///     2. There is no Highlighted Text in the editor
+    ///     3. There is an interlink `[keyword` at the current location
+    ///     4. There are Notes with `keyword` in their title
+    ///
+    ///  Otherwise we'll simply dismiss the Autocomplete Window, if any.
+    ///
+    @objc(processInterlinkLookupExcludingEntityID:)
+    func processInterlinkLookup(excludedEntityID: NSManagedObjectID) {
+        guard mustProcessInterlinkLookup,
+              let (markdownRange, keywordRange, keywordText) = parentTextView.interlinkKeywordAtSelectedLocation,
+              refreshInterlinks(for: keywordText, in: markdownRange, excluding: excludedEntityID)
+        else {
+            dismissInterlinkWindow()
+            return
+        }
+
+        displayInterlinkWindow(around: keywordRange)
+    }
+
+    /// Dismisses the Interlink Window when ANY of the following evaluates **true**:
+    ///
+    ///     1.  There is Highlighted Text in the editor (or)
+    ///     2.  There is no Interlink `[keyword` at the selected location
+    ///
+    @objc
+    func dismissInterlinkLookupIfNeeded() {
+        guard mustDismissInterlinkLookup else {
+            return
+        }
+
+        dismissInterlinkWindow()
+    }
+}
+
+
+// MARK: - Interlinking Autocomplete: Private API(s)
+//
+private extension InterlinkProcessor {
+
+    /// Indicates if the Selected Range's Length is non zero: at least one character is highlighted
+    ///
+    var isSelectingText: Bool {
+        parentTextView.selectedRange().length != .zero
+    }
+
+    /// Indicates if there's an ongoing Undo Operation in the Text Editor
+    ///
+    var isUndoingEditOP: Bool {
+        parentTextView.undoManager?.isUndoing == true
+    }
+
+    /// Indicates if the Interlink Window is visible
+    ///
+    var isInterlinkWindowOnScreen: Bool {
+        interlinkWindowController.window?.parent != nil
+    }
+}
+
+
+// MARK: - Interlinking Autocomplete: Private API(s)
+//
+private extension InterlinkProcessor {
+
+    /// Indicates if we should process Interlink Lookup
+    ///
+    var mustProcessInterlinkLookup: Bool {
+        isUndoingEditOP == false && isSelectingText == false
+    }
+
+    /// Indicates if we should dismiss the Interlink Window
+    ///
+    var mustDismissInterlinkLookup: Bool {
+        isSelectingText || isInterlinkWindowOnScreen && parentTextView.interlinkKeywordAtSelectedLocation == nil
+    }
+
+    /// Presents the Interlink PopoverWindow at a given Editor Range (Below / Above!)
+    ///
+    func displayInterlinkWindow(around range: Range<String.Index>) {
+        let locationOnScreen = parentTextView.locationOnScreenForText(in: range)
+        let parentWindow = parentTextView.window!
+
+        interlinkWindowController.attach(to: parentWindow)
+        interlinkWindowController.positionWindow(relativeTo: locationOnScreen)
+    }
+
+    /// DIsmisses the Interlink Window
+    ///
+    func dismissInterlinkWindow() {
+        interlinkWindowController.close()
+    }
+
+    /// Refreshes the Interlinks for a given Keyword at the specified Replacement Range (including Markdown `[` opening character).
+    /// - Returns: `true` whenever there *are* interlinks to be presented
+    ///
+    func refreshInterlinks(for keywordText: String, in replacementRange: Range<String.Index>, excluding excludedID: NSManagedObjectID?) -> Bool {
+        interlinkViewController.onInsertInterlink = { [weak self] text in
+            self?.parentTextView.insertTextAndLinkify(text: text, in: replacementRange)
+            self?.dismissInterlinkWindow()
+        }
+
+        return interlinkViewController.refreshInterlinks(for: keywordText, excluding: excludedID)
+    }
+}

--- a/Simplenote/NoteEditorViewController+Swift.swift
+++ b/Simplenote/NoteEditorViewController+Swift.swift
@@ -30,6 +30,11 @@ extension NoteEditorViewController {
     }
 
     @objc
+    func setupInterlinksProcessor() {
+        interlinkProcessor = InterlinkProcessor(parentTextView: noteEditor)
+    }
+
+    @objc
     func refreshScrollInsets() {
         clipView.contentInsets.top = SplitItemMetrics.editorContentTopInset
         scrollView.scrollerInsets.top = SplitItemMetrics.editorScrollerTopInset
@@ -164,18 +169,6 @@ extension NoteEditorViewController {
     ///
     var isSelectingMultipleNotes: Bool {
         selectedNotes.count > 1
-    }
-
-    /// Indicates if there's an ongoing Undo Operation in the Text Editor
-    ///
-    var isUndoingEditOP: Bool {
-        noteEditor.undoManager?.isUndoing == true
-    }
-
-    /// Indicates if the Selected Range's Length is non zero: at least one character is highlighted
-    ///
-    var isSelectingText: Bool {
-        noteEditor.selectedRange().length != .zero
     }
 
     /// Simperium 🖖
@@ -768,120 +761,6 @@ extension NoteEditorViewController: MetricsControllerDelegate {
     func metricsController(_ controller: MetricsViewController, selected note: Note) {
         SimplenoteAppDelegate.shared().displayNote(simperiumKey: note.simperiumKey)
         dismiss(controller)
-    }
-}
-
-
-// MARK: - Interlinking Autocomplete: Public API(s)
-//
-extension NoteEditorViewController {
-
-    /// Displays the Interlink Lookup Window at the cursor's location when all of the following are **true**:
-    ///
-    ///     1. We're not performing an Undo OP
-    ///     2. There is no Highlighted Text in the editor
-    ///     3. There is an interlink `[keyword` at the current location
-    ///     4. There are Notes with `keyword` in their title
-    ///
-    ///  Otherwise we'll simply dismiss the Autocomplete Window, if any.
-    ///
-    @objc
-    func processInterlinkLookup() {
-        guard mustProcessInterlinkLookup,
-              let (markdownRange, keywordRange, keywordText) = noteEditor.interlinkKeywordAtSelectedLocation,
-              refreshInterlinks(for: keywordText, in: markdownRange, excluding: note?.objectID)
-        else {
-            dismissInterlinkWindow()
-            return
-        }
-
-        displayInterlinkWindow(around: keywordRange)
-    }
-
-    /// Dismisses the Interlink Window when ANY of the following evaluates **true**:
-    ///
-    ///     1.  There is Highlighted Text in the editor (or)
-    ///     2.  There is no Interlink `[keyword` at the selected location
-    ///
-    @objc
-    func dismissInterlinkLookupIfNeeded() {
-        guard mustDismissInterlinkLookup else {
-            return
-        }
-
-        dismissInterlinkWindow()
-    }
-}
-
-
-// MARK: - Interlinking Autocomplete: Private API(s)
-//
-private extension NoteEditorViewController {
-
-    /// Indicates if we should process Interlink Lookup
-    ///
-    var mustProcessInterlinkLookup: Bool {
-        isUndoingEditOP == false && isSelectingText == false
-    }
-
-    /// Indicates if we should dismiss the Interlink Window
-    ///
-    var mustDismissInterlinkLookup: Bool {
-        isSelectingText || isInterlinkWindowOnScreen && noteEditor.interlinkKeywordAtSelectedLocation == nil
-    }
-
-    /// Indicates if the Interlink Window is visible
-    ///
-    var isInterlinkWindowOnScreen: Bool {
-        interlinkWindowController?.window?.parent != nil
-    }
-
-    /// Presents the Interlink PopoverWindow at a given Editor Range (Below / Above!)
-    ///
-    func displayInterlinkWindow(around range: Range<String.Index>) {
-        let locationOnScreen = noteEditor.locationOnScreenForText(in: range)
-        let interlinkWindowController = reusableInterlinkWindowController()
-
-        interlinkWindowController.attach(to: view.window)
-        interlinkWindowController.positionWindow(relativeTo: locationOnScreen)
-    }
-
-    /// DIsmisses the Interlink Window (if any!)
-    ///
-    func dismissInterlinkWindow() {
-        interlinkWindowController?.close()
-    }
-
-    /// Refreshes the Interlinks for a given Keyword at the specified Replacement Range (including Markdown `[` opening character).
-    /// - Returns: `true` whenever there *are* interlinks to be presented
-    ///
-    func refreshInterlinks(for keywordText: String, in replacementRange: Range<String.Index>, excluding excludedID: NSManagedObjectID?) -> Bool {
-        guard let interlinkViewController = reusableInterlinkWindowController().contentViewController as? InterlinkViewController else {
-            fatalError()
-        }
-
-        interlinkViewController.onInsertInterlink = { [weak self] text in
-            self?.noteEditor.insertTextAndLinkify(text: text, in: replacementRange)
-            self?.dismissInterlinkWindow()
-        }
-
-        return interlinkViewController.refreshInterlinks(for: keywordText, excluding: excludedID)
-    }
-
-    /// Returns a reusable InterlinkWindowController instance
-    ///
-    func reusableInterlinkWindowController() -> PopoverWindowController {
-        if let interlinkWindowController = interlinkWindowController {
-            return interlinkWindowController
-        }
-
-        let interlinkWindowController = PopoverWindowController()
-        self.interlinkWindowController = interlinkWindowController
-
-        let interlinkViewController = InterlinkViewController()
-        interlinkWindowController.contentViewController = interlinkViewController
-
-        return interlinkWindowController
     }
 }
 

--- a/Simplenote/NoteEditorViewController.h
+++ b/Simplenote/NoteEditorViewController.h
@@ -11,7 +11,7 @@
 @import Simperium_OSX;
 
 @class BackgroundView;
-@class PopoverWindowController;
+@class InterlinkProcessor;
 @class NoteEditorViewController;
 @class NoteListViewController;
 @class MarkdownViewController;
@@ -70,7 +70,7 @@ typedef NS_ENUM(NSInteger, NoteFontSize) {
 @property (nonatomic, strong, readonly) NSArray<Note *>                         *selectedNotes;
 @property (nonatomic, assign, readonly) BOOL                                    viewingTrash;
 @property (nonatomic, strong, nullable) NSLayoutConstraint                      *sidebarSemaphoreLeadingConstraint;
-@property (nonatomic, strong, nullable) PopoverWindowController                 *interlinkWindowController;
+@property (nonatomic, strong) InterlinkProcessor                                *interlinkProcessor;
 @property (nonatomic,   weak) Note                                              *note;
 @property (nonatomic,   weak) id<EditorControllerNoteActionsDelegate>           noteActionsDelegate;
 @property (nonatomic,   weak) id<EditorControllerTagActionsDelegate>            tagActionsDelegate;

--- a/Simplenote/NoteEditorViewController.m
+++ b/Simplenote/NoteEditorViewController.m
@@ -100,6 +100,9 @@ static NSString * const SPMarkdownPreferencesKey        = @"kMarkdownPreferences
     [self setupStatusImageView];
     [self setupTagsField];
 
+    // Interlinks
+    [self setupInterlinksProcessor];
+
     // Preload Markdown Preview
     self.markdownViewController = [MarkdownViewController new];
     [self.markdownViewController preloadView];
@@ -346,7 +349,7 @@ static NSString * const SPMarkdownPreferencesKey        = @"kMarkdownPreferences
 
     [self refreshToolbarActions];
 
-    [self processInterlinkLookup];
+    [self.interlinkProcessor processInterlinkLookupExcludingEntityID: self.note.objectID];
     
     [self.saveTimer invalidate];
     self.saveTimer = [NSTimer scheduledTimerWithTimeInterval:2.0 target:self selector:@selector(saveAndSync:) userInfo:nil repeats:NO];
@@ -357,7 +360,7 @@ static NSString * const SPMarkdownPreferencesKey        = @"kMarkdownPreferences
 
 - (void)textViewDidChangeSelection:(NSNotification *)notification
 {
-    [self dismissInterlinkLookupIfNeeded];
+    [self.interlinkProcessor dismissInterlinkLookupIfNeeded];
 }
 
 


### PR DESCRIPTION
### Details
In this PR we're implementing **InterlinkProcessor** (and dropping the Interlink processing logic from the EditorViewController!)

cc @eshurakov 
(Thanks in advance!!)

### Test
1. Open any note
2. Type `[` + keyword (Note that **keyword** must be present in any of your note's titles)

- [x] Verify the Interlink Popover shows up
- [x] Verify that you can move the Keyboard Arrows (Up / Down) to cycle thru results
- [x] Verify that typing anything else causes the UI to refresh the results
- [x] Verify that pressing **Return** inserts the Interlink
- [x] Verify that clicking elsewhere (while the popover is visible) dismisses the Interlink UI

### Release
These changes do not require release notes.
