### PR TITLE
Decoupling PopoverWindowController: Mk 3

### DIFF
--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -198,6 +198,8 @@
 		B53ACE0E25DD7DF900CF527A /* InterlinkProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53ACE0D25DD7DF900CF527A /* InterlinkProcessor.swift */; };
 		B53ACE0F25DD7DF900CF527A /* InterlinkProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53ACE0D25DD7DF900CF527A /* InterlinkProcessor.swift */; };
 		B53ACE1325DD7E6C00CF527A /* SearchQuery+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAA4854925D5E22000F3BDB9 /* SearchQuery+Simplenote.swift */; };
+		B53ACE1E25DD9C6A00CF527A /* InterlinkResultsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53ACE1D25DD9C6A00CF527A /* InterlinkResultsController.swift */; };
+		B53ACE1F25DD9C6A00CF527A /* InterlinkResultsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53ACE1D25DD9C6A00CF527A /* InterlinkResultsController.swift */; };
 		B53BF19C24ABDE7C00938C34 /* DateFormatter+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53BF19B24ABDE7C00938C34 /* DateFormatter+Simplenote.swift */; };
 		B53BF19D24ABDE7C00938C34 /* DateFormatter+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53BF19B24ABDE7C00938C34 /* DateFormatter+Simplenote.swift */; };
 		B53BF1A024AC1FB800938C34 /* Version.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53BF19F24AC1FB800938C34 /* Version.swift */; };
@@ -630,6 +632,7 @@
 		B5395E1C253F70E30068F1A6 /* MetricTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetricTableViewCell.swift; sourceTree = "<group>"; };
 		B53ACDE325DD47BB00CF527A /* InterlinkViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = InterlinkViewController.xib; sourceTree = "<group>"; };
 		B53ACE0D25DD7DF900CF527A /* InterlinkProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterlinkProcessor.swift; sourceTree = "<group>"; };
+		B53ACE1D25DD9C6A00CF527A /* InterlinkResultsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterlinkResultsController.swift; sourceTree = "<group>"; };
 		B53BF19B24ABDE7C00938C34 /* DateFormatter+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DateFormatter+Simplenote.swift"; sourceTree = "<group>"; };
 		B53BF19F24AC1FB800938C34 /* Version.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Version.swift; sourceTree = "<group>"; };
 		B53BF1A324AC38C100938C34 /* VersionsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VersionsController.swift; sourceTree = "<group>"; };
@@ -1435,6 +1438,7 @@
 				B5C63336251E6A5A00C8BF46 /* InterlinkViewController.swift */,
 				B53ACDE325DD47BB00CF527A /* InterlinkViewController.xib */,
 				B53ACE0D25DD7DF900CF527A /* InterlinkProcessor.swift */,
+				B53ACE1D25DD9C6A00CF527A /* InterlinkResultsController.swift */,
 			);
 			name = Interlinks;
 			sourceTree = "<group>";
@@ -1972,6 +1976,7 @@
 				B58A71BE258422CC00601641 /* NSBezierPath+Simplenote.swift in Sources */,
 				B557A0E325BB0DC000E5313E /* AccountVerificationCoordinator.swift in Sources */,
 				B503FF4824848D0B00066059 /* TagAttachmentCell.swift in Sources */,
+				B53ACE1E25DD9C6A00CF527A /* InterlinkResultsController.swift in Sources */,
 				A6672FB825C7F1BB00090DE3 /* ContentSlice.swift in Sources */,
 				A6BBDA3325501398005C8343 /* SPTextView.swift in Sources */,
 				B5117998242036B1005F8936 /* NSString+Simplenote.swift in Sources */,
@@ -2143,6 +2148,7 @@
 				B535014C249D5908003837C8 /* HorizontalScrollView.swift in Sources */,
 				B5C7DD3E243E1F1900BEE354 /* VersionsViewController.swift in Sources */,
 				B57CB87C244DEC4B00BA7969 /* MigrationsHandler.swift in Sources */,
+				B53ACE1F25DD9C6A00CF527A /* InterlinkResultsController.swift in Sources */,
 				466FFEAE17CC10A800399652 /* NSString+Metadata.m in Sources */,
 				B5A2F1F12432DE54003B29C6 /* NSRange+Simplenote.swift in Sources */,
 				B54F9A6B24D0BDC100BCF754 /* TagTextFormatter.swift in Sources */,

--- a/Simplenote/InterlinkProcessor.swift
+++ b/Simplenote/InterlinkProcessor.swift
@@ -15,17 +15,13 @@ protocol InterlinkProcessorDelegate: NSObjectProtocol {
 //
 class InterlinkProcessor: NSObject {
 
-    /// Main MOC
-    ///
-    private let viewContext: NSManagedObjectContext
-
     /// Hosting TextView
     ///
     private let parentTextView: SPTextView
 
     /// Storage Lookup
     ///
-    private lazy var resultsController = InterlinkResultsController(viewContext: viewContext)
+    private let resultsController: InterlinkResultsController
 
     /// Interlink Popover
     ///
@@ -47,7 +43,7 @@ class InterlinkProcessor: NSObject {
     /// Designated Initialier
     ///
     init(viewContext: NSManagedObjectContext, parentTextView: SPTextView) {
-        self.viewContext = viewContext
+        self.resultsController = InterlinkResultsController(viewContext: viewContext)
         self.parentTextView = parentTextView
     }
 

--- a/Simplenote/InterlinkResultsController.swift
+++ b/Simplenote/InterlinkResultsController.swift
@@ -1,0 +1,78 @@
+import Foundation
+import SimplenoteFoundation
+
+
+// MARK: - InterlinkResultsController
+//
+class InterlinkResultsController {
+
+    /// ResultsController: In charge of CoreData Queries!
+    ///
+    private let resultsController: ResultsController<Note>
+
+    /// Limits the maximum number of results to fetch
+    ///
+    var maximumNumberOfResults = Settings.maximumNumberOfResults
+
+    /// Designated Initializer
+    ///
+    init(viewContext: NSManagedObjectContext) {
+        resultsController = ResultsController<Note>(viewContext: viewContext, sortedBy: [
+            NSSortDescriptor(keyPath: \Note.content, ascending: true)
+        ])
+
+        resultsController.predicate = NSPredicate.predicateForNotes(deleted: false)
+        try? resultsController.performFetch()
+    }
+
+
+    /// Returns the collection of Notes filtered by the specified Keyword in their title, excluding a specific ObjectID
+    /// - Important: Returns `nil` when there are no results!
+    ///
+    func searchNotes(byTitleKeyword keyword: String, excluding excludedID: NSManagedObjectID?) -> [Note]? {
+        filter(notes: resultsController.fetchedObjects, byTitleKeyword: keyword, excluding: excludedID)
+    }
+}
+
+
+// MARK: - Private
+//
+private extension InterlinkResultsController {
+
+    /// Filters a collection of notes by their Title contents, excluding a specific Object ID.
+    ///
+    /// - Important: Why do we perform an *in memory* filtering?
+    ///     - CoreData's SQLite store does not support block based predicates
+    ///     - RegExes aren't diacritic + case insensitve friendly
+    ///     - It's easier and anyone can follow along!
+    ///
+    func filter(notes: [Note], byTitleKeyword keyword: String, excluding excludedID: NSManagedObjectID?) -> [Note]? {
+        var output = [Note]()
+        let normalizedKeyword = keyword.folding(options: [.diacriticInsensitive, .caseInsensitive], locale: nil)
+
+        for note in notes where note.objectID != excludedID {
+            note.ensurePreviewStringsAreAvailable()
+
+            guard let normalizedTitle = note.titlePreview?.folding(options: [.diacriticInsensitive, .caseInsensitive], locale: nil),
+                  normalizedTitle.contains(normalizedKeyword)
+            else {
+                continue
+            }
+
+            output.append(note)
+
+            if output.count >= maximumNumberOfResults {
+                break
+            }
+        }
+
+        return output.isEmpty ? nil : output
+    }
+}
+
+
+// MARK: - Settings!
+//
+private enum Settings {
+    static let maximumNumberOfResults = 15
+}

--- a/Simplenote/InterlinkViewController.swift
+++ b/Simplenote/InterlinkViewController.swift
@@ -1,18 +1,14 @@
 import Foundation
 import AppKit
-import SimplenoteFoundation
 
 
 // MARK: - InterlinkViewController
 //
 class InterlinkViewController: NSViewController {
 
-    /// Background
+    /// Interface Outlets
     ///
     @IBOutlet private var backgroundView: BackgroundView!
-
-    /// Autocomplete TableView
-    ///
     @IBOutlet private var tableView: NSTableView!
 
     /// Mouse Tracking
@@ -82,16 +78,6 @@ private extension InterlinkViewController {
 
     func setupTrackingAreas() {
         view.addTrackingArea(trackingArea)
-    }
-}
-
-
-// MARK: - Filtering
-//
-private extension InterlinkViewController {
-
-    func refreshTableView() {
-        tableView.reloadDataAndResetSelection()
     }
 }
 

--- a/Simplenote/InterlinkViewController.swift
+++ b/Simplenote/InterlinkViewController.swift
@@ -19,26 +19,13 @@ class InterlinkViewController: NSViewController {
     ///
     private lazy var trackingArea = NSTrackingArea(rect: .zero, options: [.inVisibleRect, .activeAlways, .mouseEnteredAndExited], owner: self, userInfo: nil)
 
-    /// Main Context
+    /// Interlink Notes to be presented onScreen
     ///
-    private var mainContext: NSManagedObjectContext {
-        SimplenoteAppDelegate.shared().managedObjectContext
+    var notes = [Note]() {
+        didSet {
+            tableView?.reloadData()
+        }
     }
-
-    /// ResultsController: In charge of CoreData Queries!
-    ///
-    private lazy var resultsController: ResultsController<Note> = {
-        return ResultsController<Note>(viewContext: mainContext, sortedBy: [
-            NSSortDescriptor(keyPath: \Note.content, ascending: true)
-        ])
-    }()
-
-    /// In-Memory Filtered Notes
-    /// -   Our Storage does not split `Title / Body`. Filtering by keywords in the title require a NSPredicate + Block
-    /// -   The above is awfully underperformant.
-    /// -   Most efficient approach code wise / speed involves simply keeping a FRC instance, and filtering it as needed
-    ///
-    private var filteredNotes = [Note]()
 
     /// Closure to be executed whenever a Note is selected. The Interlink URL will be passed along.
     ///
@@ -55,7 +42,6 @@ class InterlinkViewController: NSViewController {
         super.viewDidLoad()
         startListeningToNotifications()
         refreshStyle()
-        setupResultsController()
         setupRoundedCorners()
         setupTableView()
         setupTrackingAreas()
@@ -69,28 +55,6 @@ class InterlinkViewController: NSViewController {
     override func mouseExited(with event: NSEvent) {
         super.mouseExited(with: event)
         NSCursor.arrow.set()
-    }
-}
-
-
-// MARK: - Public API(s)
-//
-extension InterlinkViewController {
-
-    /// Refreshes the Autocomplete Results. Returns `true` when there are visible rows.
-    /// - Important:
-    ///     By design, whenever there are no results we won't be refreshing the TableView. Instead, we'll stick to the "old results".
-    ///     This way we get to avoid the awkward visual effect of "empty autocomplete window"
-    ///
-    func refreshInterlinks(for keyword: String, excluding excludedID: NSManagedObjectID?) -> Bool {
-        filteredNotes = filterNotes(resultsController.fetchedObjects, byTitleKeyword: keyword, excluding: excludedID)
-        let displaysRows = filteredNotes.count > .zero
-
-        if displaysRows {
-            refreshTableView()
-        }
-
-        return displaysRows
     }
 }
 
@@ -119,39 +83,12 @@ private extension InterlinkViewController {
     func setupTrackingAreas() {
         view.addTrackingArea(trackingArea)
     }
-
-    func setupResultsController() {
-        resultsController.predicate = NSPredicate.predicateForNotes(deleted: false)
-        try? resultsController.performFetch()
-    }
 }
 
 
 // MARK: - Filtering
 //
 private extension InterlinkViewController {
-
-    func filterNotes(_ notes: [Note], byTitleKeyword keyword: String, excluding excludedID: NSManagedObjectID?, limit: Int = Settings.maximumNumberOfResults) -> [Note] {
-        var output = [Note]()
-        let normalizedKeyword = keyword.folding(options: [.diacriticInsensitive, .caseInsensitive], locale: nil)
-
-        for note in notes where note.objectID != excludedID {
-            note.ensurePreviewStringsAreAvailable()
-            guard let normalizedTitle = note.titlePreview?.folding(options: [.diacriticInsensitive, .caseInsensitive], locale: nil),
-                  normalizedTitle.contains(normalizedKeyword)
-            else {
-                continue
-            }
-
-            output.append(note)
-
-            if output.count >= limit {
-                break
-            }
-        }
-
-        return output
-    }
 
     func refreshTableView() {
         tableView.reloadDataAndResetSelection()
@@ -210,11 +147,7 @@ private extension InterlinkViewController {
 private extension InterlinkViewController {
 
     func noteAtRow(_ row: Int) -> Note? {
-        guard row < filteredNotes.count else {
-            return nil
-        }
-
-        return filteredNotes[row]
+        return row < notes.count ? notes[row] : nil
     }
 }
 
@@ -224,7 +157,7 @@ private extension InterlinkViewController {
 extension InterlinkViewController: NSTableViewDataSource {
 
     func numberOfRows(in tableView: NSTableView) -> Int {
-        filteredNotes.count
+        notes.count
     }
 }
 
@@ -270,5 +203,4 @@ extension InterlinkViewController: SPTableViewDelegate {
 //
 private enum Settings {
     static let cornerRadius = CGFloat(6)
-    static let maximumNumberOfResults = 15
 }

--- a/Simplenote/InterlinkViewController.xib
+++ b/Simplenote/InterlinkViewController.xib
@@ -25,13 +25,13 @@
                         <rect key="frame" x="0.0" y="0.0" width="230" height="57"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnReordering="NO" columnSelection="YES" columnResizing="NO" multipleSelection="NO" emptySelection="NO" autosaveColumns="NO" rowHeight="19" viewBased="YES" id="kmt-Mq-rj9" customClass="SPTableView">
+                            <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" tableStyle="plain" columnReordering="NO" columnSelection="YES" columnResizing="NO" multipleSelection="NO" emptySelection="NO" autosaveColumns="NO" rowHeight="19" usesAutomaticRowHeights="YES" viewBased="YES" id="kmt-Mq-rj9" customClass="SPTableView">
                                 <rect key="frame" x="0.0" y="0.0" width="230" height="57"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="calibratedRGB"/>
+                                <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                                 <color key="gridColor" white="0.66666666669999997" alpha="0.43099850169999998" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <tableColumns>
-                                    <tableColumn width="198" minWidth="40" maxWidth="1000" id="F7x-Cd-um9">
+                                    <tableColumn width="230" minWidth="47" maxWidth="230" id="F7x-Cd-um9">
                                         <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border">
                                             <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                             <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
@@ -41,14 +41,12 @@
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                             <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                                         </textFieldCell>
-                                        <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                         <prototypeCellViews>
-                                            <tableCellView identifier="LinkTableCellView" id="c7l-Cg-OcQ" customClass="LinkTableCellView" customModule="Simplenote" customModuleProvider="target">
-                                                <rect key="frame" x="10" y="0.0" width="210" height="19"/>
-                                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                            <tableCellView identifier="LinkTableCellView" translatesAutoresizingMaskIntoConstraints="NO" id="c7l-Cg-OcQ" customClass="LinkTableCellView" customModule="Simplenote" customModuleProvider="target">
+                                                <rect key="frame" x="0.0" y="0.0" width="230" height="19"/>
                                                 <subviews>
                                                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="AlK-lN-eE6">
-                                                        <rect key="frame" x="15" y="0.0" width="174" height="19"/>
+                                                        <rect key="frame" x="15" y="0.0" width="194" height="19"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="19" id="pQm-Hj-7Zk"/>
                                                         </constraints>

--- a/Simplenote/LinkTableCellView.swift
+++ b/Simplenote/LinkTableCellView.swift
@@ -65,6 +65,6 @@ private extension LinkTableCellView {
 private extension LinkTableCellView {
 
     func refreshStyle() {
-        textField?.textColor = selected ? .simplenoteSelectedTextColor : .simplenoteTextColor
+        textField?.textColor = .simplenoteTextColor
     }
 }

--- a/Simplenote/NoteEditorViewController+Swift.swift
+++ b/Simplenote/NoteEditorViewController+Swift.swift
@@ -33,6 +33,7 @@ extension NoteEditorViewController {
     func setupInterlinksProcessor() {
         interlinkProcessor = InterlinkProcessor(viewContext: simplenoteAppDelegate.managedObjectContext,
                                                 parentTextView: noteEditor)
+        interlinkProcessor.delegate = self
     }
 
     @objc
@@ -826,6 +827,17 @@ extension NoteEditorViewController {
         ])
 
         self.searchMapView = searchMapView
+    }
+}
+
+
+// MARK: - Interlinks Insertion
+//
+extension NoteEditorViewController: InterlinkProcessorDelegate {
+
+    func interlinkProcessor(_ processor: InterlinkProcessor, insert text: String, in range: Range<String.Index>) {
+        noteEditor.insertTextAndLinkify(text: text, in: range)
+        processor.dismissInterlinkLookup()
     }
 }
 

--- a/Simplenote/NoteEditorViewController+Swift.swift
+++ b/Simplenote/NoteEditorViewController+Swift.swift
@@ -31,7 +31,8 @@ extension NoteEditorViewController {
 
     @objc
     func setupInterlinksProcessor() {
-        interlinkProcessor = InterlinkProcessor(parentTextView: noteEditor)
+        interlinkProcessor = InterlinkProcessor(viewContext: simplenoteAppDelegate.managedObjectContext,
+                                                parentTextView: noteEditor)
     }
 
     @objc


### PR DESCRIPTION
### Details
In this PR we're implementing **InterlinkResultsController** (and decoupling CoreData-Y responsibilities from the InterlinkViewController)

cc @eshurakov 
(Thanks in advance!!)

### Test
1. Open any note
2. Type `[` + keyword (Note that **keyword** must be present in any of your note's titles)

- [x] Verify the Interlink Popover shows up
- [x] Verify that you can move the Keyboard Arrows (Up / Down) to cycle thru results
- [x] Verify that typing anything else causes the UI to refresh the results
- [x] Verify that pressing **Return** inserts the Interlink
- [x] Verify that clicking elsewhere (while the popover is visible) dismisses the Interlink UI

### Release
These changes do not require release notes.
