### PR TITLE
Signup Verification: Supporting Clicks

### DIFF
--- a/Simplenote/SignupVerificationViewController.swift
+++ b/Simplenote/SignupVerificationViewController.swift
@@ -99,6 +99,15 @@ extension SignupVerificationViewController {
     func backWasPressed(_ sender: Any) {
         presentAuthenticationInteface()
     }
+
+    @IBAction
+    func contactWasPressed(_ sender: Any) {
+        guard let targetURL = URL(string: "mailto:" + SPCredentials.simplenoteFeedbackMail) else {
+            return
+        }
+
+        NSWorkspace.shared.open(targetURL)
+    }
 }
 
 

--- a/Simplenote/SignupVerificationViewController.swift
+++ b/Simplenote/SignupVerificationViewController.swift
@@ -80,8 +80,23 @@ private extension SignupVerificationViewController {
     func setupSupportLabel() {
         let text = String(format: Localization.support, SPCredentials.simplenoteFeedbackMail)
 
-        supportTextField.stringValue = text
-        supportTextField.textColor = NSColor(studioColor: .gray50)
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.alignment = .center
+
+        let attributes: [NSAttributedString.Key: Any] = [
+            .foregroundColor: NSColor(studioColor: .gray50),
+            .font: Fonts.regularMessageFont,
+            .paragraphStyle: paragraphStyle
+        ]
+
+        let highlightAttributes: [NSAttributedString.Key: Any] = [
+            .underlineStyle: NSUnderlineStyle.single.rawValue
+        ]
+
+        supportTextField.attributedStringValue = NSMutableAttributedString(string: text,
+                                                                           attributes: attributes,
+                                                                           highlighting: SPCredentials.simplenoteFeedbackMail,
+                                                                           highlightAttributes: highlightAttributes)
     }
 
     func setupBackButton() {

--- a/Simplenote/SignupVerificationViewController.xib
+++ b/Simplenote/SignupVerificationViewController.xib
@@ -41,6 +41,13 @@
                         </textField>
                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KH5-BY-5Ba">
                             <rect key="frame" x="-2" y="48" width="294" height="32"/>
+                            <gestureRecognizers>
+                                <clickGestureRecognizer delaysPrimaryMouseButtonEvents="YES" numberOfClicksRequired="1" id="dqG-sI-Es9">
+                                    <connections>
+                                        <action selector="contactWasPressed:" target="-2" id="epN-A4-qrc"/>
+                                    </connections>
+                                </clickGestureRecognizer>
+                            </gestureRecognizers>
                             <textFieldCell key="cell" allowsUndo="NO" alignment="center" title="[Didn’t get an email? Please contact support@simplenote.com.]" id="lDF-iv-aFc">
                                 <font key="font" usesAppearanceFont="YES"/>
                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>


### PR DESCRIPTION
### Fix
In this PR we're adjusting the Signup Verification UI, so that clicking on the Contact label opens the system's default Mail app.

cc @eshurakov (Thank yooouuu)

### Test
1. Signup for a new account
2. Reach the **Signup Verification UI**
3. Click over the field that reads ```Didn't get an email? You may already have an account. Contact```

- [ ] Verify your system's default Mail app gets open

### Release
These changes do not require release notes.
