### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+# Apply to all files
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# Ruby specific rules
+[{*.rb,Fastfile,Gemfile}]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
This PR updates `.editorconfig` to add some basic rules, based on the set we agreed on in wordpress-mobile/release-toolkit#219.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.
