### PR TITLE
Decrease the minimum width of the note list pane

### DIFF
--- a/Simplenote/SplitViewController.swift
+++ b/Simplenote/SplitViewController.swift
@@ -229,7 +229,7 @@ private enum Metrics {
     static let tagsMinWidth: CGFloat = 150
     static let tagsMaxWidth: CGFloat = 300
 
-    static let listMinWidth: CGFloat = 300
+    static let listMinWidth: CGFloat = 150
     static let listMaxWidth: CGFloat = 500
 
     static let mainMinWidth: CGFloat = 300


### PR DESCRIPTION
### Fix
***(Required)*** Add a concise description of what you fixed.  If this is related to an issue, add a link to it.  If applicable, add screenshots, animations, or videos to help illustrate the fix.

See issue: https://github.com/Automattic/simplenote-macos/issues/915

Reduced the minimum width of the note list pane from 300 to 150.

### Test
***(Required)*** List the steps to test the behavior.

Toggle on the note list side pane. Adjust the width of it to the leftmost to see the effective minimum width.

### Review
***(Required)*** Add instructions for reviewers.

Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
***(Required)*** Add a concise statement to `RELEASE-NOTES.txt` if the changes should be included in release notes. Include details about updating the notes in this section.

Add in `RELEASE-NOTES.txt`:

> Reduced the minimum width of the note list pane

