### PR TITLE
Window: Miniaturize (OR) Zoom behavior on double click

### DIFF
--- a/Simplenote/Window.swift
+++ b/Simplenote/Window.swift
@@ -166,7 +166,12 @@ private extension Window {
             return
         }
 
-        self.performZoom(nil)
+        if shouldMiniaturizeOnDoubleClick {
+            miniaturize(nil)
+            return
+        }
+
+        performZoom(nil)
     }
 
     /// In AppKit the Window's Field Editor handles Input, "on behalf" of the First Responder
@@ -185,5 +190,11 @@ private extension Window {
 
         let onScreenResponderBounds = effectiveFirstResponder.convert(effectiveFirstResponder.bounds, to: nil)
         return onScreenResponderBounds.contains(point)
+    }
+
+    /// Indicates if the System Setting "Miniaturize on Double Click" is enabled
+    ///
+    var shouldMiniaturizeOnDoubleClick: Bool {
+        return UserDefaults.standard.string(forKey: "AppleActionOnDoubleClick") == "Minimize"
     }
 }


### PR DESCRIPTION
### Fix
In this PR we're updating our Window subclass, so that the default "Double click on Titlebar" behavior is respected.

Another day, another bugfix!!
cc @eshurakov (Thankyou!)

Closes #856

### Test
1. Open **System Preferences** > **Dock**
2. Enable `Double Click Window's titlebar to minimize`
3. Double click on the Titlebar

- [ ] Verify that the main window gets minimized into the Dock
- [ ] Verify that reverting to the standard behavior causes Simplenote to get maximized

### Release
***(Required)*** Add a concise statement to `RELEASE-NOTES.txt` if the changes should be included in release notes. Include details about updating the notes in this section. For example:
> `RELEASE-NOTES.txt` was updated in d3adb3ef with:
> 
> > Added markdown support

If the changes should not be included in release notes, add a statement to this section. For example:

> These changes do not require release notes.
