### PR TITLE
Add logic to trigger App Store & GitHub upload via CircleCI APIs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,10 +59,6 @@ jobs:
     steps:
       - setup_environment
       - run:
-          name: Decrypt Secrets
-          command: |
-            bundle exec fastlane run configure_apply
-      - run:
           name: Build and Upload to App Store and GitHub
           command: |
             bundle exec fastlane build_and_upload_app_store create_github_release:true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,11 @@ orbs:
   # This uses the Orbs located at https://github.com/wordpress-mobile/circleci-orbs
   ios: wordpress-mobile/ios@1.0
 
+parameters:
+  app_store_build:
+    type: boolean
+    default: false
+
 # Reusable sets of steps
 commands:
   copy_demo_credentials:
@@ -49,8 +54,31 @@ jobs:
           name: Verify App Store Target Builds
           command: bundle exec fastlane test_app_store_build
 
+  App Store Upload:
+    executor: *xcode_image
+    steps:
+      - setup_environment
+      - run:
+          name: Decrypt Secrets
+          command: |
+            bundle exec fastlane run configure_apply
+      - run:
+          name: Build and Upload to App Store and GitHub
+          command: |
+            bundle exec fastlane build_and_upload_app_store create_github_release:true
+
 workflows:
   simplenote_macos:
+    when:
+      not: << pipeline.parameters.app_store_build >>
     jobs:
       - Test
       - Verify App Store Target Builds
+
+  app_store:
+    when: << pipeline.parameters.app_store_build >>
+    jobs:
+      - Test
+      - App Store Upload:
+          requires:
+            - Test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,6 +59,9 @@ jobs:
     steps:
       - setup_environment
       - run:
+          name: Install Sentry CLI
+          command: brew install getsentry/tools/sentry-cli
+      - run:
           name: Build and Upload to App Store and GitHub
           command: |
             bundle exec fastlane build_and_upload_app_store create_github_release:true

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/wordpress-mobile/release-toolkit
-  revision: 48f500bd9212f13d2bf71220c89a8794cdd46e03
-  tag: 0.13.0
+  revision: 348de22c625922cca9a5060261fa7a0c4005786e
+  tag: 0.16.0
   specs:
-    fastlane-plugin-wpmreleasetoolkit (0.13.0)
+    fastlane-plugin-wpmreleasetoolkit (0.16.0)
       activesupport (~> 5)
       bigdecimal (~> 1.4)
       chroma (= 0.2.0)
@@ -21,7 +21,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     CFPropertyList (3.0.3)
-    activesupport (5.2.4.4)
+    activesupport (5.2.5)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
@@ -94,7 +94,7 @@ GEM
     colored2 (3.1.2)
     commander-fastlane (4.4.6)
       highline (~> 1.7.2)
-    concurrent-ruby (1.1.7)
+    concurrent-ruby (1.1.8)
     declarative (0.0.20)
     declarative-option (0.1.0)
     diffy (3.4.0)
@@ -212,7 +212,7 @@ GEM
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     httpclient (2.8.3)
-    i18n (1.8.7)
+    i18n (1.8.9)
       concurrent-ruby (~> 1.0)
     jmespath (1.4.0)
     json (2.5.1)
@@ -224,7 +224,7 @@ GEM
     mini_magick (4.11.0)
     mini_mime (1.0.3)
     mini_portile2 (2.5.0)
-    minitest (5.14.3)
+    minitest (5.14.4)
     molinillo (0.6.6)
     multi_json (1.15.0)
     multipart-post (2.0.0)
@@ -232,13 +232,13 @@ GEM
     nap (1.1.0)
     naturally (2.2.1)
     netrc (0.11.0)
-    nokogiri (1.11.1)
+    nokogiri (1.11.2)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
     octokit (4.20.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
-    oj (3.11.0)
+    oj (3.11.3)
     optimist (3.0.1)
     options (2.3.2)
     os (1.1.1)

--- a/config/Version.public.xcconfig
+++ b/config/Version.public.xcconfig
@@ -6,4 +6,4 @@ VERSION_LONG=2.12.0.2
 
 // This is the value for the CFBundleVersion it should be incremented on every
 // build that gets distributed
-BUILD_NUMBER=11233
+BUILD_NUMBER=11234

--- a/config/Version.public.xcconfig
+++ b/config/Version.public.xcconfig
@@ -6,4 +6,4 @@ VERSION_LONG=2.12.0.2
 
 // This is the value for the CFBundleVersion it should be incremented on every
 // build that gets distributed
-BUILD_NUMBER=11234
+BUILD_NUMBER=11235

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -6,7 +6,9 @@ fastlane_require 'shellwords' # used for shell-escaping paths
 # Environment
 ########################################################################
 Dotenv.load('~/.simplenotemacos-env.default')
-ENV[GHHELPER_REPO="Automattic/simplenote-macos"]
+ORGANIZATION_NAME = 'Automattic'
+REPOSITORY_NAME = 'simplenote-macos'
+ENV[GHHELPER_REPO="#{ORGANIZATION_NAME}/#{REPOSITORY_NAME}"]
 ENV["PROJECT_NAME"]="Simplenote"
 ENV["PROJECT_ROOT_FOLDER"]="./"
 ENV["PUBLIC_CONFIG_FILE"]="./config/Version.Public.xcconfig"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -375,6 +375,24 @@ end
     end
   end
 
+  #############################################################################
+  # trigger_app_store_ci_build
+  # ---------------------------------------------------------------------------
+  # This lane triggers a build for App Store distribution on CI
+  # ---------------------------------------------------------------------------
+  # Usage:
+  # bundle exec fastlane trigger_release_build [branch_to_build:<branch_name>]
+  #############################################################################
+  lane :trigger_app_store_ci_build do | options |
+    circleci_trigger_job(
+      circle_ci_token: ENV["CIRCLE_CI_AUTH_TOKEN"],
+      repository: REPOSITORY_NAME,
+      organization: ORGANIZATION_NAME,
+      branch: options[:branch_to_build],
+      job_params: { app_store_build: true }
+    )
+  end
+
 ########################################################################
 # Helper Lanes
 ########################################################################

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -211,14 +211,15 @@ end
   # bundle exec fastlane finalize_release
   # bundle exec fastlane finalize_release skip_confirm:true
   #####################################################################################
-  desc "Removes all the temp tags and puts the final one"
+  desc 'Does the necessary build and metadata updates then triggers an App Store deployment'
   lane :finalize_release do | options |
     ios_finalize_prechecks(options)
     unless ios_current_branch_is_hotfix
       ios_update_metadata(options)
       ios_bump_version_beta()
     end
-    ios_final_tag(options)
+
+    trigger_app_store_ci_build(branch_to_build: "release/#{ios_get_app_version()}")
   end
 
   #####################################################################################

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -282,6 +282,10 @@ end
   # bundle exec fastlane build_and_upload_app_store create_github_release:true
   #############################################################################
   lane :build_and_upload_app_store do | options |
+    configure_apply()
+    sh("rake dependencies:pod:clean")
+    cocoapods()
+
     # This allows code signing to work on CircleCI. It is skipped if this isn't
     # running on CI.
     #

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -2,6 +2,6 @@
 #
 # Ensure this file is checked in to source control!
 
-gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag: '0.13.0'
+gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag: '0.16.0'
 gem 'fastlane-plugin-sentry'
 gem 'fastlane-plugin-appcenter', '1.6.0'

--- a/fastlane/env/user.env-example
+++ b/fastlane/env/user.env-example
@@ -1,3 +1,7 @@
 GHHELPER_ACCESS=
 APPCENTER_API_TOKEN=
 SENTRY_AUTH_TOKEN=
+
+# Token to trigger builds via the CircleCI APIs
+# See: https://circleci.com/docs/2.0/managing-api-tokens/
+CIRCLE_CI_AUTH_TOKEN=<CircleCI Auth Token>


### PR DESCRIPTION
### Fix
Add the Fastlane and CircleCI machinery to trigger a deployment to the App Store via the CircleCI APIs from Fastlane, and updates the `finalize_release` lane to trigger such a deployment.

### Test

1. Checkout this branch
2. Manually bump the build number
3. Push the change
3. Run the `trigger_app_store_ci_build branch_to_build:trigger-app-store-deploy-via-api`

You should see a build starting on CircleCI. ~It should fail because there's already a version with that version on App Store connect.~ The reason I asked to manually bump the build number is that, unlike for TestFlight in iOS, this build won't fail if you upload a binary with a version+build that already exists. It will finish happily, then spam the rest of the team with an email about the duplicated build number 😅 .

E.g. running the lane from cae6ce1 resulted in [this job](https://app.circleci.com/pipelines/github/Automattic/simplenote-macos/2303/workflows/fbc59f6f-01d7-42c6-a492-9bdd69e1bb7b/jobs/2572) starting in CI

![image](https://user-images.githubusercontent.com/1218433/115663434-d5ec2b80-a383-11eb-9376-8cc948a76350.png)

After it finished, the build could be found on App Store Connect

![image](https://user-images.githubusercontent.com/1218433/115663480-e8fefb80-a383-11eb-85b5-4a842960baef.png)

I don't think there's much value into hacking the `code_freeze` lane to verify it calls this new lane instead of creating a tag and pushing it. Looking at the code should be enough.

### Review

Only one developer required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.
