### PR TITLE
MainWindowController: Enabling movableByBackground

### DIFF
--- a/Simplenote/BackgroundView.swift
+++ b/Simplenote/BackgroundView.swift
@@ -76,6 +76,10 @@ class BackgroundView: NSView {
     ///
     var cursor: NSCursor?
 
+    /// When enabled, this NSView instance will forward Drag events over to the window
+    ///
+    var forwardsWindowDragEvents = false
+
 
     // MARK: - Overridden Methods
 
@@ -104,5 +108,16 @@ class BackgroundView: NSView {
         if let cursor = cursor {
             addCursorRect(bounds, cursor: cursor)
         }
+    }
+
+    override func mouseDragged(with event: NSEvent) {
+        super.mouseDragged(with: event)
+
+        /// 😯 This is really happening.
+        guard forwardsWindowDragEvents else {
+            return
+        }
+
+        window?.performDrag(with: event)
     }
 }

--- a/Simplenote/MainWindowController.swift
+++ b/Simplenote/MainWindowController.swift
@@ -27,6 +27,7 @@ class MainWindowController: NSWindowController {
 
     override func windowDidLoad() {
         super.windowDidLoad()
+        setupMainWindow()
         relocateSemaphoreButtons()
         startListeningToFullscreenNotifications()
     }
@@ -53,6 +54,12 @@ private extension MainWindowController {
     ///
     func setupAutosave() {
         simplenoteWindow.setFrameAutosaveName(.mainWindow)
+    }
+
+    /// Initializes the main Window
+    ///
+    func setupMainWindow() {
+        simplenoteWindow.isMovableByWindowBackground = true
     }
 
     /// We'll need to drop the Semaphore Workaround when entering Fullscreen

--- a/Simplenote/NoteListViewController.swift
+++ b/Simplenote/NoteListViewController.swift
@@ -81,6 +81,7 @@ class NoteListViewController: NSViewController {
 
         setupProgressIndicator()
         setupSearchField()
+        setupHeaderView()
         setupTableView()
         startListeningToNotifications()
         startListControllerSync()
@@ -143,6 +144,12 @@ extension NoteListViewController {
 // MARK: - Interface Initialization
 //
 private extension NoteListViewController {
+
+    /// Setup: Header
+    ///
+    func setupHeaderView() {
+        headerDividerView.forwardsWindowDragEvents = true
+    }
 
     /// Setup: TableView
     ///

--- a/Simplenote/ToolbarView.swift
+++ b/Simplenote/ToolbarView.swift
@@ -39,6 +39,19 @@ class ToolbarView: NSView {
         refreshStyle()
         startListeningToNotifications()
     }
+
+    override func resetCursorRects() {
+        addCursorRect(bounds, cursor: .arrow)
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        /// NO-OP: In macOS < 11 the event may actually get forwarded to the underlying NSTextView. 😯
+    }
+
+    override func mouseDragged(with event: NSEvent) {
+        super.mouseDragged(with: event)
+        window?.performDrag(with: event)
+    }
 }
 
 


### PR DESCRIPTION
### Fix
In this PR we're allowing the Main Window to be draggable from the background.

Closes #935

Thank you Evgenyyyyy

### Test
1. Log into your account

- [ ] Verify you can drag the Main Window from literally anywhere that's not a Table / Editor

### Release
These changes do not require release notes.
