### PR TITLE
Updated copy for check email prompt

### DIFF
--- a/Simplenote/SignupVerificationViewController.swift
+++ b/Simplenote/SignupVerificationViewController.swift
@@ -142,7 +142,7 @@ private extension SignupVerificationViewController {
 //
 private enum Localization {
     static let messageTemplate = NSLocalizedString("We’ve sent an email to %1$@. Please check your inbox and follow the instructions.", comment: "Signup Body Text")
-    static let support = NSLocalizedString("Didn't get an email? You may already have an account. Contact %1$@ for help.", comment: "Signup Support Text")
+    static let support = NSLocalizedString("Didn't get an email? There may already be an account associated with this email address. Contact %1$@ for help.", comment: "Signup Support Text")
     static let back = NSLocalizedString("Go Back", comment: "Back Button Title")
 }
 


### PR DESCRIPTION
### Fix

fixes #930 

This is a small PR that updates the copy around checking your email on sign up.  

old:
`Didn’t get an email? You may already have an account. Contact support@simplenote.com for help.`

new:
`Didn’t get an email? There may already be an account associated with this email address. Contact support@simplenote.com for help.`

<img src="https://cdn-std.droplr.net/files/acc_593859/oUmMA7" />
### Test
1. While logged out, go to the sign up flow and enter an email address.  You should see the new copy.

### Review
***(Required)*** Add instructions for reviewers.  For example:
> Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
> These changes do not require release notes.
