### PR TITLE
Allow using shift-tab to de-indent checklists

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 2.12
 -----
- 
+- Pressing Shift + Tab will now de-indent items in a list #864
+
 2.11
 -----
 - Fixed a bug that caused double click over the SearchBar to fail #880

--- a/Simplenote/NSTextView+Simplenote.swift
+++ b/Simplenote/NSTextView+Simplenote.swift
@@ -207,6 +207,28 @@ extension NSTextView {
         return true
     }
 
+    /// De-indents the List at the selected range (if any)
+    ///
+    @objc
+    func processTabDeletion() -> Bool {
+        let (lineRange, lineString) = selectedLineDroppingTrailingNewline()
+
+        guard let rangeOfListMarker = lineString.rangeOfListMarker, rangeOfListMarker.location > 0 else {
+            return false
+        }
+        
+        // Make sure there is a Tab character at the beginning of the line
+        if !lineString.hasPrefix(String.tab) {
+            return false
+        }
+       
+        // Delete the Tab character at the beginning of the line
+        let deletionRange = NSRange(location: lineRange.location, length: 1)
+        insertText("", replacementRange: deletionRange)
+
+        return true
+    }
+
     /// Processes a Newline Insertion on List Items:
     ///
     ///     -   No List Marker: in the current line, this method does nothing.

--- a/Simplenote/NoteEditorViewController.m
+++ b/Simplenote/NoteEditorViewController.m
@@ -284,6 +284,10 @@ static NSString * const SPMarkdownPreferencesKey        = @"kMarkdownPreferences
         return [self.noteEditor processTabInsertion];
     }
     
+    if (selector == @selector(insertBacktab:)) {
+        return [self.noteEditor processTabDeletion];
+    }
+
     return NO;
 }
 

--- a/SimplenoteTests/NSTextViewSimplenoteTests.swift
+++ b/SimplenoteTests/NSTextViewSimplenoteTests.swift
@@ -218,6 +218,45 @@ class NSTextViewSimplenoteTests: XCTestCase {
         XCTAssertEqual(textView.string, text)
     }
 
+    /// Verifies that `processTabDeletion` de-indents the List at the selected range
+    ///
+    func testProcessTabDeletionEffectivelyIndentsTextListsWhenTheCurrentLineContainsSomeListMarker() {
+        for (text, indented) in samplesForIndentation {
+            textView.string = indented
+            textView.setSelectedRange(.zero)
+
+            XCTAssertTrue(textView.processTabDeletion())
+            XCTAssertEqual(textView.string, text)
+        }
+    }
+
+    /// Verifies that `processTabDeletion` registers an Undo OP when de-indenting Text Lists
+    ///
+    func testProcessTabDeletionRegistersAnUndoableOperationWhenIndentingTextLists() {
+        let undoManager = textView.internalUndoManager
+
+        for (_, indented) in samplesForIndentation {
+            textView.string = indented
+            textView.setSelectedRange(.zero)
+
+            XCTAssertTrue(textView.processTabDeletion())
+            XCTAssertTrue(undoManager.canUndo)
+
+            undoManager.undo()
+            XCTAssertEqual(textView.string, indented)
+        }
+    }
+
+    /// Verifies that `processTabDeletion` does nothing if there are no lists at the document
+    ///
+    func testProcessTabDeletionDoesNotIndentWheneverThereAreNoListsInTheCurrentRange() {
+        let text = samplePlainText.joined()
+        textView.string = text
+
+        XCTAssertFalse(textView.processTabDeletion())
+        XCTAssertEqual(textView.string, text)
+    }
+
     /// Verifies that `processNewlineInsertion` does nothing if there are no lists in the document
     ///
     func testProcessNewlineInsertionDoesNothingWheneverThereAreNoListsInTheDocument() {


### PR DESCRIPTION
### Fix
This PR just adds a handler for the Shift+Tab action in the text editor to de-indent an item in a list. This should close #864 

https://user-images.githubusercontent.com/1083228/115119693-f8f49500-9fa9-11eb-9fbf-0dbe61a6b94b.mov

### Test
1. Create a new note
2. Write a list with several levels of indentation.
3. Put the cursor in an indented line.
4. Press Shift + Tab.
5. The line you're in should be de-indented 1 level.

### Review
***(Required)*** Add instructions for reviewers.  For example:
> Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
`RELEASE-NOTES.txt` was updated in d3adb3ef with:

> Pressing Shift + Tab will now de-indent items in a list