### PR TITLE
Updated signup remote to lowercase emails before sending to simperium

### DIFF
--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -452,6 +452,8 @@
 		B5F807CD2481982B0048CBD7 /* Note+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5F807CB2481982B0048CBD7 /* Note+Simplenote.swift */; };
 		B5F807CF2481A2010048CBD7 /* Simperium+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5F807CE2481A2010048CBD7 /* Simperium+Simplenote.swift */; };
 		B5F807D02481A2010048CBD7 /* Simperium+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5F807CE2481A2010048CBD7 /* Simperium+Simplenote.swift */; };
+		BA4C6D16264CA8C000B723A7 /* SignupRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA4C6D15264CA8C000B723A7 /* SignupRemoteTests.swift */; };
+		BA4C6D18264CAAF800B723A7 /* URLRequest+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA4C6D17264CAAF800B723A7 /* URLRequest+Simplenote.swift */; };
 		BAA4854A25D5E22000F3BDB9 /* SearchQuery+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAA4854925D5E22000F3BDB9 /* SearchQuery+Simplenote.swift */; };
 		CD6BC8FB4B8661C30318208C /* Pods_Automattic_SimplenoteTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 22D95A169BF4BF7DEABC4021 /* Pods_Automattic_SimplenoteTests.framework */; };
 		D0A1D693931CD24A56140DF7 /* Pods_Automattic_Simplenote.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0F7AA366214AF89DB7A1C687 /* Pods_Automattic_Simplenote.framework */; };
@@ -822,6 +824,8 @@
 		B5F5415325F0137100CAF52C /* MagicLinkAuthenticator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MagicLinkAuthenticator.swift; sourceTree = "<group>"; };
 		B5F807CB2481982B0048CBD7 /* Note+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Note+Simplenote.swift"; sourceTree = "<group>"; };
 		B5F807CE2481A2010048CBD7 /* Simperium+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Simperium+Simplenote.swift"; sourceTree = "<group>"; };
+		BA4C6D15264CA8C000B723A7 /* SignupRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignupRemoteTests.swift; sourceTree = "<group>"; };
+		BA4C6D17264CAAF800B723A7 /* URLRequest+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLRequest+Simplenote.swift"; sourceTree = "<group>"; };
 		BAA4854925D5E22000F3BDB9 /* SearchQuery+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SearchQuery+Simplenote.swift"; sourceTree = "<group>"; };
 		F998F3EA22853C29008C2B59 /* CrashLogging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashLogging.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -1180,6 +1184,7 @@
 			isa = PBXGroup;
 			children = (
 				B502C1E625BA2F0800145D6C /* AccountVerificationRemoteTests.swift */,
+				BA4C6D15264CA8C000B723A7 /* SignupRemoteTests.swift */,
 			);
 			name = Remote;
 			sourceTree = "<group>";
@@ -1409,6 +1414,7 @@
 				B5009939242131410037A431 /* UnicodeScalarSimplenoteTests.swift */,
 				A6672FBD25C7F77000090DE3 /* NoteBodyExcerptTests.swift */,
 				A6672FBC25C7F77000090DE3 /* StringContentSliceTests.swift */,
+				BA4C6D17264CAAF800B723A7 /* URLRequest+Simplenote.swift */,
 			);
 			name = Extensions;
 			sourceTree = "<group>";
@@ -2371,10 +2377,12 @@
 				B502C1E725BA2F0800145D6C /* AccountVerificationRemoteTests.swift in Sources */,
 				B502C1EF25BA2F2400145D6C /* MockURLSession.swift in Sources */,
 				B502C22325BA345700145D6C /* AccountVerificationControllerTests.swift in Sources */,
+				BA4C6D18264CAAF800B723A7 /* URLRequest+Simplenote.swift in Sources */,
 				B5C1F0AC242E9A9800A627E3 /* MockTextView.swift in Sources */,
 				B502C22B25BA347700145D6C /* MockAccountVerificationRemote.swift in Sources */,
 				B5469FE225880181007ED7BE /* NSUserDefaults+Tests.swift in Sources */,
 				B5EF32A8258D05640069EC7D /* MockStorage.swift in Sources */,
+				BA4C6D16264CA8C000B723A7 /* SignupRemoteTests.swift in Sources */,
 				B500993A242131410037A431 /* UnicodeScalarSimplenoteTests.swift in Sources */,
 				B5CBB073241976280003C271 /* NSAttributedStringToMarkdownConverterTests.swift in Sources */,
 				B518D37E2507C356006EA7F8 /* StringSimplenoteTests.swift in Sources */,

--- a/Simplenote/SignupRemote.swift
+++ b/Simplenote/SignupRemote.swift
@@ -40,7 +40,7 @@ class SignupRemote {
                                  timeoutInterval: RemoteConstants.timeout)
         request.httpMethod = RemoteConstants.Method.POST
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.httpBody = try? JSONEncoder().encode(["username": email])
+        request.httpBody = try? JSONEncoder().encode(["username": email.lowercased()])
 
         return request
     }

--- a/SimplenoteTests/MockURLSession.swift
+++ b/SimplenoteTests/MockURLSession.swift
@@ -5,6 +5,7 @@ import Foundation
 class MockURLSession: URLSession
 {
     var data: (Data?, URLResponse?, Error?)?
+    var lastRequest: URLRequest?
 
     /// URLSession has deprecated its initializers. We must implement our own!
     ///
@@ -13,6 +14,7 @@ class MockURLSession: URLSession
     }
 
     override func dataTask(with request: URLRequest, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask {
+        lastRequest = request
         return MockURLSessionDataTask {
             completionHandler(self.data?.0, self.data?.1, self.data?.2)
         }

--- a/SimplenoteTests/URLRequest+Simplenote.swift
+++ b/SimplenoteTests/URLRequest+Simplenote.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+extension URLRequest {
+    func decodeHtmlBody<T: Decodable>() throws -> T? {
+        guard let _ = httpBody else {
+            return nil
+        }
+
+        return try httpBody.map {
+            try JSONDecoder().decode(T.self, from: $0)
+        }
+    }
+}


### PR DESCRIPTION
### Fix
This PR fixes #951 

This PR is almost identical to the changes made to SNiOS in https://github.com/Automattic/simplenote-ios/pull/1272 

This PR changes the case on email addresses before they are sent to the server during signup. Previously there was an issue where mixed case email addresses where causing accounts to be created immediately borked. Setting the emails to lowercase on signup is part of fixing this problem.

There isn't much to see in this PR as the email case is being set just before being sent to the server. As such to verify the changes I have created unit tests to confirm what is being sent. While I was there I also wrote tests for the rest of SignupRemote


### Test
1. run the unit tests for SNiOS
2. Check the tests on SignupRemoteTests.swift, they should all pass and confirm the correct casing of the email address.

### Review
***(Required)*** Add instructions for reviewers.  For example:
> Only one developer is required to review these changes, but anyone can perform the review.

### Release
> These changes do not require release notes.
