### PR TITLE
Execute tests in random order

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,6 +44,15 @@ jobs:
       - run:
           name: Build & Test
           command: bundle exec fastlane test
+          # Starting March 2021, we've been experiencing occasional hangs after
+          # the tests finished running successfully. This reduces the time
+          # CircleCI waits with no output, the idea being that we won't have to
+          # wait for a long time to relaunch the build, which, unfortunately,
+          # is what we have to do in those occasions.
+          #
+          # See
+          # https://app.circleci.com/pipelines/github/Automattic/simplenote-macos/2363/workflows/c0aa85a0-837b-4e3f-bcda-252a273bf008/jobs/2738
+          no_output_timeout: 1m
 
   Verify App Store Target Builds:
     executor: *xcode_image

--- a/Simplenote.xcodeproj/xcshareddata/xcschemes/Simplenote.xcscheme
+++ b/Simplenote.xcodeproj/xcshareddata/xcschemes/Simplenote.xcscheme
@@ -29,7 +29,8 @@
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
-            skipped = "NO">
+            skipped = "NO"
+            testExecutionOrdering = "random">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "B5CBB068241976230003C271"


### PR DESCRIPTION
### Fix
Executes tests in random order. See discussion in https://github.com/Automattic/simplenote-macos/pull/968

### Test
Tests should pass locally and in CI

### Review
Only one developer and required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.

---

@jleandroperez @ealeksandrov thank you for the suggestion to try with running the tests in random order _first_. I thought about randomness only _after_ the skip implementation in #968 and I was too deep in that work to think of it 🙇‍♂️ .

I run these tests five times, they never experienced the `SignupRemoteTests` failure and showed the timeout failure once:

![image](https://user-images.githubusercontent.com/1218433/118871955-6d18b480-b92b-11eb-8367-5c3ecc2c6b36.png)

The fact that we didn't see any `SignupRemoteTests` failure is not a proof that randomness solves it, because flaky tests are by their very nature hard to reproduce. Still, this is a good place to start, we can't go back to #968 in case we see that failure pop up again.