### PR TITLE
Update release finalization automation

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,22 +1,3 @@
-GIT
-  remote: https://github.com/wordpress-mobile/release-toolkit
-  revision: eb0f24ec6c73b3454d711cc4b3276c50b9655861
-  tag: 0.18.1
-  specs:
-    fastlane-plugin-wpmreleasetoolkit (0.18.1)
-      activesupport (~> 5)
-      bigdecimal (~> 1.4)
-      chroma (= 0.2.0)
-      diffy (~> 3.3)
-      git (~> 1.3)
-      jsonlint (~> 0.3)
-      nokogiri (~> 1.11)
-      octokit (~> 4.18)
-      parallel (~> 1.14)
-      progress_bar (~> 1.3)
-      rake (~> 12.3)
-      rake-compiler (~> 1.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -108,7 +89,9 @@ GEM
     ethon (0.12.0)
       ffi (>= 1.3.0)
     excon (0.79.0)
-    faraday (1.4.1)
+    faraday (1.4.2)
+      faraday-em_http (~> 1.0)
+      faraday-em_synchrony (~> 1.0)
       faraday-excon (~> 1.1)
       faraday-net_http (~> 1.0)
       faraday-net_http_persistent (~> 1.1)
@@ -117,6 +100,8 @@ GEM
     faraday-cookie_jar (0.0.7)
       faraday (>= 0.8.0)
       http-cookie (~> 1.0.0)
+    faraday-em_http (1.0.0)
+    faraday-em_synchrony (1.0.0)
     faraday-excon (1.1.0)
     faraday-net_http (1.0.1)
     faraday-net_http_persistent (1.1.0)
@@ -163,6 +148,19 @@ GEM
       xcpretty-travis-formatter (>= 0.0.3)
     fastlane-plugin-appcenter (1.6.0)
     fastlane-plugin-sentry (1.6.0)
+    fastlane-plugin-wpmreleasetoolkit (1.0.1)
+      activesupport (~> 5)
+      bigdecimal (~> 1.4)
+      chroma (= 0.2.0)
+      diffy (~> 3.3)
+      git (~> 1.3)
+      jsonlint (~> 0.3)
+      nokogiri (~> 1.11)
+      octokit (~> 4.18)
+      parallel (~> 1.14)
+      progress_bar (~> 1.3)
+      rake (~> 12.3)
+      rake-compiler (~> 1.0)
     ffi (1.14.2)
     fourflusher (2.3.1)
     fuzzy_match (2.0.4)
@@ -227,7 +225,7 @@ GEM
     memoist (0.16.2)
     mini_magick (4.11.0)
     mini_mime (1.0.3)
-    mini_portile2 (2.5.1)
+    mini_portile2 (2.5.3)
     minitest (5.14.4)
     molinillo (0.6.6)
     multi_json (1.15.0)
@@ -236,7 +234,7 @@ GEM
     nap (1.1.0)
     naturally (2.2.1)
     netrc (0.11.0)
-    nokogiri (1.11.3)
+    nokogiri (1.11.7)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
     octokit (4.21.0)
@@ -319,7 +317,7 @@ DEPENDENCIES
   fastlane (~> 2)
   fastlane-plugin-appcenter (= 1.6.0)
   fastlane-plugin-sentry
-  fastlane-plugin-wpmreleasetoolkit!
+  fastlane-plugin-wpmreleasetoolkit (~> 1.0)
   octokit (~> 4.0)
   rake
   xcpretty-travis-formatter

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -219,7 +219,15 @@ end
       ios_bump_version_beta()
     end
 
-    trigger_app_store_ci_build(branch_to_build: "release/#{ios_get_app_version()}")
+    # Wrap up
+    version = ios_get_app_version
+    branch = "release/#{version}"
+    removebranchprotection(repository: GHHELPER_REPO, branch: branch)
+    setfrozentag(repository: GHHELPER_REPO, milestone: version, freeze: false)
+    create_new_milestone(repository: GHHELPER_REPO)
+    close_milestone(repository: GHHELPER_REPO, milestone: version)
+
+    trigger_app_store_ci_build(branch_to_build: branch)
   end
 
   #####################################################################################

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -2,6 +2,6 @@
 #
 # Ensure this file is checked in to source control!
 
-gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag: '0.18.1'
+gem 'fastlane-plugin-wpmreleasetoolkit', '~> 1.0'
 gem 'fastlane-plugin-sentry'
 gem 'fastlane-plugin-appcenter', '1.6.0'


### PR DESCRIPTION
Brings the release finalization Fastlane automation in line with the other projects (other than for the incremental tags removal because I haven't spent the time to followup on the mobile

### Test
I think we can test these "live" when the next release finalization time comes. Everything is straightforward and the code is the same as what's used in other repos. _100% sure I just jinxed us in saying this_.

### Review
Only one developer required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.