### PR TITLE
Scrollable Tags Editor

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 2.14
 -----
 - New Status Bar: Lets you quickly know what's your Tags / Notes selection #979
+- Tags Editor is now scrollable, making more room for the editor when appropriate #987
 
 2.13
 -----

--- a/Simplenote/HorizontalScrollView.swift
+++ b/Simplenote/HorizontalScrollView.swift
@@ -40,4 +40,11 @@ class HorizontalScrollView: NSScrollView {
         contentView.frame = bounds
         horizontalScroller?.isHidden = true
     }
+
+    /// Scrolls to the left-most edge
+    ///
+    func resetScrollPosition() {
+        let target = NSPoint(x: contentView.contentInsets.left * -1, y: .zero)
+        contentView.setBoundsOrigin(target)
+    }
 }

--- a/Simplenote/Main.storyboard
+++ b/Simplenote/Main.storyboard
@@ -646,15 +646,6 @@
                             <customView translatesAutoresizingMaskIntoConstraints="NO" id="Zgz-qj-sTm" userLabel="Tags View">
                                 <rect key="frame" x="0.0" y="0.0" width="528" height="48"/>
                                 <subviews>
-                                    <customView translatesAutoresizingMaskIntoConstraints="NO" id="K6m-2B-IQ0" userLabel="Bottom Divider View" customClass="BackgroundView" customModule="Simplenote" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="47" width="528" height="1"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="1" id="6Tb-0t-bpO"/>
-                                        </constraints>
-                                        <userDefinedRuntimeAttributes>
-                                            <userDefinedRuntimeAttribute type="boolean" keyPath="drawsTopBorder" value="YES"/>
-                                        </userDefinedRuntimeAttributes>
-                                    </customView>
                                     <scrollView placeholderIntrinsicWidth="462" placeholderIntrinsicHeight="25" borderType="none" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasVerticalScroller="NO" usesPredominantAxisScrolling="NO" verticalScrollElasticity="none" translatesAutoresizingMaskIntoConstraints="NO" id="FMH-MU-LHX" customClass="HorizontalScrollView" customModule="Simplenote" customModuleProvider="target">
                                         <rect key="frame" x="23" y="13" width="482" height="25"/>
                                         <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="dTq-DR-Qae">
@@ -687,13 +678,10 @@
                                     </scrollView>
                                 </subviews>
                                 <constraints>
-                                    <constraint firstAttribute="trailing" secondItem="K6m-2B-IQ0" secondAttribute="trailing" id="6nG-9t-6hf"/>
                                     <constraint firstItem="FMH-MU-LHX" firstAttribute="leading" secondItem="Zgz-qj-sTm" secondAttribute="leading" constant="23" id="U46-vh-YjV"/>
-                                    <constraint firstItem="K6m-2B-IQ0" firstAttribute="top" secondItem="Zgz-qj-sTm" secondAttribute="top" id="ave-sr-zJV"/>
                                     <constraint firstAttribute="height" constant="48" id="bmN-kY-Bfy"/>
                                     <constraint firstItem="FMH-MU-LHX" firstAttribute="centerY" secondItem="Zgz-qj-sTm" secondAttribute="centerY" constant="-1" id="hCu-Di-KN9"/>
                                     <constraint firstAttribute="trailing" secondItem="FMH-MU-LHX" secondAttribute="trailing" constant="23" id="nDW-rY-kig"/>
-                                    <constraint firstItem="K6m-2B-IQ0" firstAttribute="leading" secondItem="Zgz-qj-sTm" secondAttribute="leading" id="sOu-TI-Rrf"/>
                                 </constraints>
                             </customView>
                             <visualEffectView wantsLayer="YES" blendingMode="withinWindow" material="headerView" state="inactive" translatesAutoresizingMaskIntoConstraints="NO" id="wyB-gA-z62" userLabel="Header Effect View">
@@ -862,7 +850,6 @@
                     </view>
                     <connections>
                         <outlet property="backgroundView" destination="RoF-0f-Ugm" id="U5O-mZ-5Kd"/>
-                        <outlet property="bottomDividerView" destination="K6m-2B-IQ0" id="NX8-nx-JVt"/>
                         <outlet property="clipView" destination="4oT-JU-wrs" id="6KU-5h-AY4"/>
                         <outlet property="headerDividerView" destination="LMj-Ag-ut7" id="cby-F8-k2W"/>
                         <outlet property="headerEffectView" destination="wyB-gA-z62" id="WlD-sQ-TGV"/>

--- a/Simplenote/Main.storyboard
+++ b/Simplenote/Main.storyboard
@@ -526,7 +526,7 @@
                                             <textField horizontalHuggingPriority="1000" horizontalCompressionResistancePriority="1" verticalCompressionResistancePriority="1000" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="PLP-IN-gUi" userLabel="SearchTextField">
                                                 <rect key="frame" x="-2" y="7" width="41" height="14"/>
                                                 <textFieldCell key="cell" allowsUndo="NO" title="Search" usesSingleLineMode="YES" id="nCt-Ge-AWn">
-                                                    <font key="font" metaFont="system" size="11"/>
+                                                    <font key="font" metaFont="smallSystem"/>
                                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                 </textFieldCell>
@@ -534,7 +534,7 @@
                                             <textField horizontalHuggingPriority="1000" horizontalCompressionResistancePriority="1" verticalCompressionResistancePriority="1000" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VvK-y1-tIA" userLabel="TagStatusField">
                                                 <rect key="frame" x="39" y="7" width="23" height="14"/>
                                                 <textFieldCell key="cell" allowsUndo="NO" title="Tag" usesSingleLineMode="YES" id="wqh-AR-wEU">
-                                                    <font key="font" metaFont="system" size="11"/>
+                                                    <font key="font" metaFont="smallSystem"/>
                                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                 </textFieldCell>
@@ -550,7 +550,7 @@
                                             <textField horizontalHuggingPriority="1000" horizontalCompressionResistancePriority="1" verticalCompressionResistancePriority="1000" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="afF-4l-Dvz" userLabel="NoteStatusField">
                                                 <rect key="frame" x="76" y="7" width="30" height="14"/>
                                                 <textFieldCell key="cell" allowsUndo="NO" title="Note" usesSingleLineMode="YES" id="XMY-cm-Ljb">
-                                                    <font key="font" metaFont="system" size="11"/>
+                                                    <font key="font" metaFont="smallSystem"/>
                                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                 </textFieldCell>
@@ -622,7 +622,7 @@
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
                                             <color key="backgroundColor" red="1" green="0.0" blue="0.0" alpha="0.0" colorSpace="calibratedRGB"/>
-                                            <size key="minSize" width="528" height="618"/>
+                                            <size key="minSize" width="513" height="618"/>
                                             <size key="maxSize" width="10000000" height="10000000"/>
                                             <color key="insertionPointColor" name="textColor" catalog="System" colorSpace="catalog"/>
                                             <connections>
@@ -824,9 +824,9 @@
                     <rect key="frame" x="0.0" y="0.0" width="528" height="48"/>
                     <subviews>
                         <scrollView placeholderIntrinsicWidth="462" placeholderIntrinsicHeight="25" borderType="none" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasVerticalScroller="NO" usesPredominantAxisScrolling="NO" verticalScrollElasticity="none" translatesAutoresizingMaskIntoConstraints="NO" id="FMH-MU-LHX" customClass="HorizontalScrollView" customModule="Simplenote" customModuleProvider="target">
-                            <rect key="frame" x="23" y="12" width="482" height="25"/>
+                            <rect key="frame" x="0.0" y="12" width="528" height="25"/>
                             <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="dTq-DR-Qae">
-                                <rect key="frame" x="0.0" y="0.0" width="482" height="25"/>
+                                <rect key="frame" x="0.0" y="0.0" width="528" height="25"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <subviews>
                                     <tokenField horizontalHuggingPriority="750" verticalHuggingPriority="750" placeholderIntrinsicWidth="462" placeholderIntrinsicHeight="25" mirrorLayoutDirectionWhenInternationalizing="always" translatesAutoresizingMaskIntoConstraints="NO" id="U3o-VN-U2S" customClass="TagsField" customModule="Simplenote" customModuleProvider="target">
@@ -843,9 +843,10 @@
                                     <constraint firstItem="U3o-VN-U2S" firstAttribute="top" secondItem="dTq-DR-Qae" secondAttribute="top" id="osh-hn-mFG"/>
                                     <constraint firstItem="U3o-VN-U2S" firstAttribute="leading" secondItem="dTq-DR-Qae" secondAttribute="leading" id="x2F-hr-KGE"/>
                                 </constraints>
+                                <edgeInsets key="contentInsets" left="23" right="23" top="0.0" bottom="0.0"/>
                             </clipView>
-                            <scroller key="horizontalScroller" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="z3o-4M-GrW">
-                                <rect key="frame" x="0.0" y="9" width="482" height="16"/>
+                            <scroller key="horizontalScroller" wantsLayer="YES" verticalHuggingPriority="750" doubleValue="1" horizontal="YES" id="z3o-4M-GrW">
+                                <rect key="frame" x="0.0" y="9" width="528" height="16"/>
                                 <autoresizingMask key="autoresizingMask"/>
                             </scroller>
                             <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="jwH-gh-soS">
@@ -856,10 +857,10 @@
                     </subviews>
                     <constraints>
                         <constraint firstAttribute="bottom" secondItem="FMH-MU-LHX" secondAttribute="bottom" constant="12" id="587-Oz-1BM"/>
-                        <constraint firstItem="FMH-MU-LHX" firstAttribute="leading" secondItem="Zgz-qj-sTm" secondAttribute="leading" constant="23" id="U46-vh-YjV"/>
+                        <constraint firstItem="FMH-MU-LHX" firstAttribute="leading" secondItem="Zgz-qj-sTm" secondAttribute="leading" id="U46-vh-YjV"/>
                         <constraint firstAttribute="height" constant="48" id="bmN-kY-Bfy"/>
                         <constraint firstItem="FMH-MU-LHX" firstAttribute="top" secondItem="Zgz-qj-sTm" secondAttribute="top" constant="11" id="kQp-1h-apM"/>
-                        <constraint firstAttribute="trailing" secondItem="FMH-MU-LHX" secondAttribute="trailing" constant="23" id="nDW-rY-kig"/>
+                        <constraint firstAttribute="trailing" secondItem="FMH-MU-LHX" secondAttribute="trailing" id="nDW-rY-kig"/>
                     </constraints>
                 </customView>
                 <menu title="More Actions" id="O2x-0v-azu" userLabel="Note More Menu">

--- a/Simplenote/Main.storyboard
+++ b/Simplenote/Main.storyboard
@@ -612,17 +612,17 @@
                                 <rect key="frame" x="0.0" y="0.0" width="528" height="618"/>
                             </customView>
                             <scrollView borderType="none" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" horizontalScrollElasticity="none" translatesAutoresizingMaskIntoConstraints="NO" id="3M9-OX-Hpx">
-                                <rect key="frame" x="0.0" y="48" width="528" height="570"/>
+                                <rect key="frame" x="0.0" y="0.0" width="528" height="618"/>
                                 <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="4oT-JU-wrs">
-                                    <rect key="frame" x="0.0" y="0.0" width="528" height="570"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="528" height="618"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <textView drawsBackground="NO" importsGraphics="NO" richText="NO" verticallyResizable="YES" findStyle="panel" incrementalSearchingEnabled="YES" continuousSpellChecking="YES" allowsUndo="YES" allowsNonContiguousLayout="YES" linkDetection="YES" dataDetection="YES" smartInsertDelete="YES" id="84J-wh-qoX" customClass="SPTextView" customModule="Simplenote" customModuleProvider="target">
-                                            <rect key="frame" x="0.0" y="0.0" width="513" height="570"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="513" height="618"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
                                             <color key="backgroundColor" red="1" green="0.0" blue="0.0" alpha="0.0" colorSpace="calibratedRGB"/>
-                                            <size key="minSize" width="513" height="570"/>
+                                            <size key="minSize" width="528" height="618"/>
                                             <size key="maxSize" width="10000000" height="10000000"/>
                                             <color key="insertionPointColor" name="textColor" catalog="System" colorSpace="catalog"/>
                                             <connections>
@@ -639,51 +639,10 @@
                                     <autoresizingMask key="autoresizingMask"/>
                                 </scroller>
                                 <scroller key="verticalScroller" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="lkL-cz-Hnm">
-                                    <rect key="frame" x="512" y="0.0" width="16" height="570"/>
+                                    <rect key="frame" x="512" y="0.0" width="16" height="618"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                 </scroller>
                             </scrollView>
-                            <customView translatesAutoresizingMaskIntoConstraints="NO" id="Zgz-qj-sTm" userLabel="Tags View">
-                                <rect key="frame" x="0.0" y="0.0" width="528" height="48"/>
-                                <subviews>
-                                    <scrollView placeholderIntrinsicWidth="462" placeholderIntrinsicHeight="25" borderType="none" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasVerticalScroller="NO" usesPredominantAxisScrolling="NO" verticalScrollElasticity="none" translatesAutoresizingMaskIntoConstraints="NO" id="FMH-MU-LHX" customClass="HorizontalScrollView" customModule="Simplenote" customModuleProvider="target">
-                                        <rect key="frame" x="23" y="13" width="482" height="25"/>
-                                        <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="dTq-DR-Qae">
-                                            <rect key="frame" x="0.0" y="0.0" width="482" height="25"/>
-                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                            <subviews>
-                                                <tokenField horizontalHuggingPriority="750" verticalHuggingPriority="750" placeholderIntrinsicWidth="462" placeholderIntrinsicHeight="25" mirrorLayoutDirectionWhenInternationalizing="always" translatesAutoresizingMaskIntoConstraints="NO" id="U3o-VN-U2S" customClass="TagsField" customModule="Simplenote" customModuleProvider="target">
-                                                    <rect key="frame" x="-2" y="0.0" width="466" height="25"/>
-                                                    <tokenFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" baseWritingDirection="leftToRight" alignment="left" allowsEditingTextAttributes="YES" id="rEO-Bg-V6m" customClass="TagsFieldCell" customModule="Simplenote" customModuleProvider="target">
-                                                        <font key="font" metaFont="cellTitle"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                                    </tokenFieldCell>
-                                                </tokenField>
-                                            </subviews>
-                                            <constraints>
-                                                <constraint firstAttribute="bottom" secondItem="U3o-VN-U2S" secondAttribute="bottom" id="WnY-Yr-mrG"/>
-                                                <constraint firstItem="U3o-VN-U2S" firstAttribute="top" secondItem="dTq-DR-Qae" secondAttribute="top" id="osh-hn-mFG"/>
-                                                <constraint firstItem="U3o-VN-U2S" firstAttribute="leading" secondItem="dTq-DR-Qae" secondAttribute="leading" id="x2F-hr-KGE"/>
-                                            </constraints>
-                                        </clipView>
-                                        <scroller key="horizontalScroller" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="z3o-4M-GrW">
-                                            <rect key="frame" x="0.0" y="9" width="482" height="16"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                        </scroller>
-                                        <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="jwH-gh-soS">
-                                            <rect key="frame" x="-100" y="-100" width="16" height="48"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                        </scroller>
-                                    </scrollView>
-                                </subviews>
-                                <constraints>
-                                    <constraint firstItem="FMH-MU-LHX" firstAttribute="leading" secondItem="Zgz-qj-sTm" secondAttribute="leading" constant="23" id="U46-vh-YjV"/>
-                                    <constraint firstAttribute="height" constant="48" id="bmN-kY-Bfy"/>
-                                    <constraint firstItem="FMH-MU-LHX" firstAttribute="centerY" secondItem="Zgz-qj-sTm" secondAttribute="centerY" constant="-1" id="hCu-Di-KN9"/>
-                                    <constraint firstAttribute="trailing" secondItem="FMH-MU-LHX" secondAttribute="trailing" constant="23" id="nDW-rY-kig"/>
-                                </constraints>
-                            </customView>
                             <visualEffectView wantsLayer="YES" blendingMode="withinWindow" material="headerView" state="inactive" translatesAutoresizingMaskIntoConstraints="NO" id="wyB-gA-z62" userLabel="Header Effect View">
                                 <rect key="frame" x="0.0" y="566" width="528" height="52"/>
                             </visualEffectView>
@@ -827,22 +786,18 @@
                             <constraint firstItem="LMj-Ag-ut7" firstAttribute="bottom" secondItem="wyB-gA-z62" secondAttribute="bottom" id="9M6-7R-AAX"/>
                             <constraint firstItem="Dj2-Ut-m6l" firstAttribute="centerX" secondItem="w7Z-Cl-xvM" secondAttribute="centerX" id="Aih-4w-tkI"/>
                             <constraint firstItem="wyB-gA-z62" firstAttribute="top" secondItem="mdt-4X-jeq" secondAttribute="top" id="BaZ-Pi-vNU"/>
+                            <constraint firstAttribute="bottom" secondItem="3M9-OX-Hpx" secondAttribute="bottom" id="F2U-H3-cdp"/>
                             <constraint firstItem="LMj-Ag-ut7" firstAttribute="top" secondItem="wyB-gA-z62" secondAttribute="top" id="HLE-3c-ZEM"/>
                             <constraint firstItem="RoF-0f-Ugm" firstAttribute="leading" secondItem="w7Z-Cl-xvM" secondAttribute="leading" id="RhM-cA-pSD"/>
                             <constraint firstItem="wyB-gA-z62" firstAttribute="trailing" secondItem="mdt-4X-jeq" secondAttribute="trailing" id="SO2-Ts-sGE"/>
                             <constraint firstAttribute="trailing" secondItem="3M9-OX-Hpx" secondAttribute="trailing" id="SaF-9N-ZkN"/>
-                            <constraint firstAttribute="trailing" secondItem="Zgz-qj-sTm" secondAttribute="trailing" id="TWe-DC-gjH"/>
                             <constraint firstItem="LMj-Ag-ut7" firstAttribute="trailing" secondItem="wyB-gA-z62" secondAttribute="trailing" id="UME-sK-gmJ"/>
                             <constraint firstAttribute="trailing" secondItem="RoF-0f-Ugm" secondAttribute="trailing" id="Xbp-bO-h93"/>
                             <constraint firstItem="RoF-0f-Ugm" firstAttribute="top" secondItem="w7Z-Cl-xvM" secondAttribute="top" id="YgL-n8-HLQ"/>
-                            <constraint firstItem="Zgz-qj-sTm" firstAttribute="leading" secondItem="w7Z-Cl-xvM" secondAttribute="leading" id="ZU3-rD-Cfp"/>
                             <constraint firstItem="3M9-OX-Hpx" firstAttribute="top" secondItem="w7Z-Cl-xvM" secondAttribute="top" id="igC-ZM-wQh"/>
-                            <constraint firstItem="Zgz-qj-sTm" firstAttribute="top" secondItem="3M9-OX-Hpx" secondAttribute="bottom" id="n6g-mu-Sf5"/>
                             <constraint firstItem="Dj2-Ut-m6l" firstAttribute="centerY" secondItem="w7Z-Cl-xvM" secondAttribute="centerY" id="nea-OO-Awf"/>
                             <constraint firstItem="mdt-4X-jeq" firstAttribute="top" secondItem="w7Z-Cl-xvM" secondAttribute="top" id="oil-IL-VG8"/>
-                            <constraint firstItem="Zgz-qj-sTm" firstAttribute="top" secondItem="3M9-OX-Hpx" secondAttribute="bottom" id="pNt-od-Vf5"/>
                             <constraint firstAttribute="bottom" secondItem="RoF-0f-Ugm" secondAttribute="bottom" id="qeu-Jg-mO9"/>
-                            <constraint firstAttribute="bottom" secondItem="Zgz-qj-sTm" secondAttribute="bottom" id="w2I-mr-ERE"/>
                             <constraint firstItem="3M9-OX-Hpx" firstAttribute="leading" secondItem="w7Z-Cl-xvM" secondAttribute="leading" id="wOf-bO-sHt"/>
                             <constraint firstItem="wyB-gA-z62" firstAttribute="bottom" secondItem="mdt-4X-jeq" secondAttribute="bottom" id="yAR-Ci-yly"/>
                             <constraint firstItem="wyB-gA-z62" firstAttribute="leading" secondItem="mdt-4X-jeq" secondAttribute="leading" id="yWO-3G-AGN"/>
@@ -851,6 +806,7 @@
                     <connections>
                         <outlet property="backgroundView" destination="RoF-0f-Ugm" id="U5O-mZ-5Kd"/>
                         <outlet property="clipView" destination="4oT-JU-wrs" id="6KU-5h-AY4"/>
+                        <outlet property="editorBottomConstraint" destination="F2U-H3-cdp" id="qL6-dJ-fxD"/>
                         <outlet property="headerDividerView" destination="LMj-Ag-ut7" id="cby-F8-k2W"/>
                         <outlet property="headerEffectView" destination="wyB-gA-z62" id="WlD-sQ-TGV"/>
                         <outlet property="moreActionsMenu" destination="O2x-0v-azu" id="jSV-Gb-XpN"/>
@@ -859,11 +815,53 @@
                         <outlet property="statusImageView" destination="Dj2-Ut-m6l" id="vqt-cc-z7a"/>
                         <outlet property="statusTextField" destination="VFr-Z3-HgO" id="UWY-3k-pwd"/>
                         <outlet property="tagsField" destination="U3o-VN-U2S" id="qmL-AY-16b"/>
-                        <outlet property="tagsViewBottomConstraint" destination="w2I-mr-ERE" id="bm1-m4-so3"/>
+                        <outlet property="tagsView" destination="Zgz-qj-sTm" id="NUM-9Y-S6c"/>
                         <outlet property="toolbarView" destination="mdt-4X-jeq" id="Bi4-Hb-jc8"/>
                     </connections>
                 </viewController>
                 <customObject id="gag-zR-Yfy" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
+                <customView translatesAutoresizingMaskIntoConstraints="NO" id="Zgz-qj-sTm" userLabel="Tags View">
+                    <rect key="frame" x="0.0" y="0.0" width="528" height="48"/>
+                    <subviews>
+                        <scrollView placeholderIntrinsicWidth="462" placeholderIntrinsicHeight="25" borderType="none" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasVerticalScroller="NO" usesPredominantAxisScrolling="NO" verticalScrollElasticity="none" translatesAutoresizingMaskIntoConstraints="NO" id="FMH-MU-LHX" customClass="HorizontalScrollView" customModule="Simplenote" customModuleProvider="target">
+                            <rect key="frame" x="23" y="12" width="482" height="25"/>
+                            <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="dTq-DR-Qae">
+                                <rect key="frame" x="0.0" y="0.0" width="482" height="25"/>
+                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                <subviews>
+                                    <tokenField horizontalHuggingPriority="750" verticalHuggingPriority="750" placeholderIntrinsicWidth="462" placeholderIntrinsicHeight="25" mirrorLayoutDirectionWhenInternationalizing="always" translatesAutoresizingMaskIntoConstraints="NO" id="U3o-VN-U2S" customClass="TagsField" customModule="Simplenote" customModuleProvider="target">
+                                        <rect key="frame" x="-2" y="0.0" width="466" height="25"/>
+                                        <tokenFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" baseWritingDirection="leftToRight" alignment="left" allowsEditingTextAttributes="YES" id="rEO-Bg-V6m" customClass="TagsFieldCell" customModule="Simplenote" customModuleProvider="target">
+                                            <font key="font" metaFont="cellTitle"/>
+                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                        </tokenFieldCell>
+                                    </tokenField>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstAttribute="bottom" secondItem="U3o-VN-U2S" secondAttribute="bottom" id="WnY-Yr-mrG"/>
+                                    <constraint firstItem="U3o-VN-U2S" firstAttribute="top" secondItem="dTq-DR-Qae" secondAttribute="top" id="osh-hn-mFG"/>
+                                    <constraint firstItem="U3o-VN-U2S" firstAttribute="leading" secondItem="dTq-DR-Qae" secondAttribute="leading" id="x2F-hr-KGE"/>
+                                </constraints>
+                            </clipView>
+                            <scroller key="horizontalScroller" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="z3o-4M-GrW">
+                                <rect key="frame" x="0.0" y="9" width="482" height="16"/>
+                                <autoresizingMask key="autoresizingMask"/>
+                            </scroller>
+                            <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="jwH-gh-soS">
+                                <rect key="frame" x="-100" y="-100" width="16" height="48"/>
+                                <autoresizingMask key="autoresizingMask"/>
+                            </scroller>
+                        </scrollView>
+                    </subviews>
+                    <constraints>
+                        <constraint firstAttribute="bottom" secondItem="FMH-MU-LHX" secondAttribute="bottom" constant="12" id="587-Oz-1BM"/>
+                        <constraint firstItem="FMH-MU-LHX" firstAttribute="leading" secondItem="Zgz-qj-sTm" secondAttribute="leading" constant="23" id="U46-vh-YjV"/>
+                        <constraint firstAttribute="height" constant="48" id="bmN-kY-Bfy"/>
+                        <constraint firstItem="FMH-MU-LHX" firstAttribute="top" secondItem="Zgz-qj-sTm" secondAttribute="top" constant="11" id="kQp-1h-apM"/>
+                        <constraint firstAttribute="trailing" secondItem="FMH-MU-LHX" secondAttribute="trailing" constant="23" id="nDW-rY-kig"/>
+                    </constraints>
+                </customView>
                 <menu title="More Actions" id="O2x-0v-azu" userLabel="Note More Menu">
                     <items>
                         <menuItem title="Pin to Top" state="on" identifier="editorPinMenuItem" id="sTz-a2-biC">

--- a/Simplenote/NSTextView+Simplenote.swift
+++ b/Simplenote/NSTextView+Simplenote.swift
@@ -364,5 +364,15 @@ extension NSTextView {
 
         layoutManager.ensureLayout(for: textContainer)
     }
+
+    /// Scrolls to the Selected Location
+    ///
+    func scrollToSelectedLocation() {
+        guard let location = selectedRanges.first?.rangeValue.location else {
+            return
+        }
+
+        scrollRangeToVisible(NSRange(location: location, length: .zero))
+    }
 }
 

--- a/Simplenote/NoteEditorViewController+Swift.swift
+++ b/Simplenote/NoteEditorViewController+Swift.swift
@@ -54,7 +54,7 @@ extension NoteEditorViewController {
         tagsField.delegate = self
         tagsField.focusRingType = .none
         tagsField.font = .simplenoteSecondaryTextFont
-        tagsField.placeholderText = NSLocalizedString("Add tag...", comment: "Placeholder text in the Tags View")
+        tagsField.placeholderText = NSLocalizedString("Tag...", comment: "Placeholder text in the Tags View")
         tagsField.nextKeyView = noteEditor
         tagsField.formatter = TagTextFormatter(maximumLength: SimplenoteConstants.maximumTagLength)
     }

--- a/Simplenote/NoteEditorViewController+Swift.swift
+++ b/Simplenote/NoteEditorViewController+Swift.swift
@@ -256,7 +256,6 @@ extension NoteEditorViewController {
     func refreshStyle() {
         backgroundView.fillColor                = .simplenoteSecondaryBackgroundColor
         headerDividerView.borderColor           = .simplenoteDividerColor
-        bottomDividerView.borderColor           = .simplenoteSecondaryDividerColor
         noteEditor.insertionPointColor          = .simplenoteEditorTextColor
         noteEditor.textColor                    = .simplenoteEditorTextColor
         statusTextField.textColor               = .simplenoteSecondaryTextColor

--- a/Simplenote/NoteEditorViewController+Swift.swift
+++ b/Simplenote/NoteEditorViewController+Swift.swift
@@ -330,7 +330,11 @@ extension NoteEditorViewController {
 
     @objc
     func resetTagsFieldScrollOffset() {
-        tagsField.scroll(.zero)
+        guard let scrollView = tagsField.enclosingScrollView as? HorizontalScrollView else {
+            return
+        }
+
+        scrollView.resetScrollPosition()
     }
 
     /// Refreshes the TagsField's Tokens

--- a/Simplenote/NoteEditorViewController+Swift.swift
+++ b/Simplenote/NoteEditorViewController+Swift.swift
@@ -29,16 +29,16 @@ extension NoteEditorViewController {
 
     @objc
     func setupTagsView() {
-        /// # Important:
+        /// - Important:
         ///     1.  `NSClipView` was really meant to handle a single subview
         ///     2.  As it turns out, embedding the `SPTextView` inside a `NSView` (and making it the `NSClipView.documentView`) brings in several side effects
         ///     3.  For simplicity reasons, our `NSClipView.documentView` is set to the `SPTextView`
         ///     4.  We're also injecting the `TagsView` as a subview to our `NSClipView`
         ///     5.  Adding `contentInsets.bottom` allows the `TagsView` to be visualized. But `NSClipView` does not relay mouse events to this second "extra" subview
         ///
-        /// # Workaround:
-        ///     1. We've increased the `textContainerInset.height` (which affects both top/bottom)
-        ///     2. We've compensated for this "extra" top inset (caused by the new `textContainerInset.height` by adjusting `SplitItemMetrics.editorContentTopInset`
+        /// - Workaround:
+        ///     1.  We've increased the `textContainerInset.height` (which affects both top/bottom)
+        ///     2.  We've compensated for this "extra" top inset (caused by the new `textContainerInset.height` by adjusting `SplitItemMetrics.editorContentTopInset`
         ///
         scrollView.contentView.addSubview(tagsView)
 

--- a/Simplenote/NoteEditorViewController+Swift.swift
+++ b/Simplenote/NoteEditorViewController+Swift.swift
@@ -905,10 +905,12 @@ extension NoteEditorViewController {
     func toggleTagsAndEditor() {
         if noteEditor.isFirstResponder {
             view.window?.makeFirstResponder(tagsField)
+            noteEditor.scrollToEndOfDocument(self)
             tagsField.currentEditor()?.moveToEndOfDocument(nil)
             tagsField.ensureCaretIsOnscreen()
         } else {
             view.window?.makeFirstResponder(noteEditor)
+            noteEditor.scrollToSelectedLocation()
         }
     }
 }

--- a/Simplenote/NoteEditorViewController+Swift.swift
+++ b/Simplenote/NoteEditorViewController+Swift.swift
@@ -29,12 +29,23 @@ extension NoteEditorViewController {
 
     @objc
     func setupTagsView() {
+        /// # Important:
+        ///     1.  `NSClipView` was really meant to handle a single subview
+        ///     2.  As it turns out, embedding the `SPTextView` inside a `NSView` (and making it the `NSClipView.documentView`) brings in several side effects
+        ///     3.  For simplicity reasons, our `NSClipView.documentView` is set to the `SPTextView`
+        ///     4.  We're also injecting the `TagsView` as a subview to our `NSClipView`
+        ///     5.  Adding `contentInsets.bottom` allows the `TagsView` to be visualized. But `NSClipView` does not relay mouse events to this second "extra" subview
+        ///
+        /// # Workaround:
+        ///     1. We've increased the `textContainerInset.height` (which affects both top/bottom)
+        ///     2. We've compensated for this "extra" top inset (caused by the new `textContainerInset.height` by adjusting `SplitItemMetrics.editorContentTopInset`
+        ///
         scrollView.contentView.addSubview(tagsView)
 
         NSLayoutConstraint.activate([
             tagsView.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor),
             tagsView.trailingAnchor.constraint(equalTo: scrollView.trailingAnchor),
-            tagsView.topAnchor.constraint(equalTo: noteEditor.bottomAnchor)
+            tagsView.bottomAnchor.constraint(equalTo: noteEditor.bottomAnchor)
         ])
     }
 
@@ -63,7 +74,6 @@ extension NoteEditorViewController {
     @objc
     func refreshScrollInsets() {
         clipView.contentInsets.top = SplitItemMetrics.editorContentTopInset
-        clipView.contentInsets.bottom = SplitItemMetrics.editorContentBottomInset
         scrollView.scrollerInsets.top = SplitItemMetrics.editorScrollerTopInset
     }
 }
@@ -169,7 +179,8 @@ extension NoteEditorViewController {
     ///
     private func textContainerInset(superviewWidth: CGFloat, maximumTextWidth: CGFloat) -> NSSize {
         let width = max((superviewWidth - maximumTextWidth), .zero) * 0.5
-        return NSMakeSize(width + EditorMetrics.minimumPadding, EditorMetrics.minimumPadding)
+        let height = SplitItemMetrics.editorContentBottomInset
+        return NSMakeSize(width + EditorMetrics.minimumPadding, height + EditorMetrics.minimumPadding)
     }
 
     /// # Note: Why not receiving the MaximumTextWidth instead?

--- a/Simplenote/NoteEditorViewController+Swift.swift
+++ b/Simplenote/NoteEditorViewController+Swift.swift
@@ -34,7 +34,7 @@ extension NoteEditorViewController {
         NSLayoutConstraint.activate([
             tagsView.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor),
             tagsView.trailingAnchor.constraint(equalTo: scrollView.trailingAnchor),
-            tagsView.bottomAnchor.constraint(equalTo: noteEditor.bottomAnchor)
+            tagsView.topAnchor.constraint(equalTo: noteEditor.bottomAnchor)
         ])
     }
 
@@ -63,6 +63,7 @@ extension NoteEditorViewController {
     @objc
     func refreshScrollInsets() {
         clipView.contentInsets.top = SplitItemMetrics.editorContentTopInset
+        clipView.contentInsets.bottom = SplitItemMetrics.editorContentBottomInset
         scrollView.scrollerInsets.top = SplitItemMetrics.editorScrollerTopInset
     }
 }

--- a/Simplenote/NoteEditorViewController+Swift.swift
+++ b/Simplenote/NoteEditorViewController+Swift.swift
@@ -28,6 +28,17 @@ extension NoteEditorViewController {
     }
 
     @objc
+    func setupTagsView() {
+        scrollView.contentView.addSubview(tagsView)
+
+        NSLayoutConstraint.activate([
+            tagsView.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor),
+            tagsView.trailingAnchor.constraint(equalTo: scrollView.trailingAnchor),
+            tagsView.bottomAnchor.constraint(equalTo: noteEditor.bottomAnchor)
+        ])
+    }
+
+    @objc
     func setupTagsField() {
         tagsField.delegate = self
         tagsField.focusRingType = .none
@@ -46,7 +57,7 @@ extension NoteEditorViewController {
 
     @objc
     func setupBottomInsets() {
-        tagsViewBottomConstraint.constant = SplitItemMetrics.breadcrumbsViewHeight
+        editorBottomConstraint.constant = SplitItemMetrics.breadcrumbsViewHeight
     }
 
     @objc

--- a/Simplenote/NoteEditorViewController.h
+++ b/Simplenote/NoteEditorViewController.h
@@ -57,7 +57,6 @@ typedef NS_ENUM(NSInteger, NoteFontSize) {
 @property (nonatomic, strong) IBOutlet BackgroundView                           *backgroundView;
 @property (nonatomic, strong) IBOutlet NSVisualEffectView                       *headerEffectView;
 @property (nonatomic, strong) IBOutlet BackgroundView                           *headerDividerView;
-@property (nonatomic, strong) IBOutlet BackgroundView                           *bottomDividerView;
 @property (nonatomic, strong) IBOutlet ToolbarView                              *toolbarView;
 @property (nonatomic, strong) IBOutlet NSImageView                              *statusImageView;
 @property (nonatomic, strong) IBOutlet NSTextField                              *statusTextField;

--- a/Simplenote/NoteEditorViewController.h
+++ b/Simplenote/NoteEditorViewController.h
@@ -63,8 +63,9 @@ typedef NS_ENUM(NSInteger, NoteFontSize) {
 @property (nonatomic, strong) IBOutlet SPTextView                               *noteEditor;
 @property (nonatomic, strong) IBOutlet NSScrollView                             *scrollView;
 @property (nonatomic, strong) IBOutlet NSClipView                               *clipView;
+@property (nonatomic, strong) IBOutlet NSView                                   *tagsView;
 @property (nonatomic, strong) IBOutlet TagsField                                *tagsField;
-@property (nonatomic, strong) IBOutlet NSLayoutConstraint                       *tagsViewBottomConstraint;
+@property (nonatomic, strong) IBOutlet NSLayoutConstraint                       *editorBottomConstraint;
 
 @property (nonatomic, strong, readonly) MarkdownViewController                  *markdownViewController;
 @property (nonatomic, strong, readonly) Storage                                 *storage;

--- a/Simplenote/NoteEditorViewController.m
+++ b/Simplenote/NoteEditorViewController.m
@@ -94,6 +94,7 @@ static NSString * const SPMarkdownPreferencesKey        = @"kMarkdownPreferences
     [self setupScrollView];
     [self setupStatusImageView];
     [self setupTagsField];
+    [self setupTagsView];
     [self setupBottomInsets];
 
     // Interlinks

--- a/Simplenote/NoteEditorViewController.m
+++ b/Simplenote/NoteEditorViewController.m
@@ -585,8 +585,11 @@ static NSString * const SPMarkdownPreferencesKey        = @"kMarkdownPreferences
 {
     if (self.isDisplayingMarkdown || !self.isMarkdownEnabled) {
         [self dismissMarkdownPreview];
+        [self.view.window makeFirstResponder:self.noteEditor];
+
     } else {
         [self displayMarkdownPreview:self.note];
+        [self.view.window makeFirstResponder:nil];
     }
 
     [self refreshEditorActions];

--- a/Simplenote/SplitItemMetrics.swift
+++ b/Simplenote/SplitItemMetrics.swift
@@ -10,8 +10,8 @@ enum SplitItemMetrics {
     private static let sidebarTopInsetBigSur = CGFloat(62)
 
     /// Editor: Content Insets
-    private static let editorContentTopInsetLegacy = CGFloat(38)
-    private static let editorContentTopInsetBigSur = CGFloat(48)
+    private static let editorContentTopInsetLegacy = CGFloat(-10) // Standard (38pt) minus editorContentBottomInset
+    private static let editorContentTopInsetBigSur = CGFloat.zero // Standard (48pt) minus editorContentBottomInset
 
     
     /// Sidebar Insets: Tags + Notes Lists

--- a/Simplenote/SplitItemMetrics.swift
+++ b/Simplenote/SplitItemMetrics.swift
@@ -47,7 +47,7 @@ enum SplitItemMetrics {
         sidebarTopInset
     }
 
-    /// Editor Insets: Content
+    /// Editor Insets: Content Top
     ///
     static var editorContentTopInset: CGFloat {
         guard #available(macOS 11, *) else {
@@ -56,6 +56,10 @@ enum SplitItemMetrics {
 
         return editorContentTopInsetBigSur
     }
+
+    /// Editor Insets: Content Bottom
+    ///
+    static var editorContentBottomInset = CGFloat(48)
 
     /// Editor Insets: Scroller
     ///


### PR DESCRIPTION
### Details:
In this PR we're replicating iOS's Tags Editor behavior:

1. From now on, the Tags Editor will live below the Note Editor Area
2. Whenever the document is short, the Editor will be anchored at the bottom edge of the screen
3. Whenever the document is long enough, the Editor will scroll along with the Note's contents,
 
Closes #985

@eshurakov Sir! May I bug you with this one as well?
**Thanks in advance!!**

### Test: New Note
1. Add a new Note

- [x] Verify the Top Padding of the first line of text (Editor) matches the Notes List's first cell
- [x] Verify the Tags Editor is anchored at the bottom
- [x] Verify that you can click over the Tags Editor
- [x] Verify that if you add enough content, the Tags Editor scrolls along horizontally
- [x] Verify that you can remove or edit Tags

### Test: Existing Short Note
1. Click over any super short note

- [x] Verify the Tags Editor is anchored at the bottom of the Editor

### Test: Existing Long Note
1. Click over any super long note

- [x] Verify the Tags Editor is not immediately visible
- [x] Verify that if you scroll down, the Editor is revealed

### Test: Markdown Preview
1. Enable Markdown Preview in a note
2. While in Edition mode, click over the Tags Editor
3. Press the Markdown Preview button

- [x] Verify you can no longer edit the Tags (while in MD preview!)

### Test: UX
- [x] Verify the Tags Editor placeholder reads as `Tag...` (below the content editor!)
- [x] Verify that in a note with tons of Tags, the Tags Editor no longer clips its contents. [Ref. this comment!](https://github.com/Automattic/simplenote-macos/pull/987#issuecomment-872295078)
- [x] Verify that in a note with lots of text, pressing **CMD + Shift + Y** causes the Editor to scroll all the way down (and thus, making the Tags Editor visible)

### Release
`RELEASE-NOTES.txt` was updated in 7c31128 with:

> Tags Editor is now scrollable, making more room for the editor when appropriate
