### PR TITLE
Status Bar Tinting

### DIFF
--- a/Simplenote/BreadcrumbsViewController.swift
+++ b/Simplenote/BreadcrumbsViewController.swift
@@ -7,7 +7,8 @@ class BreadcrumbsViewController: NSViewController {
 
     /// Background
     ///
-    @IBOutlet private var backgroundView: BackgroundView!
+    @IBOutlet private var backgroundBox: NSBox!
+    @IBOutlet private var dividerView: BackgroundView!
 
     /// TextField: Search
     ///
@@ -93,10 +94,6 @@ class BreadcrumbsViewController: NSViewController {
 private extension BreadcrumbsViewController {
 
     func startListeningToNotifications() {
-        if #available(macOS 10.15, *) {
-            return
-        }
-
         NotificationCenter.default.addObserver(self, selector: #selector(themeDidChange), name: .ThemeDidChange, object: nil)
     }
 
@@ -220,9 +217,10 @@ private extension BreadcrumbsViewController {
     }
 
     func refreshStyle() {
-        backgroundView.drawsTopBorder = true
-        backgroundView.borderColor = .simplenoteDividerColor
-        backgroundView.fillColor = .simplenoteStatusBarBackgroundColor
+        backgroundBox.boxType = .simplenoteSidebarBoxType
+        backgroundBox.fillColor = .simplenoteSecondaryBackgroundColor
+        dividerView.borderColor = .simplenoteDividerColor
+        dividerView.drawsTopBorder = true
     }
 
     func refreshRTLSupport() {

--- a/Simplenote/Main.storyboard
+++ b/Simplenote/Main.storyboard
@@ -517,79 +517,87 @@
                         <rect key="frame" x="0.0" y="0.0" width="294" height="28"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
-                            <customView translatesAutoresizingMaskIntoConstraints="NO" id="La0-hZ-ZgT" customClass="BackgroundView" customModule="Simplenote" customModuleProvider="target">
+                            <box borderType="none" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="mNr-a6-tCn" userLabel="BackgroundBox">
+                                <rect key="frame" x="-3" y="-4" width="300" height="34"/>
+                                <view key="contentView" id="k4p-IO-bew">
+                                    <rect key="frame" x="0.0" y="0.0" width="300" height="34"/>
+                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                </view>
+                            </box>
+                            <customView translatesAutoresizingMaskIntoConstraints="NO" id="La0-hZ-ZgT" userLabel="DividerView" customClass="BackgroundView" customModule="Simplenote" customModuleProvider="target">
                                 <rect key="frame" x="0.0" y="0.0" width="294" height="28"/>
+                            </customView>
+                            <stackView distribution="fill" orientation="horizontal" alignment="centerY" spacing="4" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1pF-Zy-2Tg">
+                                <rect key="frame" x="12" y="0.0" width="104" height="28"/>
                                 <subviews>
-                                    <stackView distribution="fill" orientation="horizontal" alignment="centerY" spacing="4" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1pF-Zy-2Tg">
-                                        <rect key="frame" x="12" y="0.0" width="104" height="28"/>
-                                        <subviews>
-                                            <textField horizontalHuggingPriority="1000" horizontalCompressionResistancePriority="1" verticalCompressionResistancePriority="1000" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="PLP-IN-gUi" userLabel="SearchTextField">
-                                                <rect key="frame" x="-2" y="7" width="41" height="14"/>
-                                                <textFieldCell key="cell" allowsUndo="NO" title="Search" usesSingleLineMode="YES" id="nCt-Ge-AWn">
-                                                    <font key="font" metaFont="smallSystem"/>
-                                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                                </textFieldCell>
-                                            </textField>
-                                            <textField horizontalHuggingPriority="1000" horizontalCompressionResistancePriority="1" verticalCompressionResistancePriority="1000" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VvK-y1-tIA" userLabel="TagStatusField">
-                                                <rect key="frame" x="39" y="7" width="23" height="14"/>
-                                                <textFieldCell key="cell" allowsUndo="NO" title="Tag" usesSingleLineMode="YES" id="wqh-AR-wEU">
-                                                    <font key="font" metaFont="smallSystem"/>
-                                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                                </textFieldCell>
-                                            </textField>
-                                            <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="lLQ-th-Ae1" userLabel="NoteImageView">
-                                                <rect key="frame" x="64" y="9" width="10" height="10"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="height" constant="10" id="NxU-uW-HSU"/>
-                                                    <constraint firstAttribute="width" constant="10" id="eLa-2o-qgw"/>
-                                                </constraints>
-                                                <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="icon_disclosure_right" id="xdx-nS-iDo"/>
-                                            </imageView>
-                                            <textField horizontalHuggingPriority="1000" horizontalCompressionResistancePriority="1" verticalCompressionResistancePriority="1000" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="afF-4l-Dvz" userLabel="NoteStatusField">
-                                                <rect key="frame" x="76" y="7" width="30" height="14"/>
-                                                <textFieldCell key="cell" allowsUndo="NO" title="Note" usesSingleLineMode="YES" id="XMY-cm-Ljb">
-                                                    <font key="font" metaFont="smallSystem"/>
-                                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                                </textFieldCell>
-                                            </textField>
-                                        </subviews>
+                                    <textField horizontalHuggingPriority="1000" horizontalCompressionResistancePriority="1" verticalCompressionResistancePriority="1000" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="PLP-IN-gUi" userLabel="SearchTextField">
+                                        <rect key="frame" x="-2" y="7" width="41" height="14"/>
+                                        <textFieldCell key="cell" allowsUndo="NO" title="Search" usesSingleLineMode="YES" id="nCt-Ge-AWn">
+                                            <font key="font" metaFont="smallSystem"/>
+                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                        </textFieldCell>
+                                    </textField>
+                                    <textField horizontalHuggingPriority="1000" horizontalCompressionResistancePriority="1" verticalCompressionResistancePriority="1000" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VvK-y1-tIA" userLabel="TagStatusField">
+                                        <rect key="frame" x="39" y="7" width="23" height="14"/>
+                                        <textFieldCell key="cell" allowsUndo="NO" title="Tag" usesSingleLineMode="YES" id="wqh-AR-wEU">
+                                            <font key="font" metaFont="smallSystem"/>
+                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                        </textFieldCell>
+                                    </textField>
+                                    <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="lLQ-th-Ae1" userLabel="NoteImageView">
+                                        <rect key="frame" x="64" y="9" width="10" height="10"/>
                                         <constraints>
-                                            <constraint firstAttribute="height" constant="28" id="VNe-Th-ZKN"/>
+                                            <constraint firstAttribute="height" constant="10" id="NxU-uW-HSU"/>
+                                            <constraint firstAttribute="width" constant="10" id="eLa-2o-qgw"/>
                                         </constraints>
-                                        <visibilityPriorities>
-                                            <integer value="1000"/>
-                                            <integer value="1000"/>
-                                            <integer value="1000"/>
-                                            <integer value="1000"/>
-                                        </visibilityPriorities>
-                                        <customSpacing>
-                                            <real value="3.4028234663852886e+38"/>
-                                            <real value="3.4028234663852886e+38"/>
-                                            <real value="3.4028234663852886e+38"/>
-                                            <real value="3.4028234663852886e+38"/>
-                                        </customSpacing>
-                                    </stackView>
+                                        <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="icon_disclosure_right" id="xdx-nS-iDo"/>
+                                    </imageView>
+                                    <textField horizontalHuggingPriority="1000" horizontalCompressionResistancePriority="1" verticalCompressionResistancePriority="1000" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="afF-4l-Dvz" userLabel="NoteStatusField">
+                                        <rect key="frame" x="76" y="7" width="30" height="14"/>
+                                        <textFieldCell key="cell" allowsUndo="NO" title="Note" usesSingleLineMode="YES" id="XMY-cm-Ljb">
+                                            <font key="font" metaFont="smallSystem"/>
+                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                        </textFieldCell>
+                                    </textField>
                                 </subviews>
                                 <constraints>
-                                    <constraint firstItem="1pF-Zy-2Tg" firstAttribute="top" secondItem="La0-hZ-ZgT" secondAttribute="top" id="5gv-uq-55C"/>
-                                    <constraint firstAttribute="bottom" secondItem="1pF-Zy-2Tg" secondAttribute="bottom" id="8Qe-ZS-byG"/>
-                                    <constraint firstItem="1pF-Zy-2Tg" firstAttribute="leading" secondItem="La0-hZ-ZgT" secondAttribute="leading" constant="12" id="GEr-YL-UTk"/>
-                                    <constraint firstItem="1pF-Zy-2Tg" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="La0-hZ-ZgT" secondAttribute="leading" constant="12" id="HgA-xK-ktY"/>
+                                    <constraint firstAttribute="height" constant="28" id="VNe-Th-ZKN"/>
                                 </constraints>
-                            </customView>
+                                <visibilityPriorities>
+                                    <integer value="1000"/>
+                                    <integer value="1000"/>
+                                    <integer value="1000"/>
+                                    <integer value="1000"/>
+                                </visibilityPriorities>
+                                <customSpacing>
+                                    <real value="3.4028234663852886e+38"/>
+                                    <real value="3.4028234663852886e+38"/>
+                                    <real value="3.4028234663852886e+38"/>
+                                    <real value="3.4028234663852886e+38"/>
+                                </customSpacing>
+                            </stackView>
                         </subviews>
                         <constraints>
+                            <constraint firstAttribute="bottom" secondItem="mNr-a6-tCn" secondAttribute="bottom" id="4zS-rd-ezW"/>
                             <constraint firstAttribute="trailing" secondItem="La0-hZ-ZgT" secondAttribute="trailing" id="IKz-vx-WCw"/>
                             <constraint firstAttribute="bottom" secondItem="La0-hZ-ZgT" secondAttribute="bottom" id="JgV-wf-bxz"/>
+                            <constraint firstItem="1pF-Zy-2Tg" firstAttribute="top" secondItem="WNl-MD-ENM" secondAttribute="top" id="VYQ-31-8cL"/>
+                            <constraint firstAttribute="trailing" secondItem="mNr-a6-tCn" secondAttribute="trailing" id="Yk5-RG-UUX"/>
+                            <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="1pF-Zy-2Tg" secondAttribute="trailing" constant="12" id="cES-O4-fyg"/>
+                            <constraint firstItem="mNr-a6-tCn" firstAttribute="top" secondItem="WNl-MD-ENM" secondAttribute="top" id="iti-9g-MH9"/>
+                            <constraint firstItem="mNr-a6-tCn" firstAttribute="leading" secondItem="WNl-MD-ENM" secondAttribute="leading" id="iuL-wp-BIi"/>
                             <constraint firstItem="La0-hZ-ZgT" firstAttribute="top" secondItem="WNl-MD-ENM" secondAttribute="top" id="jon-fw-SiV"/>
+                            <constraint firstAttribute="bottom" secondItem="1pF-Zy-2Tg" secondAttribute="bottom" id="rU8-cF-C8e"/>
+                            <constraint firstItem="1pF-Zy-2Tg" firstAttribute="leading" secondItem="WNl-MD-ENM" secondAttribute="leading" constant="12" id="sn0-hy-BSA"/>
                             <constraint firstItem="La0-hZ-ZgT" firstAttribute="leading" secondItem="WNl-MD-ENM" secondAttribute="leading" id="x0u-jc-2aX"/>
                         </constraints>
                     </view>
                     <connections>
-                        <outlet property="backgroundView" destination="La0-hZ-ZgT" id="rz6-TB-W8i"/>
+                        <outlet property="backgroundBox" destination="mNr-a6-tCn" id="Nx6-TT-Z9a"/>
+                        <outlet property="dividerView" destination="La0-hZ-ZgT" id="NaO-AB-tes"/>
                         <outlet property="noteImageView" destination="lLQ-th-Ae1" id="Tha-2R-3Ei"/>
                         <outlet property="noteTextField" destination="afF-4l-Dvz" id="Jas-lE-uxT"/>
                         <outlet property="searchTextField" destination="PLP-IN-gUi" id="Cbo-Qd-JXq"/>
@@ -598,7 +606,7 @@
                 </viewController>
                 <customObject id="qkg-c8-hZz" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="382" y="633"/>
+            <point key="canvasLocation" x="382" y="705"/>
         </scene>
         <!--Note Editor View Controller-->
         <scene sceneID="JcX-qD-6EF">
@@ -797,7 +805,7 @@
                             <constraint firstItem="3M9-OX-Hpx" firstAttribute="top" secondItem="w7Z-Cl-xvM" secondAttribute="top" id="igC-ZM-wQh"/>
                             <constraint firstItem="Dj2-Ut-m6l" firstAttribute="centerY" secondItem="w7Z-Cl-xvM" secondAttribute="centerY" id="nea-OO-Awf"/>
                             <constraint firstItem="mdt-4X-jeq" firstAttribute="top" secondItem="w7Z-Cl-xvM" secondAttribute="top" id="oil-IL-VG8"/>
-                            <constraint firstAttribute="bottom" secondItem="RoF-0f-Ugm" secondAttribute="bottom" id="qeu-Jg-mO9"/>
+                            <constraint firstItem="3M9-OX-Hpx" firstAttribute="bottom" secondItem="RoF-0f-Ugm" secondAttribute="bottom" id="pXb-pc-ZNb"/>
                             <constraint firstItem="3M9-OX-Hpx" firstAttribute="leading" secondItem="w7Z-Cl-xvM" secondAttribute="leading" id="wOf-bO-sHt"/>
                             <constraint firstItem="wyB-gA-z62" firstAttribute="bottom" secondItem="mdt-4X-jeq" secondAttribute="bottom" id="yAR-Ci-yly"/>
                             <constraint firstItem="wyB-gA-z62" firstAttribute="leading" secondItem="mdt-4X-jeq" secondAttribute="leading" id="yWO-3G-AGN"/>

--- a/Simplenote/NSColor+Theme.swift
+++ b/Simplenote/NSColor+Theme.swift
@@ -172,11 +172,6 @@ extension NSColor {
     }
 
     @objc
-    static var simplenoteStatusBarBackgroundColor: NSColor {
-        dynamicColor(lightStudio: .gray0, darkStudio: .darkGray2)
-    }
-
-    @objc
     static var simplenoteStatusBarTextColor: NSColor {
         NSColor(studioColor: .gray30)
     }

--- a/Simplenote/SplitItemMetrics.swift
+++ b/Simplenote/SplitItemMetrics.swift
@@ -79,6 +79,10 @@ enum SplitItemMetrics {
     ///
     static let headerMaximumAlphaGradientOffset = CGFloat(14)
 
+    /// SplitView Divider Insets
+    ///
+    static let notesDividerInsets = NSEdgeInsets(top: .zero, left: .zero, bottom: breadcrumbsViewHeight, right: .zero)
+
     /// Spacing required between the Window's Semaphore (Close / Minimize / Maximize) and the first View component
     ///
     static let toolbarSemaphorePaddingX = CGFloat(16)

--- a/Simplenote/SplitView.swift
+++ b/Simplenote/SplitView.swift
@@ -38,6 +38,14 @@ class SplitView: NSSplitView {
         }
     }
 
+    /// Map containing `Divider Index` > `Insets`
+    ///
+    var simplenoteDividerInsets: [Int: NSEdgeInsets] = [:] {
+        didSet {
+            needsDisplay = true
+        }
+    }
+
     // MARK: - Overridden Methods
 
     override var dividerThickness: CGFloat {
@@ -46,6 +54,31 @@ class SplitView: NSSplitView {
 
     override var dividerColor: NSColor {
         return simplenoteDividerColor
+    }
+
+    override func drawDivider(in rect: NSRect) {
+        guard let dividerIndex = indexOfDivider(in: rect), let insets = simplenoteDividerInsets[dividerIndex] else {
+            super.drawDivider(in: rect)
+            return
+        }
+
+        var updated         = rect
+        updated.origin.y    += insets.top
+        updated.size.height -= insets.top + insets.bottom
+        super.drawDivider(in: updated)
+    }
+
+    private func indexOfDivider(in rect: NSRect) -> Int? {
+        for dividerIndex in 0..<arrangedSubviews.count {
+            let min = minPossiblePositionOfDivider(at: dividerIndex)
+            let max = maxPossiblePositionOfDivider(at: dividerIndex)
+
+            if rect.minX >= min && rect.minX < max {
+                return dividerIndex
+            }
+        }
+
+        return nil
     }
 }
 

--- a/Simplenote/SplitViewController.swift
+++ b/Simplenote/SplitViewController.swift
@@ -214,6 +214,7 @@ extension SplitViewController {
         }
 
         splitView.simplenoteDividerColor = .simplenoteDividerColor
+        splitView.simplenoteDividerInsets = [SplitItemKind.notes.rawValue : SplitItemMetrics.notesDividerInsets]
     }
 }
 


### PR DESCRIPTION
### Fix
In this PR we're implementing Destop Tinting in the Status Bar area.

Closes #990


### Test
1. Launch the app!
2. Switch to Dark Mode

- [ ] Verify the Status Bar supports Desktop Tinting (should match the same behavior as in the Notes List)
- [ ] Verify that the app also looks great when you switch to Light Mode

### Release
These changes do not require release notes.
