### PR TITLE
Bugfix: Focus Mode Launch + Status Bar

### DIFF
--- a/Simplenote/TagListViewController+Swift.swift
+++ b/Simplenote/TagListViewController+Swift.swift
@@ -118,8 +118,24 @@ extension TagListViewController {
     }
 
     @objc
+    func startListeningToLaunchNotifications() {
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(finishedLaunching),
+                                               name: NSApplication.didFinishLaunchingNotification,
+                                               object: nil)
+    }
+
+    @objc
     func clipViewDidScroll(sender: Notification) {
         refreshHeaderSeparatorAlpha()
+    }
+
+    @objc
+    func finishedLaunching(sender: Notification) {
+        /// # Workaround:
+        /// -   Triggering this notification right here helps us avoid timming issues between Storyboard Instantiation and delegate setup.
+        /// -   This used to be a hook in `viewWillAppear`. But since the app can launch in Focus Mode directly (macOS State Restoration) we're forced to go nuclear.
+        notifyTagsListFilterDidChange()
     }
 
     @objc

--- a/Simplenote/TagListViewController.m
+++ b/Simplenote/TagListViewController.m
@@ -64,18 +64,10 @@ CGFloat const TagListEstimatedRowHeight                     = 30;
 
     [self startListeningToSettingsNotifications];
     [self startListeningToScrollNotifications];
+    [self startListeningToLaunchNotifications];
 
     [self loadTags];
     [self applyStyle];
-}
-
-- (void)viewWillAppear
-{
-    [super viewWillAppear];
-
-    // Workaround: Triggering this notification right here helps us avoid timming issues between Storyboard
-    // Instantiation and delegate setup.
-    [self notifyTagsListFilterDidChange];
 }
 
 - (void)viewWillLayout


### PR DESCRIPTION
### Fix
In this PR we're fixing a bug that caused the Status Bar not to display the selected filter.

### Details:
This glitch is caused by `viewWillAppear` not being invoked when State Restoration kicks in, and the app launches directly into Focus Mode.

Workaround ^ N, ideas on how to better address this one would be more than welcome!

**Thank yoouuu**

cc @eshurakov 

### Test
1. Launch Simplenote
2. Enter Focus Mode **(Option + Command + F)**
3. Press **Command Q** to quit the app
4. Relaunch Simplenote

- [x] Verify the Status Bar reads as `All Notes > [TITLE]`

### Release
These changes do not require release notes.
