### PR TITLE
Insert Checklists Validation

### DIFF
--- a/Simplenote/Base.lproj/MainMenu.xib
+++ b/Simplenote/Base.lproj/MainMenu.xib
@@ -631,7 +631,7 @@
                 <menuItem title="Format" id="THl-80-myZ">
                     <menu key="submenu" title="Format" id="5HH-LQ-Fk8">
                         <items>
-                            <menuItem title="Insert Checklist" keyEquivalent="C" id="iNS-zx-oXr">
+                            <menuItem title="Insert Checklist" keyEquivalent="C" identifier="editorChecklistMenuItem" id="iNS-zx-oXr">
                                 <attributedString key="userComments">
                                     <fragment content="Inserts a new Checklist"/>
                                 </attributedString>

--- a/Simplenote/NSUserInterfaceItemIdentifier+Simplenote.swift
+++ b/Simplenote/NSUserInterfaceItemIdentifier+Simplenote.swift
@@ -48,6 +48,7 @@ extension NSUserInterfaceItemIdentifier {
     /// Identifiers: Editor
     ///
     static let editorPinMenuItem            = NSUserInterfaceItemIdentifier(rawValue: "editorPinMenuItem")
+    static let editorChecklistMenuItem      = NSUserInterfaceItemIdentifier(rawValue: "editorChecklistMenuItem")
     static let editorMarkdownMenuItem       = NSUserInterfaceItemIdentifier(rawValue: "editorMarkdownMenuItem")
     static let editorCopyInterlinkMenuItem  = NSUserInterfaceItemIdentifier(rawValue: "editorCopyInterlinkMenuItem")
     static let editorShareMenuItem          = NSUserInterfaceItemIdentifier(rawValue: "editorShareMenuItem")

--- a/Simplenote/NoteEditorViewController+Swift.swift
+++ b/Simplenote/NoteEditorViewController+Swift.swift
@@ -367,6 +367,9 @@ extension NoteEditorViewController: NSMenuItemValidation {
         }
 
         switch identifier {
+        case .editorChecklistMenuItem:
+            return validateEditorChecklistMenuItem(menuItem)
+
         case .editorCopyInterlinkMenuItem:
             return validateEditorCopyInterlinkMenuItem(menuItem)
 
@@ -403,6 +406,10 @@ extension NoteEditorViewController: NSMenuItemValidation {
         default:
             return true
         }
+    }
+
+    func validateEditorChecklistMenuItem(_ item: NSMenuItem) -> Bool {
+        return isDisplayingNote && noteEditor.isFirstResponder
     }
 
     func validateEditorCopyInterlinkMenuItem(_ item: NSMenuItem) -> Bool {

--- a/Simplenote/ToolbarView.swift
+++ b/Simplenote/ToolbarView.swift
@@ -114,7 +114,7 @@ private extension ToolbarView {
     }
 
     func setupActionButtons() {
-        checklistsButton.toolTip = NSLocalizedString("Checklists", comment: "Tooltip: Insert Checklist")
+        checklistsButton.toolTip = NSLocalizedString("Insert Checklist", comment: "Tooltip: Insert Checklist")
         metricsButton.toolTip = NSLocalizedString("Metrics", comment: "Tooltip: Note Metrics")
         moreButton.toolTip = NSLocalizedString("More", comment: "Tooltip: More Actions")
         previewButton.toolTip = NSLocalizedString("Markdown Preview", comment: "Tooltip: Markdown Preview")


### PR DESCRIPTION
### Fix
In this PR we're updating the `Insert Checklist` macOS Menu Item validation.

cc @charliescheer another quick one! TY!
Closes #995

### Test: Enabled
1. Cilck over the Note Editor
2. Click over `Format`

- [x] Verify the **Insert Checklist** item is enabled

### Test: Disabled
1. Cilck over the Note Editor
2. Click anywhere in the Tags Editor area (bottom of the UI)
3. Click over `Format`

- [x] Verify the **Insert Checklist** item is disabled
- [x] Verify that the action remains disabled if you click on the Notes List or Tags List

### Release
These changes do not require release notes.
