### PR TITLE
Removed uppercase from h5/h6 in markdown preview

### DIFF
--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -456,6 +456,7 @@
 		BA4C6D16264CA8C000B723A7 /* SignupRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA4C6D15264CA8C000B723A7 /* SignupRemoteTests.swift */; };
 		BA4C6D18264CAAF800B723A7 /* URLRequest+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA4C6D17264CAAF800B723A7 /* URLRequest+Simplenote.swift */; };
 		BAA4854A25D5E22000F3BDB9 /* SearchQuery+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAA4854925D5E22000F3BDB9 /* SearchQuery+Simplenote.swift */; };
+		BAF8D5DC26AE3BE800CA9383 /* markdown-light.css in Resources */ = {isa = PBXBuildFile; fileRef = BAF8D5DB26AE3BE800CA9383 /* markdown-light.css */; };
 		CD6BC8FB4B8661C30318208C /* Pods_Automattic_SimplenoteTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 22D95A169BF4BF7DEABC4021 /* Pods_Automattic_SimplenoteTests.framework */; };
 		D0A1D693931CD24A56140DF7 /* Pods_Automattic_Simplenote.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0F7AA366214AF89DB7A1C687 /* Pods_Automattic_Simplenote.framework */; };
 		F998F3EB22853C29008C2B59 /* CrashLogging.swift in Sources */ = {isa = PBXBuildFile; fileRef = F998F3EA22853C29008C2B59 /* CrashLogging.swift */; };
@@ -829,6 +830,7 @@
 		BA4C6D15264CA8C000B723A7 /* SignupRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignupRemoteTests.swift; sourceTree = "<group>"; };
 		BA4C6D17264CAAF800B723A7 /* URLRequest+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLRequest+Simplenote.swift"; sourceTree = "<group>"; };
 		BAA4854925D5E22000F3BDB9 /* SearchQuery+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SearchQuery+Simplenote.swift"; sourceTree = "<group>"; };
+		BAF8D5DB26AE3BE800CA9383 /* markdown-light.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; path = "markdown-light.css"; sourceTree = "<group>"; };
 		F998F3EA22853C29008C2B59 /* CrashLogging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashLogging.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -1035,6 +1037,7 @@
 			children = (
 				37AE49C61FFEBB0B00FCB165 /* markdown-dark.css */,
 				37AE49C51FFEBB0A00FCB165 /* markdown-default.css */,
+				BAF8D5DB26AE3BE800CA9383 /* markdown-light.css */,
 			);
 			path = CSS;
 			sourceTree = "<group>";
@@ -1782,6 +1785,7 @@
 				B53ACDE425DD47BB00CF527A /* InterlinkViewController.xib in Resources */,
 				37AE49C91FFEBB0B00FCB165 /* markdown-dark.css in Resources */,
 				B5686D0E1AEAE6D7009F9E20 /* Images.xcassets in Resources */,
+				BAF8D5DC26AE3BE800CA9383 /* markdown-light.css in Resources */,
 				B58117D625B9D5F500927E0C /* AccountVerificationViewController.xib in Resources */,
 				B5C7DD43243E4A8E00BEE354 /* CollaborateViewController.xib in Resources */,
 				B5A89195231ECB3C0007EDCB /* LICENSE in Resources */,

--- a/Simplenote/CSS/markdown-default.css
+++ b/Simplenote/CSS/markdown-default.css
@@ -74,7 +74,6 @@ html {
 
 .note-detail-markdown h5, .note-detail-markdown h6 {
     font-size: 1em;
-    text-transform: uppercase;
 }
 
 .note-detail-markdown #title {

--- a/Simplenote/CSS/markdown-default.css
+++ b/Simplenote/CSS/markdown-default.css
@@ -32,7 +32,6 @@ html {
 
 ::-webkit-scrollbar-thumb {
     border-radius: 6px;
-    background: #84878a;
 }
 
 /* Same styles as app.simplenote.com/publish */
@@ -101,14 +100,9 @@ html {
     height: auto;
 }
 
-.note-detail-markdown a {
-    color: #4895d9;
-}
-
 .note-detail-markdown hr {
     border: 0;
     margin: 3.4em 0;
-    color: #4895d9;
     height: 1em;
 }
 
@@ -130,19 +124,13 @@ html {
     padding-left: 1.7em;
 }
 
-.note-detail-markdown code {
-    color: #899199;
-}
-
 .note-detail-markdown pre {
     padding: 1em;
     border-radius: 3px;
-    background: #f6f7f8;
 }
 
 .note-detail-markdown pre code {
     font-size: 85%;
-    color: #616870;
     background: transparent;
     width: 100%;
     overflow-x: auto;
@@ -157,12 +145,8 @@ html {
     width: 100%;
 }
 
-.note-detail-markdown table tr:nth-child(2n) {
-    background-color: #f6f7f8;
-}
-
 .note-detail-markdown table th, .note-detail-markdown table td {
-    border: 1px solid #c0c4c8;
+    border: 1px solid;
     padding: 6px 13px;
 }
 

--- a/Simplenote/CSS/markdown-light.css
+++ b/Simplenote/CSS/markdown-light.css
@@ -12,7 +12,7 @@
 }
 
 .note-detail-markdown code {
-    color: #84878a;
+    color: #899199;
 }
 
 .note-detail-markdown pre {
@@ -24,9 +24,9 @@
 }
 
 .note-detail-markdown table tr:nth-child(2n) {
-    background-color: #383d41;
+    background-color: #f6f7f8;
 }
 
 .note-detail-markdown table th, .note-detail-markdown table td {
-    border-color: #575e65;
+    border-color: #c0c4c8;
 }

--- a/Simplenote/SPMarkdownParser.m
+++ b/Simplenote/SPMarkdownParser.m
@@ -78,7 +78,7 @@
 
 + (NSString *)cssPath:(BOOL)isDarkMode
 {
-    return isDarkMode ? @"markdown-dark.css" : @"markdown-default.css";
+    return isDarkMode ? @"markdown-dark.css" : @"markdown-light.css";
 }
 
 + (NSString *)htmlFooter

--- a/Simplenote/SPMarkdownParser.m
+++ b/Simplenote/SPMarkdownParser.m
@@ -63,14 +63,20 @@
     headerStart = [headerStart stringByAppendingString:[NSString stringWithFormat:colorCSS, textHexColor]];
 
     NSString *headerEnd = @"</style></head><body><div class=\"note-detail-markdown\"><div id=\"static_content\">";
-    NSString *path = [self cssPathForDarkMode:isDarkMode];
-    NSString *css = [NSString stringWithContentsOfURL:[[NSBundle mainBundle] URLForResource:path withExtension:nil]
+
+    NSString *css = [NSString stringWithContentsOfURL:[[NSBundle mainBundle] URLForResource:@"markdown-default.css" withExtension:nil]
                                              encoding:NSUTF8StringEncoding error:nil];
+
+    NSString *colorCssPath = [self cssPath:isDarkMode];
+    NSString *colors = [NSString stringWithContentsOfURL:[[NSBundle mainBundle] URLForResource: colorCssPath withExtension:nil]
+                                                 encoding:NSUTF8StringEncoding error:nil];
+
+    css = [css stringByAppendingString:colors];
     
     return [[headerStart stringByAppendingString:css] stringByAppendingString:headerEnd];
 }
 
-+ (NSString *)cssPathForDarkMode:(BOOL)isDarkMode
++ (NSString *)cssPath:(BOOL)isDarkMode
 {
     return isDarkMode ? @"markdown-dark.css" : @"markdown-default.css";
 }

--- a/Simplenote/SPMarkdownParser.m
+++ b/Simplenote/SPMarkdownParser.m
@@ -67,7 +67,7 @@
     NSString *css = [NSString stringWithContentsOfURL:[[NSBundle mainBundle] URLForResource:@"markdown-default.css" withExtension:nil]
                                              encoding:NSUTF8StringEncoding error:nil];
 
-    NSString *colorCssPath = [self cssPath:isDarkMode];
+    NSString *colorCssPath = [self cssPathForDarkMode:isDarkMode];
     NSString *colors = [NSString stringWithContentsOfURL:[[NSBundle mainBundle] URLForResource: colorCssPath withExtension:nil]
                                                  encoding:NSUTF8StringEncoding error:nil];
 
@@ -76,7 +76,7 @@
     return [[headerStart stringByAppendingString:css] stringByAppendingString:headerEnd];
 }
 
-+ (NSString *)cssPath:(BOOL)isDarkMode
++ (NSString *)cssPathForDarkMode:(BOOL)isDarkMode
 {
     return isDarkMode ? @"markdown-dark.css" : @"markdown-light.css";
 }


### PR DESCRIPTION
### Fix
This PR fixes #1002  

Currently H5 and H6 headings in markdown preview are forced to be uppercase.  We decided to remove that uppercase.

Also this PR reorganizes the css so that the colors are in their own file which will simplify updates to the css in the future

### Test
1. In a note with markdown preview, add some text that uses H5 and H6 
2. display the preview and make sure that the text is not uppercased
3. also check and make sure both dark mode and light mode are loading the correct CSS in preview

### Review
***(Required)*** Add instructions for reviewers.  For example:
> Only one developer is required to review these changes, but anyone can perform the review.

### Release
> These changes do not require release notes.
