### PR TITLE
Fixing Format String

### DIFF
--- a/Simplenote/BreadcrumbsViewController.swift
+++ b/Simplenote/BreadcrumbsViewController.swift
@@ -165,7 +165,8 @@ extension BreadcrumbsViewController {
     }
 
     func notesControllerDidSelectNotes(_ notes: [Note]) {
-        statusForNotes = NSLocalizedString("\(notes.count) Selected", comment: "Presented when there are multiple selected notes")
+        let formatString = NSLocalizedString("%d Selected", comment: "Presented when there are multiple selected notes")
+        statusForNotes = String.localizedStringWithFormat(formatString, notes.count)
     }
 
     func notesControllerDidSelectZeroNotes() {


### PR DESCRIPTION
### Fix
In this PR we're replacing Swift String Interpolation with Format Strings, since GlotPress goes haywire!

cc @charliescheer / @eshurakov (Thanks in advance!!)

### Test
1. Launch Simplenote
2. Make sure the Status Bar is enabled
3. Press CMD + Click over multiple notes

- [x] Verify the Status Bar reads as `N Selected`

### Release
These changes do not require release notes.
