### PR TITLE
Track `Package.resolved` file

### DIFF
--- a/Simplenote.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Simplenote.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,34 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "SimplenoteFoundation",
+        "repositoryURL": "git@github.com:Automattic/SimplenoteFoundation-Swift.git",
+        "state": {
+          "branch": null,
+          "revision": "2731e4d28c42d394ddc62cd864d9f7ff96759228",
+          "version": "1.3.0"
+        }
+      },
+      {
+        "package": "SimplenoteInterlinks",
+        "repositoryURL": "git@github.com:Automattic/SimplenoteInterlinks-Swift.git",
+        "state": {
+          "branch": null,
+          "revision": "be3827a5bf05c5349ed62126c3e1dc60a2a6cee6",
+          "version": "1.1.0"
+        }
+      },
+      {
+        "package": "SimplenoteSearch",
+        "repositoryURL": "git@github.com:Automattic/SimplenoteSearch-Swift.git",
+        "state": {
+          "branch": null,
+          "revision": "499d2809d169fcbeb9ff75568d9f1f937f290ffc",
+          "version": "1.3.0"
+        }
+      }
+    ]
+  },
+  "version": 1
+}


### PR DESCRIPTION
This file is useful to ensure all developers fetching the project from Git use the _resolved_ version of the Swift packages. This is the same concept as `Gemfile.lock`, `Podfile.lock`, `package-lock.json`, etc.

See discussion at https://github.com/woocommerce/woocommerce-ios/pull/4392#discussion_r648001032

### Test
I think the fact that CI builds the app and the test pass is proof enough that the change is harmless. I'm pretty sure anyone who built the app locally would have this file there already, and it's something that Xcode generates, not a custom file I added.

Still, maybe it's worth checking out the PR locally and see if it builds?

### Review
Only one developer required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.