### PR TITLE
[Tooling] Fix hotfix lanes

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -182,7 +182,7 @@ end
   #####################################################################################
   # new_hotfix_release
   # -----------------------------------------------------------------------------------
-  # This lane updates the release branch for a new hotix release.
+  # This lane creates the release branch for a new hotfix release.
   # -----------------------------------------------------------------------------------
   # Usage:
   # bundle exec fastlane new_hotfix_release [skip_confirm:<skip confirm>] [version:<version>]
@@ -191,11 +191,28 @@ end
   # bundle exec fastlane new_hotfix_release version:10.6.1
   # bundle exec fastlane new_hotfix_release skip_confirm:true version:10.6.1
   #####################################################################################
-  desc "Creates a new hotfix branch from the given tag"
+  desc 'Creates a new hotfix branch for the given version:x.y.z. The branch will be cut from the tag x.y of the previous release'
   lane :new_hotfix_release do | options |
     prev_ver = ios_hotfix_prechecks(options)
     ios_bump_version_hotfix(previous_version: prev_ver, version: options[:version])
-    ios_tag_build()
+  end
+
+  #####################################################################################
+  # finalize_hotfix_release
+  # -----------------------------------------------------------------------------------
+  # This lane finalizes the hotfix branch.
+  # -----------------------------------------------------------------------------------
+  # Usage:
+  # bundle exec fastlane finalize_hotfix_release [skip_confirm:<skip confirm>]
+  #
+  # Example:
+  # bundle exec fastlane finalize_hotfix_release skip_confirm:true
+  #####################################################################################
+  desc 'Performs the final checks and triggers a release build for the hotfix in the current branch'
+  lane :finalize_hotfix_release do |options|
+    ios_finalize_prechecks(options)
+    version = ios_get_app_version
+    trigger_release_build(branch_to_build: "release/#{version}")
   end
 
   #####################################################################################
@@ -213,11 +230,12 @@ end
   #####################################################################################
   desc 'Does the necessary build and metadata updates then triggers an App Store deployment'
   lane :finalize_release do | options |
+    UI.user_error!('To finalize a hotfix, please use the finalize_hotfix_release lane instead') if ios_current_branch_is_hotfix
+
     ios_finalize_prechecks(options)
-    unless ios_current_branch_is_hotfix
-      ios_update_metadata(options)
-      ios_bump_version_beta()
-    end
+    
+    ios_update_metadata(options)
+    ios_bump_version_beta()
 
     trigger_app_store_ci_build(branch_to_build: "release/#{ios_get_app_version()}")
   end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -237,7 +237,7 @@ end
     ios_update_metadata(options)
     ios_bump_version_beta()
 
-    trigger_app_store_ci_build(branch_to_build: "release/#{ios_get_app_version()}")
+    trigger_release_build(branch_to_build: "release/#{ios_get_app_version()}")
   end
 
   #####################################################################################
@@ -399,14 +399,14 @@ end
   end
 
   #############################################################################
-  # trigger_app_store_ci_build
+  # trigger_release_build
   # ---------------------------------------------------------------------------
   # This lane triggers a build for App Store distribution on CI
   # ---------------------------------------------------------------------------
   # Usage:
   # bundle exec fastlane trigger_release_build [branch_to_build:<branch_name>]
   #############################################################################
-  lane :trigger_app_store_ci_build do | options |
+  lane :trigger_release_build do | options |
     circleci_trigger_job(
       circle_ci_token: ENV["CIRCLE_CI_AUTH_TOKEN"],
       repository: REPOSITORY_NAME,


### PR DESCRIPTION
Part of the paaHJt-1WQ-p2 project.

## To test

 - Checkout this branch, run `bundle install`
 - Run `bundle exec fastlane new_hotfix_release version:2.13.1`
 - Verify that it cut a `release/2.13.1` branch from the `2.13` tag
 - Verify that it bumped the version in `Version.public.xcconfig` and `fastlane/Deliverfile` (*)
 - cherry-pick all the commits from this PR on top of the `release/2.13.1` branch. This is because we are gonna test the updated finalize lanes, and need to be on the hotfix release branch to test them. (You might get conflicts during the cherry-pick)
 - [Open the CircleCI page for SNmacOS](https://app.circleci.com/pipelines/github/Automattic/simplenote-macos) in advance, to be ready to cancel the release build
 - Run `bundle exec fastlane finalize_release`. You should get an error telling you that you should use `finalize_hotfix_release` for hotfix branches instead
 - Run `bundle exec fastlane finalize_hotfix_release` and verify that it triggered a release build, and that is is building it from the release/2.13.1 hotfix branch. Cancel the CI build immediately.
 - Delete the `release/2.13.1` branch (from both local and remote)

## A note on Deliverfile bump

@mokagio is working on removing the `Deliverfile` – see https://github.com/wordpress-mobile/release-toolkit/pull/287 – in our repos, to run `deliver` as part of a lane to which we'll explicitly pass the right parameters, including the version, hence the bump not needing to change the app version in `Deliverfile` anymore in the future.

This means that once @mokagio's work lands, the hotfix lanes will need to be amended again, to specify that the `Deliverfile` should not be updated as part of any version bump… including hotfix ones. This work will be done separately to the hotfix alignment work from this PR, to avoid postponing things too much and blocking the project.