### PR TITLE
Move swift secrets outside of the repository

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,13 +11,6 @@ parameters:
 
 # Reusable sets of steps
 commands:
-  copy_demo_credentials:
-    steps:
-      - run:
-          name: Copy Demo SPCredentials
-          command: |
-            mkdir -p Simplenote/Credentials
-            cp Simplenote/SPCredentials-demo.swift Simplenote/Credentials/SPCredentials.swift
   setup_environment:
     steps:
       - checkout
@@ -40,7 +33,6 @@ jobs:
       xcode-version: "12.4.0"
     steps:
       - setup_environment
-      - copy_demo_credentials
       - run:
           name: Build & Test
           command: bundle exec fastlane test
@@ -58,7 +50,6 @@ jobs:
     executor: *xcode_image
     steps:
       - setup_environment
-      - copy_demo_credentials
       - run:
           name: Verify App Store Target Builds
           command: bundle exec fastlane test_app_store_build

--- a/.configure
+++ b/.configure
@@ -5,7 +5,7 @@
   "files_to_copy": [
     {
       "file": "macOS/simplenote/SPCredentials.swift",
-      "destination": "Simplenote/Credentials/SPCredentials.swift",
+      "destination": "~/.configure/simplenote-macos/secrets/SPCredentials.swift",
       "encrypt": true
     },
     {

--- a/Scripts/Build-Phases/copy-secret.sh
+++ b/Scripts/Build-Phases/copy-secret.sh
@@ -1,0 +1,38 @@
+#!/bin/bash -o pipefail
+
+SOURCE_PATH=$1
+TARGET_PATH=$2
+
+USAGE="error: Usage $0 source_path target_path"
+
+if [[ -z ${SOURCE_PATH:+x} || -z ${TARGET_PATH:+x} ]]; then
+  echo $USAGE
+  exit 1
+fi
+
+# From now on, fail on unbound variables. Didn't do it earlier to show the
+# usage message.
+set -u
+
+git check-ignore "${TARGET_PATH}" > /dev/null
+GIT_IGNORE_EXIT_CODE=$?
+if [ $GIT_IGNORE_EXIT_CODE -ne 0 ]; then
+    echo "error: Attempting to store secret file in path that is not ignored by Git (${TARGET_PATH})."
+    exit 1
+fi
+
+# From now on, fail the script if there's an error.
+# We didn't do it above because we wanted to track the `git check-ignore` exit
+# code.
+set -e
+
+if [ ! -f ${SOURCE_PATH} ]; then
+    echo "error: Unable to copy credentials. Could not find ${SOURCE_PATH}."
+    exit 1
+else
+    echo "Copying credentials..."
+    mkdir -p $(dirname $TARGET_PATH)
+    cp ${SOURCE_PATH} ${TARGET_PATH}
+fi
+
+echo "✅ Copied secret at ${SOURCE_PATH} to ${TARGET_PATH}"

--- a/Scripts/Build-Phases/copy-secret.sh
+++ b/Scripts/Build-Phases/copy-secret.sh
@@ -1,38 +1,84 @@
-#!/bin/bash -o pipefail
+#!/bin/bash -euo pipefail
 
-SOURCE_PATH=$1
-TARGET_PATH=$2
-
-USAGE="error: Usage $0 source_path target_path"
-
-if [[ -z ${SOURCE_PATH:+x} || -z ${TARGET_PATH:+x} ]]; then
-  echo $USAGE
-  exit 1
-fi
-
-# From now on, fail on unbound variables. Didn't do it earlier to show the
-# usage message.
-set -u
-
-git check-ignore "${TARGET_PATH}" > /dev/null
-GIT_IGNORE_EXIT_CODE=$?
-if [ $GIT_IGNORE_EXIT_CODE -ne 0 ]; then
-    echo "error: Attempting to store secret file in path that is not ignored by Git (${TARGET_PATH})."
+# To help the Xcode build system optimize the build, we want to ensure each of
+# the secrets we want to copy is defined as an input file for the run script
+# build phase.
+#
+# > The Xcode Build System will use [these files] to determine if your run
+# > scripts should actually run or not. So this should include any file that
+# > your run script phase, the script content, is actually going to read or
+# > look at during its process.
+#
+# > If you have no input files declared, the Xcode build system will need to
+# > run your run script phase on every single build.
+#
+# https://developer.apple.com/videos/play/wwdc2018/408/
+function ensure_is_in_input_files_list() {
+  # Loop through the file input lists looking for $1. If not found, fail the
+  # build.
+  if [ -z "$1" ]; then
+    echo "error: Input file list verification needs a path to verify!"
     exit 1
-fi
+  fi
+  file_to_find=$1
 
-# From now on, fail the script if there's an error.
-# We didn't do it above because we wanted to track the `git check-ignore` exit
-# code.
-set -e
-
-if [ ! -f ${SOURCE_PATH} ]; then
-    echo "error: Unable to copy credentials. Could not find ${SOURCE_PATH}."
+  if [ $SCRIPT_INPUT_FILE_LIST_COUNT -eq 0 ]; then
+    echo "error: No input file list given (.xcfilelist). Cannot continue."
     exit 1
-else
-    echo "Copying credentials..."
-    mkdir -p $(dirname $TARGET_PATH)
-    cp ${SOURCE_PATH} ${TARGET_PATH}
+  fi
+
+  i=0
+  found=false
+  while [[ $i -lt $SCRIPT_INPUT_FILE_LIST_COUNT && "$found" = false ]]
+  do
+    # Need this two step process to access the input at index
+    file_list_resolved_var_name=SCRIPT_INPUT_FILE_LIST_${i}
+    # The following reads the processed xcfilelist line by line looking for
+    # the given file
+    while read input_file; do
+      if [ "$file_to_find" == "$input_file" ]; then
+        found=true
+        break
+      fi
+    done <"${!file_list_resolved_var_name}"
+    let i=i+1
+  done
+  if [ "$found" = false ]; then
+    echo "error: Could not find $file_to_find as an input to the build phase. Add $file_to_find to the input files list using the .xcfilelist."
+    exit 1
+  fi
+}
+
+SECRETS_ROOT="${HOME}/.configure/simplenote-macos/secrets"
+SECRETS_FILE="${SECRETS_ROOT}/SPCredentials.swift"
+EXAMPLE_SECRETS_FILE="${SRCROOT}/Simplenote/SPCredentials-demo.swift"
+
+ensure_is_in_input_files_list $SECRETS_FILE
+ensure_is_in_input_files_list $EXAMPLE_SECRETS_FILE
+
+SECRETS_DESTINATION_FILE="${SRCROOT}/Simplenote/Credentials/SPCredentials.swift"
+mkdir -p $(dirname "$SECRETS_DESTINATION_FILE")
+
+if [ -f "$SECRETS_FILE" ]; then
+    echo "Applying Production Secrets"
+    cp -v "$SECRETS_FILE" "${SECRETS_DESTINATION_FILE}"
+    exit 0
 fi
 
-echo "✅ Copied secret at ${SOURCE_PATH} to ${TARGET_PATH}"
+# No secrets file found. Use the example secrets file as a last resort, unless
+# building for Release.
+
+COULD_NOT_FIND_SECRET_MSG="Could not find secrets file at ${SECRETS_DESTINATION_FILE}. This is likely due to the source secrets being missing from ${SECRETS_ROOT}"
+INTERNAL_CONTRIBUTOR_MSG="If you are an internal contributor, run \`bundle exec fastlane run configure_apply\` to update your secrets"
+
+case $CONFIGURATION in
+  Release)
+    echo "error: $COULD_NOT_FIND_SECRET_MSG. Cannot continue Release build. $INTERNAL_CONTRIBUTOR_MSG and try again. External contributors should not need to perform a Release build."
+    exit 1
+    ;;
+  *)
+    echo "warning: $COULD_NOT_FIND_SECRET_MSG. Falling back to $EXAMPLE_SECRETS_FILE. In a Release build, this would be an error. $INTERNAL_CONTRIBUTOR_MSG and try again. If you are an external contributor, you can ignore this warning."
+    echo "Applying Example Secrets"
+    cp -v "$EXAMPLE_SECRETS_FILE" "$SECRETS_DESTINATION_FILE"
+    ;;
+esac

--- a/Scripts/Build-Phases/copy-secret.xcfilelist
+++ b/Scripts/Build-Phases/copy-secret.xcfilelist
@@ -1,0 +1,7 @@
+# Inputs for the build phase run script marshalling the secrets for the app,
+# currently running from the SimplenoteSecrets aggregate targets
+${HOME}/.configure/simplenote-macos/secrets/SPCredentials.swift
+${SRCROOT}/Simplenote/SPCredentials-demo.swift
+# Add the script itself as an input, so the build system will know to run it
+# if it changes
+${SRCROOT}/Scripts/Build-Phases/copy-secret.sh

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -1973,7 +1973,7 @@
 			inputFileListPaths = (
 			);
 			inputPaths = (
-				"~/.mobile-secrets/macOS/simplenote/SPCredentials.swift",
+				"${HOME}/.mobile-secrets/macOS/simplenote/SPCredentials.swift",
 			);
 			outputFileListPaths = (
 			);
@@ -1982,7 +1982,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "SOURCE_PATH=~/.mobile-secrets/macOS/simplenote/SPCredentials.swift\nTARGET_FOLDER=${SRCROOT}/Simplenote/Credentials\nTARGET_PATH=${TARGET_FOLDER}/SPCredentials.swift\n\nif [ ! -f ${SOURCE_PATH} ]; then\n    echo \"Unable to Copy Credentials =(\"\nelse\n    echo \"Copying Credentials...\"\n    mkdir -p ${TARGET_FOLDER}\n    cp ${SOURCE_PATH} ${TARGET_PATH}\nfi\n";
+			shellScript = "${SRCROOT}/Scripts/Build-Phases/copy-secret.sh \\\n    $SCRIPT_INPUT_FILE_0 \\\n    $SCRIPT_OUTPUT_FILE_0\n";
 		};
 		BCBFB16555965D73674605BA /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -1971,9 +1971,9 @@
 			files = (
 			);
 			inputFileListPaths = (
+				"${SRCROOT}/Scripts/Build-Phases/copy-secret.xcfilelist",
 			);
 			inputPaths = (
-				"${HOME}/.mobile-secrets/macOS/simplenote/SPCredentials.swift",
 			);
 			outputFileListPaths = (
 			);
@@ -1982,7 +1982,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "${SRCROOT}/Scripts/Build-Phases/copy-secret.sh \\\n    $SCRIPT_INPUT_FILE_0 \\\n    $SCRIPT_OUTPUT_FILE_0\n";
+			shellScript = "${SRCROOT}/Scripts/Build-Phases/copy-secret.sh\n";
 		};
 		BCBFB16555965D73674605BA /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -95,6 +95,7 @@ end
 
 desc 'Builds the app using the App Store target but without code signing, just to check the target builds'
 lane :test_app_store_build do | options |
+  configure_apply
   build_simplenote(codesign: false)
 end
 


### PR DESCRIPTION
Moves the `SPCredentials.swift` secret outside of the repository. Similar to what we did in https://github.com/wordpress-mobile/WordPress-iOS/pull/16806.

### To Test

1. Checkout this branch
2. Build the app, you should get a warning

<img width="1904" alt="Screen Shot 2021-08-04 at 11 28 01 pm" src="https://user-images.githubusercontent.com/1218433/128189203-c8a0fafc-d5db-4fde-a54a-245a8ea398a9.png">

3. Run `bundle exec fastlane run configure_apply`
4. Verify that `SPCredentials.swift` is now in `~/.configure/simplenote-macos/secrets`
4. Build the app again, the warning should be gone

### Review
Only one developer required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.