### PR TITLE
Issue/password verification

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,6 @@
 2.15
 -----
-
+-   [Internal] added login alert for compromised password #1017
 
 2.14
 -----

--- a/Simplenote/AuthViewController+Swift.swift
+++ b/Simplenote/AuthViewController+Swift.swift
@@ -194,10 +194,10 @@ extension AuthViewController {
     @objc
     func showCompromisedPasswordAlert(for window: NSWindow, completion: @escaping (NSApplication.ModalResponse) -> Void) {
         let alert = NSAlert()
-        alert.messageText = "Compromised Password"
-        alert.informativeText = "This password has appeared in a data breach, which puts your account at high risk of compromise. It is recommended that you change your password immediately."
-        alert.addButton(withTitle: "Change Password")
-        alert.addButton(withTitle: "Not Now")
+        alert.messageText = Localization.compromisedPasswordAlert
+        alert.informativeText = Localization.compromisedPasswordMessage
+        alert.addButton(withTitle: Localization.changePasswordAction)
+        alert.addButton(withTitle: Localization.dismissChangePasswordAction)
 
         alert.beginSheetModal(for: window, completionHandler: completion)
     }
@@ -229,4 +229,8 @@ private enum Localization {
     static let signUpTip = NSLocalizedString("Need an account?", comment: "Link to create an account")
     static let forgotAction = NSLocalizedString("Forgot your Password?", comment: "Forgot Password Button")
     static let dotcomSSOAction = NSLocalizedString("Log in with WordPress.com", comment: "button title for wp.com sign in button")
+    static let compromisedPasswordAlert = NSLocalizedString("Compromised Password", comment: "Compromised passsword alert title")
+    static let compromisedPasswordMessage = NSLocalizedString("This password has appeared in a data breach, which puts your account at high risk of compromise. It is recommended that you change your password immediately.", comment: "Compromised password alert message")
+    static let changePasswordAction = NSLocalizedString("Change Password", comment: "Change password action")
+    static let dismissChangePasswordAction = NSLocalizedString("Not Now", comment: "Dismiss change password alert action")
 }

--- a/Simplenote/AuthViewController+Swift.swift
+++ b/Simplenote/AuthViewController+Swift.swift
@@ -168,7 +168,7 @@ extension AuthViewController {
             if success {
                 self.presentSignupVerification(email: email)
             } else {
-                self.showAuthenticationError(forCode: statusCode)
+                self.showAuthenticationError(forCode: statusCode, responseString: nil)
             }
 
             self.stopSignupAnimation()
@@ -188,6 +188,20 @@ extension AuthViewController {
     }
 }
 
+// MARK: - Compromised Password
+//
+extension AuthViewController {
+    @objc
+    func showCompromisedPasswordAlert(for window: NSWindow, completion: @escaping (NSApplication.ModalResponse) -> Void) {
+        let alert = NSAlert()
+        alert.messageText = "Compromised Password"
+        alert.informativeText = "This password has appeared in a data breach, which puts your account at high risk of compromise. It is recommended that you change your password immediately."
+        alert.addButton(withTitle: "Change Password")
+        alert.addButton(withTitle: "Not Now")
+
+        alert.beginSheetModal(for: window, completionHandler: completion)
+    }
+}
 
 // MARK: - Metrics
 //

--- a/Simplenote/AuthViewController.h
+++ b/Simplenote/AuthViewController.h
@@ -33,6 +33,6 @@
 - (void)stopSignupAnimation;
 
 - (void)presentPasswordResetAlert;
-- (void)showAuthenticationErrorForCode:(NSInteger)responseCode;
+- (void)showAuthenticationErrorForCode:(NSInteger)responseCode responseString:(NSString *)responseString;
 
 @end

--- a/Simplenote/AuthViewController.m
+++ b/Simplenote/AuthViewController.m
@@ -336,10 +336,11 @@ static NSString *SPAuthSessionKey = @"SPAuthSessionKey";
 -(void)process401FromResponseString:(NSString *)responseString
 {
     if ([responseString  isEqual:@"compromised password"]) {
+        __weak typeof(self) weakSelf = self;
         [self showCompromisedPasswordAlertFor:NSApplication.sharedApplication.windows.lastObject
                                    completion:^(NSModalResponse response)  {
             if (response == NSAlertFirstButtonReturn) {
-                [self openResetPasswordURL];
+                [weakSelf openResetPasswordURL];
             }
         }];
         return;

--- a/Simplenote/AuthViewController.m
+++ b/Simplenote/AuthViewController.m
@@ -333,9 +333,9 @@ static NSString *SPAuthSessionKey = @"SPAuthSessionKey";
     }
 }
 
--(void)process401FromResponseString: (NSString *)responseString
+-(void)process401FromResponseString:(NSString *)responseString
 {
-    if ([responseString  isEqual: @"compromised password"]) {
+    if ([responseString  isEqual:@"compromised password"]) {
         [self showCompromisedPasswordAlertFor:NSApplication.sharedApplication.windows.lastObject
                                    completion:^(NSModalResponse response)  {
             if (response == NSAlertFirstButtonReturn) {

--- a/Simplenote/AuthViewController.m
+++ b/Simplenote/AuthViewController.m
@@ -324,7 +324,11 @@ static NSString *SPAuthSessionKey = @"SPAuthSessionKey";
             [self.view.window makeFirstResponder:self.usernameField];
             break;
         case 401:
-            [self process401FromResponseString:responseString];
+            if ([self isPasswordCompromisedResponse:responseString]) {
+                [self presentPasswordCompromisedAlert];
+            } else {
+                [self showAuthenticationError:NSLocalizedString(@"Bad email or password", @"Error for bad email or password")];
+            }
             break;
 
         default:
@@ -333,20 +337,20 @@ static NSString *SPAuthSessionKey = @"SPAuthSessionKey";
     }
 }
 
--(void)process401FromResponseString:(NSString *)responseString
+- (BOOL)isPasswordCompromisedResponse:(NSString *)responseString
 {
-    if ([responseString  isEqual:@"compromised password"]) {
-        __weak typeof(self) weakSelf = self;
-        [self showCompromisedPasswordAlertFor:NSApplication.sharedApplication.windows.lastObject
-                                   completion:^(NSModalResponse response)  {
-            if (response == NSAlertFirstButtonReturn) {
-                [weakSelf openResetPasswordURL];
-            }
-        }];
-        return;
-    }
+   return ([responseString isEqual:@"compromised password"]);
+}
 
-    [self showAuthenticationError:NSLocalizedString(@"Bad email or password", @"Error for bad email or password")];
+-(void)presentPasswordCompromisedAlert
+{
+    __weak typeof(self) weakSelf = self;
+    [self showCompromisedPasswordAlertFor:self.view.window
+                               completion:^(NSModalResponse response)  {
+        if (response == NSAlertFirstButtonReturn) {
+            [weakSelf openResetPasswordURL];
+        }
+    }];
 }
 
 #pragma mark - NSTextView

--- a/Simplenote/AuthViewController.m
+++ b/Simplenote/AuthViewController.m
@@ -336,7 +336,7 @@ static NSString *SPAuthSessionKey = @"SPAuthSessionKey";
 -(void)process401FromResponseString: (NSString *)responseString
 {
     if ([responseString  isEqual: @"compromised password"]) {
-        [self showCompromisedPasswordAlertFor:SimplenoteAppDelegate.sharedDelegate.window
+        [self showCompromisedPasswordAlertFor:NSApplication.sharedApplication.windows.lastObject
                                    completion:^(NSModalResponse response)  {
             if (response == NSAlertFirstButtonReturn) {
                 [self openResetPasswordURL];


### PR DESCRIPTION
### Fix
This pr adds a case to SPAuthError that can see if a user's password has been found in a compromised password database.  If it has, the user is prompted to change their password before they can log into their account.

<img src="https://cdn-std.droplr.net/files/acc_593859/BwrqDc" />

### Test
Internal reference for testing steps. 
p1628654849033800-slack-C01KRRK0MLJ

### Review
***(Required)*** Add instructions for reviewers.  For example:
> Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
***(Required)*** Add a concise statement to `RELEASE-NOTES.txt` if the changes should be included in release notes. Include details about updating the notes in this section. For example:
> `RELEASE-NOTES.txt` was updated in 903316 with:
>  > -   [Internal] added login alert for compromised password #1017