### PR TITLE
Updated expected body for verification required

### DIFF
--- a/Simplenote/AuthViewController.m
+++ b/Simplenote/AuthViewController.m
@@ -350,7 +350,7 @@ static NSString *SPAuthSessionKey = @"SPAuthSessionKey";
 
 - (BOOL)isRequiresVerificationdResponse:(NSString *)responseString
 {
-   return ([responseString isEqual:@"requires verification"]);
+   return ([responseString isEqual:@"verification required"]);
 }
 
 -(void)presentPasswordCompromisedAlert


### PR DESCRIPTION
### Fix
This is a quick PR to update to the key for verification required.

Previously the expected response that had been added to the error was not correct.  It was `requires verification` which is not the correct key.  I have updated it to `verification required` 

### Test
1. Setup some sort of proxy system like Charles to interrupt responses from the auth endpoint
2. modify the response to be a 403 error with a body of `verification required` 
3. You should see an alert with instructions for resending a verification

### Review
***(Required)*** Add instructions for reviewers.  For example:
> Only one developer is required to review these changes, but anyone can perform the review.

### Release
***(Required)*** Add a concise statement to `RELEASE-NOTES.txt` if the changes should be included in release notes. Include details about updating the notes in this section. For example:
> These changes do not require release notes.
