### PR TITLE
Updated copy for account deletion alert message to include user email

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,6 @@
 2.16
 -----
-
+- Updated the account deletion flow for clarity #1026
 
 2.15
 -----

--- a/Simplenote/AccountDeletionController.swift
+++ b/Simplenote/AccountDeletionController.swift
@@ -14,7 +14,7 @@ class AccountDeletionController: NSObject {
 
     @objc
     func requestAccountDeletion(for user: SPUser, with window: Window) {
-        let alert = NSAlert(messageText: Constants.deleteAccount, informativeText: Constants.confirmAlertMessage)
+        let alert = NSAlert(messageText: Constants.deleteAccount, informativeText: Constants.confirmAlertMessage(with: user.email))
 
         alert.alertStyle = .critical
         alert.addButton(withTitle: Constants.deleteAccountButton)
@@ -51,8 +51,11 @@ class AccountDeletionController: NSObject {
 }
 
 private struct Constants {
+    static func confirmAlertMessage(with email: String) -> String {
+        String(format: confirmAlertTemplate, email)
+    }
     static let deleteAccount = NSLocalizedString("Delete Account", comment: "Delete account title and action")
-    static let confirmAlertMessage = NSLocalizedString("By deleting your account, all notes created with this account will be permanently deleted. This action is not reversible.", comment: "Delete account confirmation alert message")
+    static let confirmAlertTemplate = NSLocalizedString("By deleting the account for %@, all notes created with this account will be permanently deleted. This action is not reversible.", comment: "Delete account confirmation alert message")
     static let deleteAccountButton = NSLocalizedString("Request Account Deletion", comment: "Title for account deletion confirm button")
     static let cancel = NSLocalizedString("Cancel", comment: "Cancel button title")
 


### PR DESCRIPTION
### Fix
This is a quick update that fixes #1023 

Currently the alert message that appears when a user tries to delete their account does not include any details that identify their account.  This update adds their email address to the alert message for clarity

<img src="https://cdn-std.droplr.net/files/acc_593859/VsABnj" />

### Test
1. go to the menu Simplenote -> Delete Account
2. an alert will appear that should include the email address for the account being deleted

### Review
***(Required)*** Add instructions for reviewers.  For example:
> Only one developer is required to review these changes, but anyone can perform the review.

### Release
***(Required)*** Add a concise statement to `RELEASE-NOTES.txt` if the changes should be included in release notes. Include details about updating the notes in this section. For example:
> `RELEASE-NOTES.txt` was updated in 9aa5fb with:
> 
> > - Updated the account deletion flow for clarity #1026 
