### PR TITLE
Move automation to fetch code signing credentials in dedicated lane

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -287,21 +287,7 @@ end
     sh("rake dependencies:pod:clean")
     cocoapods()
 
-    # This allows code signing to work on CircleCI. It is skipped if this isn't
-    # running on CI.
-    #
-    # See https://circleci.com/docs/2.0/ios-codesigning/
-    setup_circle_ci
-
-    sync_code_signing(
-      type: 'appstore',
-      platform: 'macos',
-      # This Mac app also needs a Mac Installer Distribution certificate
-      additional_cert_types: ['mac_installer_distribution'],
-      readonly: true,
-      app_identifier: 'com.automattic.SimplenoteMac',
-      api_key_path: APP_STORE_CONNECT_API_KEY_PATH
-    )
+    fetch_code_signing_credentials
 
     archive_path = File.join(BUILD_FOLDER, 'Simplenote-Mac.xcarchive')
     build_simplenote(codesign: true, archive_path: archive_path)
@@ -345,6 +331,24 @@ end
         prerelease: options[:prerelease],
       )
     end
+  end
+
+  lane :fetch_code_signing_credentials do
+    # This allows code signing to work on CircleCI. It is skipped if this isn't
+    # running on CI.
+    #
+    # See https://circleci.com/docs/2.0/ios-codesigning/
+    setup_circle_ci
+
+    sync_code_signing(
+      type: 'appstore',
+      platform: 'macos',
+      # This Mac app also needs a Mac Installer Distribution certificate
+      additional_cert_types: ['mac_installer_distribution'],
+      readonly: true,
+      app_identifier: 'com.automattic.SimplenoteMac',
+      api_key_path: APP_STORE_CONNECT_API_KEY_PATH
+    )
   end
 
   # Temporary lane to automate the process of uploading the .app manually


### PR DESCRIPTION
This will allow developers who might need to produce a build locally to
get all the certificates they need.


### Test

Checkout this branch and run `bundle exec fastlane run configure_apply && bundle exec fastlane fetch_code_signing_credentials`. It should succeed:

![image](https://user-images.githubusercontent.com/1218433/132269066-4447e44e-3058-41d7-a555-28535be9bb6c.png)


### Review
Only one developer required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.
