### PR TITLE
Hotfix light mode window issue

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,11 @@
 -----
 
 
+2.15.1
+-----
+- Fixed a bug that caused the app window not to load in light mode #1031
+
+
 2.15
 -----
 - [Internal] added error response case on login for unverified emails #1019

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,12 +1,13 @@
 2.16
 -----
-- Updated the account deletion flow for clarity #1026
+
 
 2.15
 -----
 - [Internal] added error response case on login for unverified emails #1019
 - In app account deletion: Now you can delete your account from the app #1013
 - [Internal] added login alert for compromised password #1017
+- Updated the account deletion flow for clarity #1026
 
 2.14
 -----

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -466,6 +466,7 @@
 		BAA0A88F26BA39200006260E /* AccountDeletionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAA0A88126B9F8970006260E /* AccountDeletionController.swift */; };
 		BAA0A89326BA39260006260E /* RemoteError.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAA0A87926B9F0B50006260E /* RemoteError.swift */; };
 		BAA4854A25D5E22000F3BDB9 /* SearchQuery+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAA4854925D5E22000F3BDB9 /* SearchQuery+Simplenote.swift */; };
+		BAD4ECC026E6FC0A00881CC4 /* markdown-light.css in Resources */ = {isa = PBXBuildFile; fileRef = BAF8D5DB26AE3BE800CA9383 /* markdown-light.css */; };
 		BAE66CAA26AF647500398FF3 /* Remote.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA938CEB26ACFF4A00BE5A1D /* Remote.swift */; };
 		BAF8D5DC26AE3BE800CA9383 /* markdown-light.css in Resources */ = {isa = PBXBuildFile; fileRef = BAF8D5DB26AE3BE800CA9383 /* markdown-light.css */; };
 		BAFB545026CCA7F1006E037C /* NSProgressIndicator+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAFB544F26CCA7F1006E037C /* NSProgressIndicator+Simplenote.swift */; };
@@ -1840,6 +1841,7 @@
 				B53ACDE525DD47BB00CF527A /* InterlinkViewController.xib in Resources */,
 				B5438013246358BA00F34B1C /* Icons.xcassets in Resources */,
 				B5C7DD44243E4A8E00BEE354 /* CollaborateViewController.xib in Resources */,
+				BAD4ECC026E6FC0A00881CC4 /* markdown-light.css in Resources */,
 				B58117D725B9D5F500927E0C /* AccountVerificationViewController.xib in Resources */,
 				37AE49CA1FFEBB0B00FCB165 /* markdown-dark.css in Resources */,
 				466FFF1717CC10A800399652 /* Localizable.strings in Resources */,


### PR DESCRIPTION
### Fix
The most recent version of Simplenote Mac has an issue where if the theme is set to light mode the window will not load when the app is opened.  This PR fixes that issue

### Test
1.  Set simplenote to load in the light theme (if set to use the system default set your device to light, otherwise go to View -> Theme -> Light)
2. run the app
3. you should see the window open as normal

### Review
***(Required)*** Add instructions for reviewers.  For example:
> Only one developer iss required to review these changes, but anyone can perform the review.

### Release
***(Required)*** Add a concise statement to `RELEASE-NOTES.txt` if the changes should be included in release notes. Include details about updating the notes in this section. For example:
> `RELEASE-NOTES.txt` was updated in cd1a67 with:
> 
> > - Fixed a bug that caused the app window not to load in light mode #1031

