### PR TITLE
Copy Secrets: Preventing Overwork

### DIFF
--- a/Scripts/Build-Phases/copy-secret.sh
+++ b/Scripts/Build-Phases/copy-secret.sh
@@ -59,6 +59,11 @@ ensure_is_in_input_files_list $EXAMPLE_SECRETS_FILE
 SECRETS_DESTINATION_FILE="${SRCROOT}/Simplenote/Credentials/SPCredentials.swift"
 mkdir -p $(dirname "$SECRETS_DESTINATION_FILE")
 
+if cmp --silent -- ${SECRETS_FILE} ${SECRETS_DESTINATION_FILE}; then
+    echo "☑️ Credentials were not modified. Skipping..."
+    exit 0
+fi
+
 if [ -f "$SECRETS_FILE" ]; then
     echo "Applying Production Secrets"
     cp -v "$SECRETS_FILE" "${SECRETS_DESTINATION_FILE}"


### PR DESCRIPTION
### Fix
I've noticed in Xcode 13 we're getting **a ton** of build errors, regularly, regarding the `SPCredentials.swift` file being modified during a build.

In this PR we're adding a small check, to prevent copying the secrets file whenever it was not modified.

cc @charliescheer @oguzkocer 
Thank you gentleman!!

### Test
- [x] Verify the app builds correctly
- [x] Verify the `SPCredentials` file is copied when needed
- [x] Verify that modifying the code and rebuilding doesn't trigger a `SPCredentials` error.

### Release
These changes do not require release notes.
