### PR TITLE
Added a 420 too many login attempts error

### DIFF
--- a/Simplenote/AuthViewController.m
+++ b/Simplenote/AuthViewController.m
@@ -337,6 +337,9 @@ static NSString *SPAuthSessionKey = @"SPAuthSessionKey";
                 [self showAuthenticationError:NSLocalizedString(@"Authorization failed", @"Error for authorization failure")];
             }
             break;
+        case 429:
+            [self showAuthenticationError:NSLocalizedString(@"Too many log in attempts. Try again later.", @"Error for too many login attempts")];
+            break;
         default:
             [self showAuthenticationError:NSLocalizedString(@"We're having problems. Please try again soon.", @"Generic error")];
             break;


### PR DESCRIPTION
### Fix
This PR adds a new login error case for a response 429 too many attempts

Internal ref: paFIJd-ou#comment-1094-p2

### Test
1. setup some sort of proxy to interrupt incoming web traffic for the auth endpoint
2. change the response to 429
3. you should see an error for too many attempts


### Review
***(Required)*** Add instructions for reviewers.  For example:
> Only one developer is required to review these changes, but anyone can perform the review.

### Release
> These changes do not require release notes.
