### PR TITLE
fixed release notes for preferences

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,6 @@
 2.18
 -----
-
+- Added preferences menu to centralize app options and customizations #1042
 
 2.17
 -----
@@ -8,7 +8,7 @@
 
 2.16
 -----
-- Added preferences menu to centralize app options and customizations #1042
+
 
 2.15.1
 -----


### PR DESCRIPTION
### Fix
This was a quick PR to update the release number for the preferences menu change.  This change had been started and targeted for a different release, but was delayed.  The expected version for that release will be 2.18 not 2.16.

This updates the release notes to reflect that change

### Test
no testing required

### Review
***(Required)*** Add instructions for reviewers.  For example:
> Only one developer is required to review these changes, but anyone can perform the review.

### Release
***(Required)*** Add a concise statement to `RELEASE-NOTES.txt` if the changes should be included in release notes. Include details about updating the notes in this section. For example:
> `RELEASE-NOTES.txt` was updated in 57f7aeb with:
>
 

2.18
-----
- Added preferences menu to centralize app options and customizations #1042
