### PR TITLE
Increases no_output_timeout for CircleCI test job to 3m

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
           #
           # See
           # https://app.circleci.com/pipelines/github/Automattic/simplenote-macos/2363/workflows/c0aa85a0-837b-4e3f-bcda-252a273bf008/jobs/2738
-          no_output_timeout: 1m
+          no_output_timeout: 3m
 
   Verify App Store Target Builds:
     executor: *xcode_image


### PR DESCRIPTION
We have been having some false negative test runs in CircleCI due to `no_output_timeout`, so we are increasing it to 3m. See [this relevant thread](https://github.com/Automattic/simplenote-macos/pull/970#issuecomment-963650149) for more details.