### PR TITLE
Remove pr list generation at code freeze

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -121,7 +121,6 @@ end
     ios_bump_version_release()
     new_version = ios_get_app_version()
     ios_update_release_notes(new_version: new_version)
-    get_prs_list(repository:GHHELPER_REPO, milestone: new_version, report_path:"#{File.expand_path('~')}/simplenotemacos_prs_list_#{old_version}_#{new_version}.txt")
     setbranchprotection(repository:GHHELPER_REPO, branch: "release/#{new_version}")
     setfrozentag(repository:GHHELPER_REPO, milestone: new_version)
 
@@ -418,11 +417,4 @@ end
       job_params: { app_store_build: true }
     )
   end
-
-########################################################################
-# Helper Lanes
-########################################################################
-desc "Get a list of pull request from `start_tag` to the current state"
-lane :get_pullrequests_list do | options |
-  get_prs_list(repository:GHHELPER_REPO, start_tag:"#{options[:start_tag]}", report_path:"#{File.expand_path('~')}/simplenotemacos_prs_list.txt")
-end
+  


### PR DESCRIPTION
This PR removes the step in Fastlane's `code_freeze` lane that generates a text file with a list of the PRs that made it to the new version. With the current process to generate the release notes and the new tooling we built to generate the draft of the release announcement, this file is not used anymore.

This is also removing the `get_pullrequests_list` lane.

### Review
 Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.
