### PR TITLE
Add higher CI priority to release builds

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,7 +5,7 @@ common_params:
     - automattic/bash-cache#2.9.0
   # Common environment values to use with the `env` key.
   - &common_env
-    IMAGE_ID: xcode-14.0.1
+    IMAGE_ID: xcode-14.2
 
 # This is the default pipeline – it will build and test the app
 steps:

--- a/.buildkite/release-build.yml
+++ b/.buildkite/release-build.yml
@@ -5,11 +5,12 @@ common_params:
     - automattic/bash-cache#2.9.0
   # Common environment values to use with the `env` key.
   - &common_env
-    IMAGE_ID: xcode-14.0.1
+    IMAGE_ID: xcode-14.2
 
 # This is the default pipeline – it will build and test the app
 steps:
   - label: "🛠 App Store Upload"
     command: .buildkite/commands/build-and-upload-release.sh
+    priority: 1
     env: *common_env
     plugins: *common_plugins


### PR DESCRIPTION
### Summary of changes:

This PR increases the priority of release builds on Buildkite. This will be useful so that release builds won't get delayed if the CI queue gets backed up. The default priority of a build is 0, so increasing the release builds to 1 will put them before other builds: https://buildkite.com/docs/pipelines/managing-priorities

I also increased the CI image to Xcode 14.2 while I was changing these files. 