### PR TITLE
Updated logic to let the user Change minimum window

### DIFF
--- a/Simplenote/NSNotification+Simplenote.h
+++ b/Simplenote/NSNotification+Simplenote.h
@@ -15,3 +15,4 @@ extern NSString * const StatusBarDisplayModeDidChangeNotification;
 extern NSString * const TagSortModeDidChangeNotification;
 extern NSString * const ThemeDidChangeNotification;
 extern NSString * const FontSizeDidChangeNotification;
+extern NSString * const SplitViewStateDidChangeNotification;

--- a/Simplenote/NSNotification+Simplenote.m
+++ b/Simplenote/NSNotification+Simplenote.m
@@ -13,4 +13,5 @@ NSString * const NoteListSortModeDidChangeNotification      = @"NoteListSortMode
 NSString * const StatusBarDisplayModeDidChangeNotification  = @"StatusBarDisplayModeDidChangeNotification";
 NSString * const TagSortModeDidChangeNotification           = @"TagSortModeDidChangeNotification";
 NSString * const ThemeDidChangeNotification                 = @"ThemeDidChangeNotification";
-NSString * const FontSizeDidChangeNotification              = @"FondSizeDidChangeNotification";
+NSString * const FontSizeDidChangeNotification              = @"FontSizeDidChangeNotification";
+NSString * const SplitViewStateDidChangeNotification        = @"SplitViewStateDidChangeNotification";

--- a/Simplenote/SplitViewController.swift
+++ b/Simplenote/SplitViewController.swift
@@ -170,6 +170,8 @@ private extension SplitViewController {
         if notesSplitItem.isCollapsed != state.isNotesCollapsed {
             notesSplitItem.animator().isCollapsed = state.isNotesCollapsed
         }
+
+        NotificationCenter.default.post(name: .SplitViewStateDidChange, object: nil, userInfo: ["isEditorMode": isFocusModeEnabled])
     }
 
     func restorePreviousState() -> Bool {
@@ -227,7 +229,7 @@ extension SplitViewController {
 
 // MARK: - SplitState: Represents the Internal SplitView State
 //
-private enum SplitState {
+private enum SplitState: String {
     case everything
     case tagsCollapsed
     case editor


### PR DESCRIPTION

### Fix
This PR let the users to change the min width of the main window, when is on editor mode. This will fix the issue: https://github.com/Automattic/simplenote-macos/issues/1083

Because the main window width is set to a min of 720 (on Main.storyboard), every time that the user are in the editor mode, it's impossible to reduce the size.

In this PR, I'm listening every time that the user collapse/expand the Split View to set the correct min size.
I'm set the minWidth to 300, because was the min size that let the user to see all the buttons on the tab bar, included the markdown.

### Test
> 1. Go to any note
> 2. Tap on collapse button until the Editor mode is visible
> 3. Resize the window

![Screen Shot 2023-03-17 at 12 30 00](https://user-images.githubusercontent.com/619159/225950340-a8b2e6bc-f42e-4b92-9f2f-b9539297cc64.png)

Rollback:
> 1. Tap the collapse 
> 2. Tap on collapse to add the others panels
> 3. Resize the window

### Review
> Only one developer are required to review these changes, but anyone can perform the review. A designer could be an extra option to validate the size.

### Release
> `RELEASE-NOTES.txt` was updated with:
> 
> > Added the feature to reduce the width of the Main Window on the editor mode to make this smaller that the current one
