### PR TITLE
Updated logic to support duplicate note

### DIFF
--- a/Simplenote/Base.lproj/MainMenu.xib
+++ b/Simplenote/Base.lproj/MainMenu.xib
@@ -116,7 +116,7 @@
                                     <action selector="newNoteWasPressed:" target="494" id="kR0-1Q-w9M"/>
                                 </connections>
                             </menuItem>
-                            <menuItem title="Duplicate" keyEquivalent="d" identifier="systemNewNoteMenuItem" id="T6H-IV-fBg">
+                            <menuItem title="Duplicate" keyEquivalent="d" identifier="systemDuplicateNoteMenuItem" id="T6H-IV-fBg">
                                 <attributedString key="userComments">
                                     <fragment content="Adds a New Note"/>
                                 </attributedString>

--- a/Simplenote/Base.lproj/MainMenu.xib
+++ b/Simplenote/Base.lproj/MainMenu.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="19162" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="19529" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="19162"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="19529"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="NSApplication">
@@ -113,7 +113,15 @@
                                     <fragment content="Adds a New Note"/>
                                 </attributedString>
                                 <connections>
-                                    <action selector="newNoteWasPressed:" target="494" id="Dqn-qR-Zuq"/>
+                                    <action selector="newNoteWasPressed:" target="494" id="kR0-1Q-w9M"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Duplicate" keyEquivalent="d" identifier="systemNewNoteMenuItem" id="T6H-IV-fBg">
+                                <attributedString key="userComments">
+                                    <fragment content="Adds a New Note"/>
+                                </attributedString>
+                                <connections>
+                                    <action selector="duplicateNote:" target="494" id="j1F-nz-Ada"/>
                                 </connections>
                             </menuItem>
                             <menuItem title="Move to Trash" identifier="systemTrashMenuItem" id="1655">

--- a/Simplenote/Main.storyboard
+++ b/Simplenote/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="18122"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="19529"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -475,6 +475,12 @@
                                 <action selector="copyInterlinkWasPressed:" target="JtV-0Z-Zh8" id="mP7-0c-YCD"/>
                             </connections>
                         </menuItem>
+                        <menuItem title="Duplicate Note" identifier="listDuplicateNoteMenuItem" id="Il6-D0-o4Q" userLabel="Duplicate Note">
+                            <modifierMask key="keyEquivalentModifierMask"/>
+                            <connections>
+                                <action selector="duplicateNote:" target="JtV-0Z-Zh8" id="XN8-bg-PpF"/>
+                            </connections>
+                        </menuItem>
                         <menuItem title="Move to Trash" identifier="listTrashNoteMenuItem" id="sEB-rr-DQo" userLabel="Delete Note">
                             <modifierMask key="keyEquivalentModifierMask"/>
                             <connections>
@@ -844,7 +850,7 @@
                             <rect key="frame" x="0.0" y="12" width="528" height="25"/>
                             <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="dTq-DR-Qae">
                                 <rect key="frame" x="0.0" y="0.0" width="528" height="25"/>
-                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                <autoresizingMask key="autoresizingMask"/>
                                 <subviews>
                                     <tokenField horizontalHuggingPriority="750" verticalHuggingPriority="750" placeholderIntrinsicWidth="462" placeholderIntrinsicHeight="25" mirrorLayoutDirectionWhenInternationalizing="always" translatesAutoresizingMaskIntoConstraints="NO" id="U3o-VN-U2S" customClass="TagsField" customModule="Simplenote" customModuleProvider="target">
                                         <rect key="frame" x="-2" y="0.0" width="466" height="25"/>
@@ -896,8 +902,11 @@
                         </menuItem>
                         <menuItem title="Copy Internal Link" identifier="editorCopyInterlinkMenuItem" id="6b8-Xr-2VS">
                             <modifierMask key="keyEquivalentModifierMask"/>
+                        </menuItem>
+                        <menuItem title="Duplicate Note" identifier="editorDuplicateNoteMenuItem" id="C5L-kt-xCZ" userLabel="Duplicate Note">
+                            <modifierMask key="keyEquivalentModifierMask"/>
                             <connections>
-                                <action selector="copyInterlinkWasPressedWithSender:" target="owM-kh-Bm6" id="Qda-6t-kVe"/>
+                                <action selector="duplicateNoteWasPressed:" target="owM-kh-Bm6" id="Fcv-fy-ayu"/>
                             </connections>
                         </menuItem>
                         <menuItem title="Share" identifier="editorShareMenuItem" id="AAE-bz-XTn">

--- a/Simplenote/Main.storyboard
+++ b/Simplenote/Main.storyboard
@@ -902,6 +902,9 @@
                         </menuItem>
                         <menuItem title="Copy Internal Link" identifier="editorCopyInterlinkMenuItem" id="6b8-Xr-2VS">
                             <modifierMask key="keyEquivalentModifierMask"/>
+                            <connections>
+                                <action selector="copyInterlinkWasPressedWithSender:" target="owM-kh-Bm6" id="zmB-H6-hW4"/>
+                            </connections>
                         </menuItem>
                         <menuItem title="Duplicate Note" identifier="editorDuplicateNoteMenuItem" id="C5L-kt-xCZ" userLabel="Duplicate Note">
                             <modifierMask key="keyEquivalentModifierMask"/>

--- a/Simplenote/NSUserInterfaceItemIdentifier+Simplenote.swift
+++ b/Simplenote/NSUserInterfaceItemIdentifier+Simplenote.swift
@@ -12,6 +12,7 @@ extension NSUserInterfaceItemIdentifier {
 
     /// Identifiers: System Menu
     ///
+    static let systemDuplicateNoteMenuItem        = NSUserInterfaceItemIdentifier(rawValue: "systemDuplicateNoteMenuItem")
     static let systemNewNoteMenuItem        = NSUserInterfaceItemIdentifier(rawValue: "systemNewNoteMenuItem")
     static let systemTrashMenuItem          = NSUserInterfaceItemIdentifier(rawValue: "systemTrashMenuItem")
     static let systemPrintMenuItem          = NSUserInterfaceItemIdentifier(rawValue: "systemPrintMenuItem")
@@ -36,6 +37,7 @@ extension NSUserInterfaceItemIdentifier {
     ///
     static let listCopyInterlinkMenuItem    = NSUserInterfaceItemIdentifier(rawValue: "listCopyInterlinkMenuItem")
     static let listDeleteForeverMenuItem    = NSUserInterfaceItemIdentifier(rawValue: "listDeleteForeverMenuItem")
+    static let listDuplicateNoteMenuItem        = NSUserInterfaceItemIdentifier(rawValue: "listDuplicateNoteMenuItem")
     static let listPinMenuItem              = NSUserInterfaceItemIdentifier(rawValue: "listPinMenuItem")
     static let listRestoreNoteMenuItem      = NSUserInterfaceItemIdentifier(rawValue: "listRestoreNoteMenuItem")
     static let listTrashNoteMenuItem        = NSUserInterfaceItemIdentifier(rawValue: "listTrashNoteMenuItem")
@@ -44,6 +46,7 @@ extension NSUserInterfaceItemIdentifier {
     ///
     static let editorPinMenuItem            = NSUserInterfaceItemIdentifier(rawValue: "editorPinMenuItem")
     static let editorChecklistMenuItem      = NSUserInterfaceItemIdentifier(rawValue: "editorChecklistMenuItem")
+    static let editorDuplicateNoteMenuItem        = NSUserInterfaceItemIdentifier(rawValue: "editorDuplicateNoteMenuItem")
     static let editorMarkdownMenuItem       = NSUserInterfaceItemIdentifier(rawValue: "editorMarkdownMenuItem")
     static let editorCopyInterlinkMenuItem  = NSUserInterfaceItemIdentifier(rawValue: "editorCopyInterlinkMenuItem")
     static let editorShareMenuItem          = NSUserInterfaceItemIdentifier(rawValue: "editorShareMenuItem")

--- a/Simplenote/NoteEditorViewController+Swift.swift
+++ b/Simplenote/NoteEditorViewController+Swift.swift
@@ -374,7 +374,7 @@ extension NoteEditorViewController: NSMenuItemValidation {
             return validateEditorCopyInterlinkMenuItem(menuItem)
 
         case .editorDuplicateNoteMenuItem:
-            return validateSystemDuplicateNoteMenuItem(menuItem)
+            return validateEditorDuplicateNoteMenuItem(menuItem)
 
         case .editorPinMenuItem:
             return validateEditorPinMenuItem(menuItem)
@@ -423,10 +423,9 @@ extension NoteEditorViewController: NSMenuItemValidation {
         return isDisplayingNote
     }
 
-    func validateListDuplicateNoteMenuItem(_ item: NSMenuItem) -> Bool {
-        // TODO: Add localization keys+values for this new item
+    func validateEditorDuplicateNoteMenuItem(_ item: NSMenuItem) -> Bool {
         item.title = NSLocalizedString("Duplicate Note", comment: "Duplicate Note List Action")
-        return isDisplayingNote
+        return isDisplayingNote && selectedNotes.count == 1
     }
 
     func validateEditorPinMenuItem(_ item: NSMenuItem) -> Bool {
@@ -469,7 +468,7 @@ extension NoteEditorViewController: NSMenuItemValidation {
     }
 
     func validateSystemDuplicateNoteMenuItem(_ item: NSMenuItem) -> Bool {
-        return isDisplayingNote && !viewingTrash
+        return isDisplayingNote && !viewingTrash && selectedNotes.count == 1
     }
 
     func validateSystemNewNoteMenuItem(_ item: NSMenuItem) -> Bool {

--- a/Simplenote/NoteEditorViewController+Swift.swift
+++ b/Simplenote/NoteEditorViewController+Swift.swift
@@ -373,6 +373,9 @@ extension NoteEditorViewController: NSMenuItemValidation {
         case .editorCopyInterlinkMenuItem:
             return validateEditorCopyInterlinkMenuItem(menuItem)
 
+        case .editorDuplicateNoteMenuItem:
+            return validateSystemDuplicateNoteMenuItem(menuItem)
+
         case .editorPinMenuItem:
             return validateEditorPinMenuItem(menuItem)
 
@@ -394,6 +397,9 @@ extension NoteEditorViewController: NSMenuItemValidation {
         case .editorCollaborateMenuItem:
             return validateEditorCollaborateMenuItem(menuItem)
 
+        case .systemDuplicateNoteMenuItem:
+            return validateSystemDuplicateNoteMenuItem(menuItem)
+
         case .systemNewNoteMenuItem:
             return validateSystemNewNoteMenuItem(menuItem)
 
@@ -414,6 +420,12 @@ extension NoteEditorViewController: NSMenuItemValidation {
 
     func validateEditorCopyInterlinkMenuItem(_ item: NSMenuItem) -> Bool {
         item.title = NSLocalizedString("Copy Internal Link", comment: "Copy Link Menu Action")
+        return isDisplayingNote
+    }
+
+    func validateListDuplicateNoteMenuItem(_ item: NSMenuItem) -> Bool {
+        // TODO: Add localization keys+values for this new item
+        item.title = NSLocalizedString("Duplicate Note", comment: "Duplicate Note List Action")
         return isDisplayingNote
     }
 
@@ -454,6 +466,10 @@ extension NoteEditorViewController: NSMenuItemValidation {
     func validateEditorCollaborateMenuItem(_ item: NSMenuItem) -> Bool {
         item.title = NSLocalizedString("Collaborate", comment: "Collaborate Menu Action")
         return isDisplayingNote
+    }
+
+    func validateSystemDuplicateNoteMenuItem(_ item: NSMenuItem) -> Bool {
+        return isDisplayingNote && !viewingTrash
     }
 
     func validateSystemNewNoteMenuItem(_ item: NSMenuItem) -> Bool {

--- a/Simplenote/NoteEditorViewController.h
+++ b/Simplenote/NoteEditorViewController.h
@@ -77,7 +77,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (IBAction)newNoteWasPressed:(id)sender;
 - (IBAction)duplicateNoteWasPressed:(id)sender;
-- (void)duplicateNote:(nullable Note *)sender;
+- (void)duplicateNoteWasPressed;
 - (void)save;
 - (void)displayNote:(nullable Note *)selectedNote;
 - (void)displayNotes:(NSArray<Note *> *)selectedNotes;

--- a/Simplenote/NoteEditorViewController.h
+++ b/Simplenote/NoteEditorViewController.h
@@ -76,6 +76,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, nullable) NSObject                                *searchQuery;
 
 - (IBAction)newNoteWasPressed:(id)sender;
+- (IBAction)duplicateNoteWasPressed:(id)sender;
+- (void)duplicateNote:(nullable Note *)sender;
 - (void)save;
 - (void)displayNote:(nullable Note *)selectedNote;
 - (void)displayNotes:(NSArray<Note *> *)selectedNotes;

--- a/Simplenote/NoteEditorViewController.m
+++ b/Simplenote/NoteEditorViewController.m
@@ -385,13 +385,13 @@ static NSString * const SPMarkdownPreferencesKey        = @"kMarkdownPreferences
 - (IBAction)newNoteWasPressed:(id)sender
 {
     [SPTracker trackEditorNoteCreated];
-    [self createNoteWasPressed:nil];
+    [self createNoteFromNote:nil];
 }
 
 - (IBAction)duplicateNoteWasPressed:(id)sender
 {
     // TODO: Set correct analytic event
-    [self duplicateNote:nil];
+    [self duplicateNoteWasPressed];
 }
 
 - (IBAction)deleteAction:(id)sender
@@ -583,16 +583,12 @@ static NSString * const SPMarkdownPreferencesKey        = @"kMarkdownPreferences
 
 #pragma mark - New Note
 
-- (void)duplicateNote:(nullable Note *)sender
+- (void)duplicateNoteWasPressed
 {
-    if (sender != nil) {
-        [self createNoteWasPressed:sender];
-    } else {
-        [self createNoteWasPressed:self.note];
-    }
+    [self createNoteFromNote:self.note];
 }
 
-- (void) createNoteWasPressed:(nullable Note *)sender {
+- (void) createNoteFromNote:(nullable Note *)oldNote {
 
     // Save current note first
     self.note.content = [self.noteEditor plainTextContent];
@@ -607,10 +603,10 @@ static NSString * const SPMarkdownPreferencesKey        = @"kMarkdownPreferences
     newNote.creationDate = [NSDate date];
     newNote.markdown = [[NSUserDefaults standardUserDefaults] boolForKey:SPMarkdownPreferencesKey];
 
-    if (sender != nil) {
-        newNote.content = sender.content;
-        newNote.tags = sender.tags;
-        newNote.tagsArray = sender.tagsArray;
+    if (oldNote != nil) {
+        newNote.content = oldNote.content;
+        newNote.tags = oldNote.tags;
+        newNote.tagsArray = oldNote.tagsArray;
     }
 
     NSString *currentTag = [appDelegate selectedTagName];

--- a/Simplenote/NoteListViewController.swift
+++ b/Simplenote/NoteListViewController.swift
@@ -735,7 +735,6 @@ extension NoteListViewController: NSMenuItemValidation {
     }
 
     func validateListDuplicateNoteMenuItem(_ item: NSMenuItem) -> Bool {
-        // TODO: Add localization keys+values for this new item
         item.title = NSLocalizedString("Duplicate Note", comment: "Duplicate Note List Action")
         return isSelectionNotEmpty
     }
@@ -856,11 +855,11 @@ extension NoteListViewController {
 
     @IBAction
     func duplicateNote(_ sender: Any) {
-        guard let note = selectedNotes.first else {
+        guard selectedNotes.first != nil else {
             return
         }
 
-        noteEditorViewController.duplicateNote(note)
+        noteEditorViewController.duplicateNoteWasPressed()
         // TODO: Set correct analytic event
     }
 

--- a/Simplenote/NoteListViewController.swift
+++ b/Simplenote/NoteListViewController.swift
@@ -707,6 +707,9 @@ extension NoteListViewController: NSMenuItemValidation {
         case .listDeleteForeverMenuItem:
             return validateListDeleteForeverMenuItem(menuItem)
 
+        case .listDuplicateNoteMenuItem:
+            return validateListDuplicateNoteMenuItem(menuItem)
+
         case .listPinMenuItem:
             return validateListPinMenuItem(menuItem)
 
@@ -728,6 +731,12 @@ extension NoteListViewController: NSMenuItemValidation {
 
     func validateListDeleteForeverMenuItem(_ item: NSMenuItem) -> Bool {
         item.title = NSLocalizedString("Delete Forever", comment: "Delete Forever List Action")
+        return isSelectionNotEmpty
+    }
+
+    func validateListDuplicateNoteMenuItem(_ item: NSMenuItem) -> Bool {
+        // TODO: Add localization keys+values for this new item
+        item.title = NSLocalizedString("Duplicate Note", comment: "Duplicate Note List Action")
         return isSelectionNotEmpty
     }
 
@@ -843,6 +852,16 @@ extension NoteListViewController {
         simperium.save()
 
         SPTracker.trackListNoteDeletedForever()
+    }
+
+    @IBAction
+    func duplicateNote(_ sender: Any) {
+        guard let note = selectedNotes.first else {
+            return
+        }
+
+        noteEditorViewController.duplicateNote(note)
+        // TODO: Set correct analytic event
     }
 
     @IBAction

--- a/Simplenote/SimplenoteAppDelegate+Swift.swift
+++ b/Simplenote/SimplenoteAppDelegate+Swift.swift
@@ -182,6 +182,12 @@ extension SimplenoteAppDelegate {
     }
 
     @IBAction
+    func duplicateNote(_ sender: Any) {
+        noteEditorViewController.duplicateNote(nil)
+        // TODO: Set correct analytic event
+    }
+
+    @IBAction
     func printWasPressed(_ sender: Any) {
         noteEditorViewController.printAction(sender)
     }
@@ -335,6 +341,9 @@ extension SimplenoteAppDelegate: NSMenuItemValidation {
         case .systemNewNoteMenuItem:
             return validateSystemNewNoteMenuItem(menuItem)
 
+        case .systemDuplicateNoteMenuItem:
+            return validateSystemNewNoteMenuItem(menuItem)
+
         case .systemPrintMenuItem:
             return validateSystemPrintMenuItem(menuItem)
 
@@ -381,6 +390,10 @@ extension SimplenoteAppDelegate: NSMenuItemValidation {
 
     func validateSystemNewNoteMenuItem(_ item: NSMenuItem) -> Bool {
         noteEditorViewController.validateSystemNewNoteMenuItem(item)
+    }
+
+    func validateSystemDuplicateNoteMenuItem(_ item: NSMenuItem) -> Bool {
+        noteEditorViewController.validateSystemDuplicateNoteMenuItem(item)
     }
 
     func validateSystemPrintMenuItem(_ item: NSMenuItem) -> Bool {

--- a/Simplenote/SimplenoteAppDelegate+Swift.swift
+++ b/Simplenote/SimplenoteAppDelegate+Swift.swift
@@ -183,7 +183,7 @@ extension SimplenoteAppDelegate {
 
     @IBAction
     func duplicateNote(_ sender: Any) {
-        noteEditorViewController.duplicateNote(nil)
+        noteEditorViewController.duplicateNoteWasPressed()
         // TODO: Set correct analytic event
     }
 
@@ -342,7 +342,7 @@ extension SimplenoteAppDelegate: NSMenuItemValidation {
             return validateSystemNewNoteMenuItem(menuItem)
 
         case .systemDuplicateNoteMenuItem:
-            return validateSystemNewNoteMenuItem(menuItem)
+            return validateSystemDuplicateNoteMenuItem(menuItem)
 
         case .systemPrintMenuItem:
             return validateSystemPrintMenuItem(menuItem)


### PR DESCRIPTION
### Fix
This PR will add the feature that let users to duplicate an existing note.  Will fix: [issue-1066](https://github.com/Automattic/simplenote-macos/issues/1066)
The idea was to create a new note, and set the content and tags of the existing one.

For that, I must to add new menu items and updated the layout and conditions to not duplicate code

### Test
> 1. Select any note of the list
> 2. Press right button
> 3. Select "Duplicate Note" option

> 1. Select any note of the list
> 2. In the Editor view, select the "more options" menu item
> 3. Select "Duplicate Note" option

> 1. Select any note of the list
> 2. In main menu select Note
> 3. Select "Duplicate Note" option

![duplicate_note](https://user-images.githubusercontent.com/619159/226000243-8b52d9f4-6871-4089-bf21-54a56db880bd.gif)


### Review
> Only one developer are required to review these changes, but anyone can perform the review.

### Release
> `RELEASE-NOTES.txt` was updated with:
> 
> > Added Duplicate Note support


### Notes
Because this is a new complete feature, and I'm not part of the company, there are some steps that need your interaction (if you want to merge this). 
The new "Duplicate Note" needs localization strings.
The new Duplicate Note, needs update the analytics with a new event, to track this and know from where was called (Notes list, Main menu, Editor Menu)