### PR TITLE
Update a8c-ci-toolkit Buildkite plugin to new name and latest version

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,7 +2,7 @@
 common_params:
   # Common plugin settings to use with the `plugins` key.
   - &common_plugins
-    - automattic/bash-cache#2.9.0
+    - automattic/a8c-ci-toolkit#2.15.0
   # Common environment values to use with the `env` key.
   - &common_env
     IMAGE_ID: xcode-14.2

--- a/.buildkite/release-build.yml
+++ b/.buildkite/release-build.yml
@@ -2,7 +2,7 @@
 common_params:
   # Common plugin settings to use with the `plugins` key.
   - &common_plugins
-    - automattic/bash-cache#2.9.0
+    - automattic/a8c-ci-toolkit#2.15.0
   # Common environment values to use with the `env` key.
   - &common_env
     IMAGE_ID: xcode-14.2


### PR DESCRIPTION
## What

- Update the `bash-cache` Buildkite plugin name to `a8c-ci-toolkit`
- Update the `a8c-ci-toolkit` plugin to version `2.15.0` 

## Testing

Ensure that CI is green and that all checks passed.

> These changes do not require release notes.
