### PR TITLE
Adds new tracks events

### DIFF
--- a/Simplenote/NSUserInterfaceItemIdentifier+Simplenote.swift
+++ b/Simplenote/NSUserInterfaceItemIdentifier+Simplenote.swift
@@ -12,7 +12,7 @@ extension NSUserInterfaceItemIdentifier {
 
     /// Identifiers: System Menu
     ///
-    static let systemDuplicateNoteMenuItem        = NSUserInterfaceItemIdentifier(rawValue: "systemDuplicateNoteMenuItem")
+    static let systemDuplicateNoteMenuItem  = NSUserInterfaceItemIdentifier(rawValue: "systemDuplicateNoteMenuItem")
     static let systemNewNoteMenuItem        = NSUserInterfaceItemIdentifier(rawValue: "systemNewNoteMenuItem")
     static let systemTrashMenuItem          = NSUserInterfaceItemIdentifier(rawValue: "systemTrashMenuItem")
     static let systemPrintMenuItem          = NSUserInterfaceItemIdentifier(rawValue: "systemPrintMenuItem")
@@ -37,7 +37,7 @@ extension NSUserInterfaceItemIdentifier {
     ///
     static let listCopyInterlinkMenuItem    = NSUserInterfaceItemIdentifier(rawValue: "listCopyInterlinkMenuItem")
     static let listDeleteForeverMenuItem    = NSUserInterfaceItemIdentifier(rawValue: "listDeleteForeverMenuItem")
-    static let listDuplicateNoteMenuItem        = NSUserInterfaceItemIdentifier(rawValue: "listDuplicateNoteMenuItem")
+    static let listDuplicateNoteMenuItem    = NSUserInterfaceItemIdentifier(rawValue: "listDuplicateNoteMenuItem")
     static let listPinMenuItem              = NSUserInterfaceItemIdentifier(rawValue: "listPinMenuItem")
     static let listRestoreNoteMenuItem      = NSUserInterfaceItemIdentifier(rawValue: "listRestoreNoteMenuItem")
     static let listTrashNoteMenuItem        = NSUserInterfaceItemIdentifier(rawValue: "listTrashNoteMenuItem")
@@ -46,7 +46,7 @@ extension NSUserInterfaceItemIdentifier {
     ///
     static let editorPinMenuItem            = NSUserInterfaceItemIdentifier(rawValue: "editorPinMenuItem")
     static let editorChecklistMenuItem      = NSUserInterfaceItemIdentifier(rawValue: "editorChecklistMenuItem")
-    static let editorDuplicateNoteMenuItem        = NSUserInterfaceItemIdentifier(rawValue: "editorDuplicateNoteMenuItem")
+    static let editorDuplicateNoteMenuItem  = NSUserInterfaceItemIdentifier(rawValue: "editorDuplicateNoteMenuItem")
     static let editorMarkdownMenuItem       = NSUserInterfaceItemIdentifier(rawValue: "editorMarkdownMenuItem")
     static let editorCopyInterlinkMenuItem  = NSUserInterfaceItemIdentifier(rawValue: "editorCopyInterlinkMenuItem")
     static let editorShareMenuItem          = NSUserInterfaceItemIdentifier(rawValue: "editorShareMenuItem")

--- a/Simplenote/NoteEditorViewController.h
+++ b/Simplenote/NoteEditorViewController.h
@@ -77,7 +77,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (IBAction)newNoteWasPressed:(id)sender;
 - (IBAction)duplicateNoteWasPressed:(id)sender;
-- (void)duplicateNoteWasPressed;
+- (void)duplicateCurrentNote;
 - (void)save;
 - (void)displayNote:(nullable Note *)selectedNote;
 - (void)displayNotes:(NSArray<Note *> *)selectedNotes;

--- a/Simplenote/NoteEditorViewController.m
+++ b/Simplenote/NoteEditorViewController.m
@@ -601,12 +601,14 @@ static NSString * const SPMarkdownPreferencesKey        = @"kMarkdownPreferences
     Note *newNote = [simperium.notesBucket insertNewObject];
     newNote.modificationDate = [NSDate date];
     newNote.creationDate = [NSDate date];
-    newNote.markdown = [[NSUserDefaults standardUserDefaults] boolForKey:SPMarkdownPreferencesKey];
 
     if (oldNote != nil) {
         newNote.content = oldNote.content;
         newNote.tags = oldNote.tags;
         newNote.tagsArray = oldNote.tagsArray;
+        newNote.markdown = oldNote.markdown;
+    } else {
+        newNote.markdown = [[NSUserDefaults standardUserDefaults] boolForKey:SPMarkdownPreferencesKey];
     }
 
     NSString *currentTag = [appDelegate selectedTagName];

--- a/Simplenote/NoteEditorViewController.m
+++ b/Simplenote/NoteEditorViewController.m
@@ -390,8 +390,8 @@ static NSString * const SPMarkdownPreferencesKey        = @"kMarkdownPreferences
 
 - (IBAction)duplicateNoteWasPressed:(id)sender
 {
-    [self duplicateNoteWasPressed];
     [SPTracker trackEditorNoteDuplicated];
+    [self duplicateCurrentNote];
 }
 
 - (IBAction)deleteAction:(id)sender
@@ -583,12 +583,12 @@ static NSString * const SPMarkdownPreferencesKey        = @"kMarkdownPreferences
 
 #pragma mark - New Note
 
-- (void)duplicateNoteWasPressed
+- (void)duplicateCurrentNote
 {
     [self createNoteFromNote:self.note];
 }
 
-- (void) createNoteFromNote:(nullable Note *)oldNote {
+- (void)createNoteFromNote:(nullable Note *)oldNote {
 
     // Save current note first
     self.note.content = [self.noteEditor plainTextContent];

--- a/Simplenote/NoteEditorViewController.m
+++ b/Simplenote/NoteEditorViewController.m
@@ -390,8 +390,8 @@ static NSString * const SPMarkdownPreferencesKey        = @"kMarkdownPreferences
 
 - (IBAction)duplicateNoteWasPressed:(id)sender
 {
-    // TODO: Set correct analytic event
     [self duplicateNoteWasPressed];
+    [SPTracker trackEditorNoteDuplicated];
 }
 
 - (IBAction)deleteAction:(id)sender

--- a/Simplenote/NoteListViewController.swift
+++ b/Simplenote/NoteListViewController.swift
@@ -860,7 +860,7 @@ extension NoteListViewController {
         }
 
         noteEditorViewController.duplicateNoteWasPressed()
-        // TODO: Set correct analytic event
+        SPTracker.trackListNoteDuplicated()
     }
 
     @IBAction

--- a/Simplenote/NoteListViewController.swift
+++ b/Simplenote/NoteListViewController.swift
@@ -859,7 +859,7 @@ extension NoteListViewController {
             return
         }
 
-        noteEditorViewController.duplicateNoteWasPressed()
+        noteEditorViewController.duplicateCurrentNote()
         SPTracker.trackListNoteDuplicated()
     }
 

--- a/Simplenote/SPTracker+Swift.swift
+++ b/Simplenote/SPTracker+Swift.swift
@@ -63,6 +63,10 @@ extension SPTracker {
         trackShortcut("create_note")
     }
 
+    static func trackShortcutDuplicateNote() {
+        trackShortcut("duplicate_note")
+    }
+
     static func trackShortcutToggleMarkdownPreview() {
         trackShortcut("markdown")
     }

--- a/Simplenote/SPTracker.h
+++ b/Simplenote/SPTracker.h
@@ -32,6 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (void)trackEditorChecklistInserted;
 + (void)trackEditorNoteCreated;
 + (void)trackEditorNoteDeleted;
++ (void)trackEditorNoteDuplicated;
 + (void)trackEditorNoteRestored;
 + (void)trackEditorNotePublished;
 + (void)trackEditorNoteUnpublished;
@@ -46,6 +47,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (void)trackListCopiedInternalLink;
 + (void)trackListNoteDeleted;
 + (void)trackListNoteDeletedForever;
++ (void)trackListNoteDuplicated;
 + (void)trackListNotePinningToggled;
 + (void)trackListNoteRestored;
 + (void)trackListNoteOpened;

--- a/Simplenote/SPTracker.m
+++ b/Simplenote/SPTracker.m
@@ -71,6 +71,11 @@
     [self trackAutomatticEventWithName:@"editor_note_deleted" properties:nil];
 }
 
++ (void)trackEditorNoteDuplicated
+{
+    [self trackAutomatticEventWithName:@"editor_note_duplicated" properties:nil];
+}
+
 + (void)trackEditorNoteRestored
 {
     [self trackAutomatticEventWithName:@"editor_note_restored" properties:nil];
@@ -140,6 +145,11 @@
 + (void)trackListNoteDeletedForever
 {
     [self trackAutomatticEventWithName:@"list_note_deleted_forever" properties:nil];
+}
+
++ (void)trackListNoteDuplicated
+{
+    [self trackAutomatticEventWithName:@"list_note_duplicated" properties:nil];
 }
 
 + (void)trackListNotePinningToggled

--- a/Simplenote/SimplenoteAppDelegate+Swift.swift
+++ b/Simplenote/SimplenoteAppDelegate+Swift.swift
@@ -183,8 +183,8 @@ extension SimplenoteAppDelegate {
 
     @IBAction
     func duplicateNote(_ sender: Any) {
-        noteEditorViewController.duplicateNoteWasPressed()
-        // TODO: Set correct analytic event
+        noteEditorViewController.duplicateCurrentNote()
+        SPTracker.trackShortcutDuplicateNote()
     }
 
     @IBAction


### PR DESCRIPTION
### Fix
In this PR we're wiring new Tracks Events, related to Note Duplication.

### Test
- [ ] Verify you can Duplicate a Note from the Editor
- [ ] Verify you can Duplicate a Note from the Notes List
- [ ] Verify you can use the **CMD + D** shortcut to duplicate a Note

### Release
These changes do not require release notes.
