### PR TITLE
Fixes Horizontal Clipping

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,10 @@
 -----
 
 
+2.19
+-----
+- Prevents Text Clipping when Scroll Bars are always visible #1097
+
 2.18
 -----
 - Added preferences menu to centralize app options and customizations #1042

--- a/Simplenote/NoteEditorViewController+Swift.swift
+++ b/Simplenote/NoteEditorViewController+Swift.swift
@@ -180,7 +180,23 @@ extension NoteEditorViewController {
     }
 
     private func maximumTextWidth(for superviewWidth: CGFloat) -> CGFloat {
-        Options.shared.editorFullWidth ? superviewWidth : min(EditorMetrics.maximumNarrowWidth, superviewWidth)
+        guard Options.shared.editorFullWidth else {
+            return min(EditorMetrics.maximumNarrowWidth, superviewWidth)
+        }
+
+        return superviewWidth - legacyScrollerWidth(for: self.scrollView)
+    }
+
+    private func legacyScrollerWidth(for scrollView: NSScrollView) -> CGFloat {
+        guard NSScroller.preferredScrollerStyle == .legacy else {
+            return .zero
+        }
+
+        guard let scroller = scrollView.verticalScroller else {
+            return .zero
+        }
+
+        return NSScroller.scrollerWidth(for: scroller.controlSize, scrollerStyle: scroller.scrollerStyle)
     }
 
     /// Whenever `SuperviewWidth > MaximumTextWidth` this API will return an Inset which will center onscreen the TextContainer


### PR DESCRIPTION
### Fix
In this PR we're accounting for the Legacy Scroller Behavior system setting, which currently produces clipping.

Closes #910

### Test
1. Open System Settings > Appearance
2. Select **Show scroll bars > Always**
3. Launch Simplentoe
4. Add a new Entry and paste the following text

   > Lorem
   > Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
Duis aute irre dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
   >
   > Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.

- [ ] Verify that you cannot get the right hand side of the text to clip


#### System Settings
<img width="300" src="https://github.com/Automattic/simplenote-macos/assets/1195260/02a770e2-0541-4674-a1bd-a9449697c4a1">


### Release
`RELEASE-NOTES.txt` was updated in 2d73fff1 with:
 
> Prevents Text Clipping when Scroll Bars are always visible #1097

