### PR TITLE
Decrease Font Size Step

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,6 @@
 2.19
 -----
-
+- Font Size step has now been decreased to 1pt #1100
 
 2.18
 -----

--- a/Simplenote/FontSettings.swift
+++ b/Simplenote/FontSettings.swift
@@ -5,7 +5,7 @@ class FontSettings: NSObject {
     static let minimum = CGFloat(10)
     static let normal = CGFloat(15)
     static let maximum = CGFloat(30)
-    static let step = CGFloat(5)
+    static let step = CGFloat(1)
 
     static func valueIsValidFontSize(_ value: CGFloat) -> Bool {
         value.truncatingRemainder(dividingBy: step) == .zero

--- a/Simplenote/Preferences.storyboard
+++ b/Simplenote/Preferences.storyboard
@@ -247,7 +247,7 @@
                                             </textField>
                                             <slider verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="pOX-Cq-Ibe">
                                                 <rect key="frame" x="176" y="14" width="370" height="28"/>
-                                                <sliderCell key="cell" continuous="YES" state="on" alignment="left" minValue="10" maxValue="30" doubleValue="15" tickMarkPosition="above" numberOfTickMarks="5" allowsTickMarkValuesOnly="YES" sliderType="linear" id="swY-bZ-H2P"/>
+                                                <sliderCell key="cell" continuous="YES" state="on" alignment="left" minValue="10" maxValue="30" doubleValue="15" tickMarkPosition="above" numberOfTickMarks="5" sliderType="linear" id="swY-bZ-H2P"/>
                                                 <connections>
                                                     <action selector="textSizeHasChanged:" target="ReV-pG-fyt" id="wVw-V2-F3w"/>
                                                 </connections>


### PR DESCRIPTION
### Details
In this PR we're decreasing the supported font size step to 1pt.

### Test
1. Launch Simplenote macOS

- [ ] Verify you can increase / decrease the font size by pressing `CMD +` / `CMD -` in the editor area
- [ ] Verify that you can modify the font size, too, from the Settings UI
- [ ] Verify that the font size step is 1pt

### Release
`RELEASE-NOTES.txt` was updated in 4cbb5a44 with:

> Font Size step has now been decreased to 1pt #1100
