### PR TITLE
Updated tracks to fetch from SPM instead of cocoapods

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -13,7 +13,6 @@ workspace 'Simplenote.xcworkspace'
 abstract_target 'Automattic' do
   # Automattic Shared
   #
-  pod 'Automattic-Tracks-iOS', '0.8.0'
   pod 'Simperium-OSX', '1.9.0'
 
   # Main Target

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,17 +1,4 @@
 PODS:
-  - Automattic-Tracks-iOS (0.8.0):
-    - CocoaLumberjack (~> 3)
-    - Reachability (~> 3)
-    - Sentry (~> 6)
-    - Sodium (>= 0.9.1)
-    - UIDeviceIdentifier (~> 1)
-  - CocoaLumberjack (3.7.0):
-    - CocoaLumberjack/Core (= 3.7.0)
-  - CocoaLumberjack/Core (3.7.0)
-  - Reachability (3.2)
-  - Sentry (6.2.1):
-    - Sentry/Core (= 6.2.1)
-  - Sentry/Core (6.2.1)
   - Simperium-OSX (1.9.0):
     - Simperium-OSX/DiffMatchPach (= 1.9.0)
     - Simperium-OSX/JRSwizzle (= 1.9.0)
@@ -23,29 +10,17 @@ PODS:
   - Simperium-OSX/SocketRocket (1.9.0)
   - Simperium-OSX/SPReachability (1.9.0)
   - Simperium-OSX/SSKeychain (1.9.0)
-  - Sodium (0.9.1)
 
 DEPENDENCIES:
-  - Automattic-Tracks-iOS (= 0.8.0)
   - Simperium-OSX (= 1.9.0)
 
 SPEC REPOS:
   trunk:
-    - Automattic-Tracks-iOS
-    - CocoaLumberjack
-    - Reachability
-    - Sentry
     - Simperium-OSX
-    - Sodium
 
 SPEC CHECKSUMS:
-  Automattic-Tracks-iOS: 1f68ebf14cc9607c65685f46b58e81532932bf48
-  CocoaLumberjack: e8955b9d337ac307103b0a34fd141c32f27e53c5
-  Reachability: 33e18b67625424e47b6cde6d202dce689ad7af96
-  Sentry: 9b922b396b0e0bca8516a10e36b0ea3ebea5faf7
   Simperium-OSX: bc465c8830e5b731e2489085459acc96160104d6
-  Sodium: 23d11554ecd556196d313cf6130d406dfe7ac6da
 
-PODFILE CHECKSUM: c750f3af3649535e285cc6f551e1fbc83e1f1cb3
+PODFILE CHECKSUM: 6a4f4b194e607ac81860112b02c6955c47c79754
 
 COCOAPODS: 1.14.1

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -465,6 +465,8 @@
 		BA553F0927065E20007737E9 /* FontSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA553F0727065E20007737E9 /* FontSettings.swift */; };
 		BA5F020526BB57F000581E92 /* NSAlert+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA5F020426BB57F000581E92 /* NSAlert+Simplenote.swift */; };
 		BA5F020626BB57F000581E92 /* NSAlert+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA5F020426BB57F000581E92 /* NSAlert+Simplenote.swift */; };
+		BA78AF6F2B5B2BBA00DCF896 /* AutomatticTracks in Frameworks */ = {isa = PBXBuildFile; productRef = BA78AF6E2B5B2BBA00DCF896 /* AutomatticTracks */; };
+		BA78AF712B5B2BC300DCF896 /* AutomatticTracks in Frameworks */ = {isa = PBXBuildFile; productRef = BA78AF702B5B2BC300DCF896 /* AutomatticTracks */; };
 		BA938CEC26ACFF4A00BE5A1D /* Remote.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA938CEB26ACFF4A00BE5A1D /* Remote.swift */; };
 		BA938CEE26AD055400BE5A1D /* AccountVerificationController+TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA938CED26AD055400BE5A1D /* AccountVerificationController+TestHelpers.swift */; };
 		BAA0A87A26B9F0B50006260E /* RemoteError.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAA0A87926B9F0B50006260E /* RemoteError.swift */; };
@@ -880,6 +882,7 @@
 				B5A8919C231ECB3D0007EDCB /* Sparkle.framework in Frameworks */,
 				26F72A8D14032D2A00A7935E /* Cocoa.framework in Frameworks */,
 				B5609AEA24EEC9910097777A /* SimplenoteSearch in Frameworks */,
+				BA78AF6F2B5B2BBA00DCF896 /* AutomatticTracks in Frameworks */,
 				B5609AF224EF17270097777A /* SimplenoteFoundation in Frameworks */,
 				D0A1D693931CD24A56140DF7 /* Pods_Automattic_Simplenote.framework in Frameworks */,
 			);
@@ -897,6 +900,7 @@
 				466FFEE117CC10A800399652 /* Cocoa.framework in Frameworks */,
 				B55E98FD1BE03E3F0087CA48 /* Security.framework in Frameworks */,
 				B5609AE824EEC9860097777A /* SimplenoteSearch in Frameworks */,
+				BA78AF712B5B2BC300DCF896 /* AutomatticTracks in Frameworks */,
 				B5609AF024EF171D0097777A /* SimplenoteFoundation in Frameworks */,
 				1E077730C2108B885911E3B5 /* Pods_Automattic_Simplenote_AppStore.framework in Frameworks */,
 			);
@@ -1696,6 +1700,7 @@
 				B5609AE924EEC9910097777A /* SimplenoteSearch */,
 				B5609AF124EF17270097777A /* SimplenoteFoundation */,
 				B50FB24B251C08910028DE25 /* SimplenoteInterlinks */,
+				BA78AF6E2B5B2BBA00DCF896 /* AutomatticTracks */,
 			);
 			productName = Simplenote;
 			productReference = 26F72A8814032D2A00A7935E /* Simplenote.app */;
@@ -1722,6 +1727,7 @@
 				B5609AE724EEC9860097777A /* SimplenoteSearch */,
 				B5609AEF24EF171D0097777A /* SimplenoteFoundation */,
 				3FAC7B24254BBCA600B47276 /* SimplenoteInterlinks */,
+				BA78AF702B5B2BC300DCF896 /* AutomatticTracks */,
 			);
 			productName = Simplenote;
 			productReference = 466FFF2F17CC10A800399652 /* Simplenote.app */;
@@ -1811,6 +1817,7 @@
 				B5609AE624EEC9860097777A /* XCRemoteSwiftPackageReference "SimplenoteSearch-Swift" */,
 				B5609AEE24EF171D0097777A /* XCRemoteSwiftPackageReference "SimplenoteFoundation-Swift" */,
 				B50FB24A251C08910028DE25 /* XCRemoteSwiftPackageReference "SimplenoteInterlinks-Swift" */,
+				BA78AF6D2B5B2BAE00DCF896 /* XCRemoteSwiftPackageReference "Automattic-Tracks-iOS" */,
 			);
 			productRefGroup = 26F72A8914032D2A00A7935E /* Products */;
 			projectDirPath = "";
@@ -3081,6 +3088,14 @@
 				minimumVersion = 1.3.0;
 			};
 		};
+		BA78AF6D2B5B2BAE00DCF896 /* XCRemoteSwiftPackageReference "Automattic-Tracks-iOS" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/Automattic/Automattic-Tracks-iOS";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 3.2.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -3113,6 +3128,16 @@
 			isa = XCSwiftPackageProductDependency;
 			package = B5609AEE24EF171D0097777A /* XCRemoteSwiftPackageReference "SimplenoteFoundation-Swift" */;
 			productName = SimplenoteFoundation;
+		};
+		BA78AF6E2B5B2BBA00DCF896 /* AutomatticTracks */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = BA78AF6D2B5B2BAE00DCF896 /* XCRemoteSwiftPackageReference "Automattic-Tracks-iOS" */;
+			productName = AutomatticTracks;
+		};
+		BA78AF702B5B2BC300DCF896 /* AutomatticTracks */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = BA78AF6D2B5B2BAE00DCF896 /* XCRemoteSwiftPackageReference "Automattic-Tracks-iOS" */;
+			productName = AutomatticTracks;
 		};
 /* End XCSwiftPackageProductDependency section */
 

--- a/Simplenote.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Simplenote.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,6 +1,24 @@
 {
   "pins" : [
     {
+      "identity" : "automattic-tracks-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Automattic/Automattic-Tracks-iOS",
+      "state" : {
+        "revision" : "b6979ef69b4b094c8809ba83661222dcd0d7667e",
+        "version" : "3.2.0"
+      }
+    },
+    {
+      "identity" : "sentry-cocoa",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/getsentry/sentry-cocoa",
+      "state" : {
+        "revision" : "3b9a8e69ca296bd8cd0e317ad7a448e5daf4a342",
+        "version" : "8.18.0"
+      }
+    },
+    {
       "identity" : "simplenotefoundation-swift",
       "kind" : "remoteSourceControl",
       "location" : "git@github.com:Automattic/SimplenoteFoundation-Swift.git",
@@ -25,6 +43,24 @@
       "state" : {
         "revision" : "499d2809d169fcbeb9ff75568d9f1f937f290ffc",
         "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-sodium",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jedisct1/swift-sodium",
+      "state" : {
+        "revision" : "4f9164a0a2c9a6a7ff53a2833d54a5c79c957342",
+        "version" : "0.9.1"
+      }
+    },
+    {
+      "identity" : "uideviceidentifier",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/squarefrog/UIDeviceIdentifier",
+      "state" : {
+        "revision" : "4699794b08bb79a4d77785edaba6ea739e298e4b",
+        "version" : "2.3.0"
       }
     }
   ],


### PR DESCRIPTION
### Fix
The version of Automattic tracks is very outdate (0.8.0)

Tracks also no longer supports downloading through cocoa pods, which SNMac is using.  

So we should update that.  Which is what I have done here.  

### Test
1. pull the branch.  Run bundle exec pod install on your snmac repo.  Clean the project
2. Confirm the app builds
3. Attempt to send an event to tracks.  Confirm it arrives.

### Review
***(Required)*** Add instructions for reviewers.  For example:
> Only one developer is required to review these changes, but anyone can perform the review.
