### PR TITLE
Fixed auth view controller rendering login fields incorrectly on launch

### DIFF
--- a/Simplenote/AuthViewController+Swift.swift
+++ b/Simplenote/AuthViewController+Swift.swift
@@ -100,6 +100,12 @@ extension AuthViewController {
         passwordFieldHeightConstraint.constant   = Metrics.passwordHeight(signingIn: signingIn)
         forgotPasswordHeightConstraint.constant  = Metrics.forgotHeight(signingIn: signingIn)
         wordPressSSOHeightConstraint.constant    = Metrics.wordPressHeight(signingIn: signingIn)
+        
+        let fields      = [passwordField, forgotPasswordButton, wordPressSSOButton].compactMap { $0 }
+        let alphaStart  = signingIn ? AppKitConstants.alpha0_0 : AppKitConstants.alpha1_0
+        let alphaEnd    = signingIn ? AppKitConstants.alpha1_0 : AppKitConstants.alpha0_0
+
+        fields.updateAlphaValue(AppKitConstants.alpha0_0)
     }
 
     /// Animates Visible / Invisible components, based on the specified state


### PR DESCRIPTION
### Fix
When the login view is originally rendered we start in a "sign in" state which displays just the email field and the login button.  If you tap the login button then we display the password field, forgot password, all the things you need.  Well.. right now when the view first renders all of the login buttons and fields are still visible, but they have no frame size so they are all on top of all of the other views.  

To make the animations work we still need those size changes, but we should also set the alpha values of those fields to 0 so they don't appear.  This PR fixes that.

Fixes #1127 

### Test
1. Log out of simplenote Mac.  
2. Confirm that when the sign up view appears you do not see a password field/forgot password link/WordPress sso login.
3. Tap the login button and make sure the views animate in
4. tap sign up and confirm that the sign up view returns correctly

### Review
***(Required)*** Add instructions for reviewers.  For example:
> Only one developer is to review these changes, but anyone can perform the review.
