### PR TITLE
Upgrade CI to Apple Silicon

### DIFF
--- a/.buildkite/commands/build-and-test-app-store.sh
+++ b/.buildkite/commands/build-and-test-app-store.sh
@@ -1,6 +1,4 @@
-#! /bin/bash
-
-set -eu
+#! /bin/bash -eu
 
 echo "--- :rubygems: Setting up Gems"
 install_gems

--- a/.buildkite/commands/build-and-test.sh
+++ b/.buildkite/commands/build-and-test.sh
@@ -1,6 +1,4 @@
-#! /bin/bash
-
-set -eu
+#! /bin/bash -eu
 
 echo "--- :rubygems: Setting up Gems"
 install_gems

--- a/.buildkite/commands/build-and-upload-release.sh
+++ b/.buildkite/commands/build-and-upload-release.sh
@@ -1,6 +1,4 @@
-#! /bin/bash
-
-set -eu
+#! /bin/bash -eu
 
 echo "--- :rubygems: Setting up Gems"
 install_gems

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,7 +2,7 @@
 common_params:
   # Common plugin settings to use with the `plugins` key.
   - &common_plugins
-    - automattic/a8c-ci-toolkit#2.15.0
+    - automattic/a8c-ci-toolkit#3.0.1
   # Common environment values to use with the `env` key.
   - &common_env
     IMAGE_ID: xcode-14.3.1

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,7 +5,7 @@ common_params:
     - automattic/a8c-ci-toolkit#3.0.1
   # Common environment values to use with the `env` key.
   - &common_env
-    IMAGE_ID: xcode-14.3.1
+    IMAGE_ID: xcode-15.2-xl
 
 # This is the default pipeline – it will build and test the app
 steps:

--- a/.buildkite/release-builds.yml
+++ b/.buildkite/release-builds.yml
@@ -2,7 +2,7 @@
 common_params:
   # Common plugin settings to use with the `plugins` key.
   - &common_plugins
-    - automattic/a8c-ci-toolkit#2.15.0
+    - automattic/a8c-ci-toolkit#3.0.1
   # Common environment values to use with the `env` key.
   - &common_env
     IMAGE_ID: xcode-14.3.1

--- a/.buildkite/release-builds.yml
+++ b/.buildkite/release-builds.yml
@@ -5,7 +5,7 @@ common_params:
     - automattic/a8c-ci-toolkit#3.0.1
   # Common environment values to use with the `env` key.
   - &common_env
-    IMAGE_ID: xcode-14.3.1
+    IMAGE_ID: xcode-15.2-xl
 
 # This is the default pipeline – it will build and test the app
 steps:


### PR DESCRIPTION
This PR updates the CI image from `14.3.1` to `15.2-xl` (an image that was created with 120 GB of space instead of 90 GB) so that it can run on Apple Silicon CI. The Buildkite-CI repo PR was already merged in https://github.com/Automattic/buildkite-ci/pull/358, so we need to merge this PR in order to SNMac to be able to use CI. 

I also updated the CI Toolkit from `2.15.0` to `3.0.1` while I was at it (no relevant breaking changes). 

Merging to `release/2.20` so that release can move forward.

I created a test Buildkite run here that passed successfully: https://buildkite.com/automattic/simplenote-macos/builds/105