### PR TITLE
Add spotlight support for Simplenote

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,6 @@
 2.21
 -----
-
+- Added spotlight search support for notes
 
 2.20
 -----

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -463,6 +463,7 @@
 		BA4C6D16264CA8C000B723A7 /* SignupRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA4C6D15264CA8C000B723A7 /* SignupRemoteTests.swift */; };
 		BA4C6D18264CAAF800B723A7 /* URLRequest+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA4C6D17264CAAF800B723A7 /* URLRequest+Simplenote.swift */; };
 		BA52005B2BC878F1003F1B75 /* CSSearchable+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA52005A2BC878F1003F1B75 /* CSSearchable+Helpers.swift */; };
+		BA52005D2BC88397003F1B75 /* NSManagedObjectContext+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA52005C2BC88397003F1B75 /* NSManagedObjectContext+Simplenote.swift */; };
 		BA553F0827065E20007737E9 /* FontSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA553F0727065E20007737E9 /* FontSettings.swift */; };
 		BA553F0927065E20007737E9 /* FontSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA553F0727065E20007737E9 /* FontSettings.swift */; };
 		BA5F020526BB57F000581E92 /* NSAlert+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA5F020426BB57F000581E92 /* NSAlert+Simplenote.swift */; };
@@ -870,6 +871,7 @@
 		BA4C6D15264CA8C000B723A7 /* SignupRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignupRemoteTests.swift; sourceTree = "<group>"; };
 		BA4C6D17264CAAF800B723A7 /* URLRequest+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLRequest+Simplenote.swift"; sourceTree = "<group>"; };
 		BA52005A2BC878F1003F1B75 /* CSSearchable+Helpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CSSearchable+Helpers.swift"; sourceTree = "<group>"; };
+		BA52005C2BC88397003F1B75 /* NSManagedObjectContext+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSManagedObjectContext+Simplenote.swift"; sourceTree = "<group>"; };
 		BA553F0727065E20007737E9 /* FontSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontSettings.swift; sourceTree = "<group>"; };
 		BA5F020426BB57F000581E92 /* NSAlert+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSAlert+Simplenote.swift"; sourceTree = "<group>"; };
 		BA938CEB26ACFF4A00BE5A1D /* Remote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Remote.swift; sourceTree = "<group>"; };
@@ -1300,6 +1302,7 @@
 				BA5F020426BB57F000581E92 /* NSAlert+Simplenote.swift */,
 				BAFB544F26CCA7F1006E037C /* NSProgressIndicator+Simplenote.swift */,
 				BA2C65CA26FE996100FA84E1 /* NSButton+Extensions.swift */,
+				BA52005C2BC88397003F1B75 /* NSManagedObjectContext+Simplenote.swift */,
 			);
 			name = Extensions;
 			sourceTree = "<group>";
@@ -2159,6 +2162,7 @@
 				B59EA98124AA5EFA008ABE4B /* NoteMetrics.swift in Sources */,
 				B5EDF338258A8F1B0066D91D /* TagListFilter.swift in Sources */,
 				375D293621E033D1007AB25A /* document.c in Sources */,
+				BA52005D2BC88397003F1B75 /* NSManagedObjectContext+Simplenote.swift in Sources */,
 				B5609AEC24EEE7200097777A /* SPBucket+Simplenote.swift in Sources */,
 				B56FA7902437C672002CB9FF /* ColorStudio.swift in Sources */,
 				B5177CD025EEEEFB00A8D834 /* NSWindow+Transitions.swift in Sources */,

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -468,6 +468,8 @@
 		BA553F0927065E20007737E9 /* FontSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA553F0727065E20007737E9 /* FontSettings.swift */; };
 		BA5F020526BB57F000581E92 /* NSAlert+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA5F020426BB57F000581E92 /* NSAlert+Simplenote.swift */; };
 		BA5F020626BB57F000581E92 /* NSAlert+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA5F020426BB57F000581E92 /* NSAlert+Simplenote.swift */; };
+		BA71EC242BC88FD000F42CB1 /* CSSearchable+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA52005A2BC878F1003F1B75 /* CSSearchable+Helpers.swift */; };
+		BA71EC252BC88FFC00F42CB1 /* NSManagedObjectContext+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA52005C2BC88397003F1B75 /* NSManagedObjectContext+Simplenote.swift */; };
 		BA78AF6F2B5B2BBA00DCF896 /* AutomatticTracks in Frameworks */ = {isa = PBXBuildFile; productRef = BA78AF6E2B5B2BBA00DCF896 /* AutomatticTracks */; };
 		BA78AF712B5B2BC300DCF896 /* AutomatticTracks in Frameworks */ = {isa = PBXBuildFile; productRef = BA78AF702B5B2BC300DCF896 /* AutomatticTracks */; };
 		BA938CEC26ACFF4A00BE5A1D /* Remote.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA938CEB26ACFF4A00BE5A1D /* Remote.swift */; };
@@ -2320,6 +2322,7 @@
 				BA2C65CF26FE996A00FA84E1 /* NSButton+Extensions.swift in Sources */,
 				375D294121E033D1007AB25A /* html_smartypants.c in Sources */,
 				B5E061782450AEDA0076111A /* ToolbarView.swift in Sources */,
+				BA71EC242BC88FD000F42CB1 /* CSSearchable+Helpers.swift in Sources */,
 				B502C1DE25BA2EB700145D6C /* AccountRemote.swift in Sources */,
 				F998F3EC22853C49008C2B59 /* CrashLogging.swift in Sources */,
 				B5919365245A7AD300A70C0C /* NSScreen+Simplenote.swift in Sources */,
@@ -2355,6 +2358,7 @@
 				B5F807CD2481982B0048CBD7 /* Note+Simplenote.swift in Sources */,
 				A6C1E21525E010140076ADF7 /* SPApplication.swift in Sources */,
 				466FFEB417CC10A800399652 /* DateTransformer.m in Sources */,
+				BA71EC252BC88FFC00F42CB1 /* NSManagedObjectContext+Simplenote.swift in Sources */,
 				B5132FA923C4B9760065DD80 /* NSTextStorage+Simplenote.swift in Sources */,
 				375D293721E033D1007AB25A /* document.c in Sources */,
 				376EE3EC202B748E00E3812E /* SPAboutTextField.swift in Sources */,

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -462,6 +462,7 @@
 		BA2C65CF26FE996A00FA84E1 /* NSButton+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA2C65CA26FE996100FA84E1 /* NSButton+Extensions.swift */; };
 		BA4C6D16264CA8C000B723A7 /* SignupRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA4C6D15264CA8C000B723A7 /* SignupRemoteTests.swift */; };
 		BA4C6D18264CAAF800B723A7 /* URLRequest+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA4C6D17264CAAF800B723A7 /* URLRequest+Simplenote.swift */; };
+		BA52005B2BC878F1003F1B75 /* CSSearchable+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA52005A2BC878F1003F1B75 /* CSSearchable+Helpers.swift */; };
 		BA553F0827065E20007737E9 /* FontSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA553F0727065E20007737E9 /* FontSettings.swift */; };
 		BA553F0927065E20007737E9 /* FontSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA553F0727065E20007737E9 /* FontSettings.swift */; };
 		BA5F020526BB57F000581E92 /* NSAlert+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA5F020426BB57F000581E92 /* NSAlert+Simplenote.swift */; };
@@ -868,6 +869,7 @@
 		BA2C65CA26FE996100FA84E1 /* NSButton+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSButton+Extensions.swift"; sourceTree = "<group>"; };
 		BA4C6D15264CA8C000B723A7 /* SignupRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignupRemoteTests.swift; sourceTree = "<group>"; };
 		BA4C6D17264CAAF800B723A7 /* URLRequest+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLRequest+Simplenote.swift"; sourceTree = "<group>"; };
+		BA52005A2BC878F1003F1B75 /* CSSearchable+Helpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CSSearchable+Helpers.swift"; sourceTree = "<group>"; };
 		BA553F0727065E20007737E9 /* FontSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontSettings.swift; sourceTree = "<group>"; };
 		BA5F020426BB57F000581E92 /* NSAlert+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSAlert+Simplenote.swift"; sourceTree = "<group>"; };
 		BA938CEB26ACFF4A00BE5A1D /* Remote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Remote.swift; sourceTree = "<group>"; };
@@ -1251,6 +1253,7 @@
 			children = (
 				B5D21CB624881EF600D57A34 /* Array+Simplenote.swift */,
 				B57CB87D244DED2300BA7969 /* Bundle+Simplenote.swift */,
+				BA52005A2BC878F1003F1B75 /* CSSearchable+Helpers.swift */,
 				B53BF19B24ABDE7C00938C34 /* DateFormatter+Simplenote.swift */,
 				B5C620AA257ED4CF008359A9 /* NSAnimationContext+Simplenote.swift */,
 				B56FA79A2437D2E0002CB9FF /* NSAppearance+Simplenote.swift */,
@@ -2120,6 +2123,7 @@
 				BA2C65CB26FE996100FA84E1 /* NSButton+Extensions.swift in Sources */,
 				B58117E225B9E5D200927E0C /* AccountVerificationController.swift in Sources */,
 				B5009937242130F70037A431 /* UnicodeScalar+Simplenote.swift in Sources */,
+				BA52005B2BC878F1003F1B75 /* CSSearchable+Helpers.swift in Sources */,
 				B5985AD5242950B40044EDE9 /* NSColor+Simplenote.swift in Sources */,
 				B5C7DD3D243E1F1900BEE354 /* VersionsViewController.swift in Sources */,
 				B58BBD3D2523FF160025135F /* PopoverWindow.swift in Sources */,

--- a/Simplenote/CSSearchable+Helpers.swift
+++ b/Simplenote/CSSearchable+Helpers.swift
@@ -31,8 +31,29 @@ extension CSSearchableItem {
 }
 
 extension CSSearchableIndex {
+    // MARK: - Index Notes
+    @objc
+    func indexSpotlightItems(in context: NSManagedObjectContext) {
+        guard Options.shared.indexNotesForSpotlight else {
+            return
+        }
+
+        context.perform {
+            if let deleted = try? context.fetchObjects(for: "Note", withPredicate: NSPredicate(format: "deleted == YES")) as? [Note] {
+                CSSearchableIndex.default().deleteSearchableNotes(deleted)
+            }
+
+            if let notes = try? context.fetchObjects(for: "Note", withPredicate: NSPredicate(format: "deleted == NO")) as? [Note] {
+                CSSearchableIndex.default().indexSearchableNotes(notes)
+            }
+        }
+    }
 
     @objc func indexSearchableNote(_ note: Note) {
+        guard Options.shared.indexNotesForSpotlight else {
+            return
+        }
+
         let item = CSSearchableItem(note: note)
         indexSearchableItems([item]) { error in
             if let error = error {
@@ -42,6 +63,10 @@ extension CSSearchableIndex {
     }
 
     @objc func indexSearchableNotes(_ notes: [Note]) {
+        guard Options.shared.indexNotesForSpotlight else {
+            return
+        }
+
         let items = notes.map {
             return CSSearchableItem(note: $0)
         }

--- a/Simplenote/CSSearchable+Helpers.swift
+++ b/Simplenote/CSSearchable+Helpers.swift
@@ -40,11 +40,11 @@ extension CSSearchableIndex {
 
         context.perform {
             if let deleted = try? context.fetchObjects(for: "Note", withPredicate: NSPredicate(format: "deleted == YES")) as? [Note] {
-                CSSearchableIndex.default().deleteSearchableNotes(deleted)
+                self.deleteSearchableNotes(deleted)
             }
 
             if let notes = try? context.fetchObjects(for: "Note", withPredicate: NSPredicate(format: "deleted == NO")) as? [Note] {
-                CSSearchableIndex.default().indexSearchableNotes(notes)
+                self.indexSearchableNotes(notes)
             }
         }
     }

--- a/Simplenote/CSSearchable+Helpers.swift
+++ b/Simplenote/CSSearchable+Helpers.swift
@@ -83,9 +83,7 @@ extension CSSearchableIndex {
     }
 
     @objc func deleteSearchableNotes(_ notes: [Note]) {
-        let ids = notes.map {
-            return $0.simperiumKey!
-        }
+        let ids = notes.compactMap({ $0.simperiumKey })
 
         deleteSearchableItems(withIdentifiers: ids) { error in
             if let error = error {

--- a/Simplenote/CSSearchable+Helpers.swift
+++ b/Simplenote/CSSearchable+Helpers.swift
@@ -1,0 +1,72 @@
+//
+//  CSSearchableItem+Helpers.swift
+//  Simplenote
+//
+//  Created by Michal Kosmowski on 25/11/2016.
+//  Copyright © 2016 Automattic. All rights reserved.
+//
+
+import Foundation
+import CoreSpotlight
+import UniformTypeIdentifiers
+
+extension CSSearchableItemAttributeSet {
+
+    convenience init(note: Note) {
+        self.init(contentType: UTType.data)
+        note.ensurePreviewStringsAreAvailable()
+        title = note.titlePreview
+        contentDescription = note.bodyPreview
+    }
+
+}
+
+extension CSSearchableItem {
+
+    convenience init(note: Note) {
+        let attributeSet = CSSearchableItemAttributeSet(note: note)
+        self.init(uniqueIdentifier: note.simperiumKey, domainIdentifier: "notes", attributeSet: attributeSet)
+    }
+
+}
+
+extension CSSearchableIndex {
+
+    @objc func indexSearchableNote(_ note: Note) {
+        let item = CSSearchableItem(note: note)
+        indexSearchableItems([item]) { error in
+            if let error = error {
+                NSLog("Couldn't index note in spotlight: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    @objc func indexSearchableNotes(_ notes: [Note]) {
+        let items = notes.map {
+            return CSSearchableItem(note: $0)
+        }
+
+        indexSearchableItems(items) { error in
+            if let error = error {
+                NSLog("Couldn't index notes in spotlight: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    @objc func deleteSearchableNote(_ note: Note) {
+        deleteSearchableNotes([note])
+    }
+
+    @objc func deleteSearchableNotes(_ notes: [Note]) {
+        let ids = notes.map {
+            return $0.simperiumKey!
+        }
+
+        deleteSearchableItems(withIdentifiers: ids) { error in
+            if let error = error {
+                NSLog("Couldn't delete notes from spotlight index: \(error.localizedDescription)")
+            }
+        }
+    }
+
+}

--- a/Simplenote/NSManagedObjectContext+Simplenote.swift
+++ b/Simplenote/NSManagedObjectContext+Simplenote.swift
@@ -1,0 +1,22 @@
+//
+//  NSManagedObjectContext+Simplenote.swift
+//  Simplenote
+//
+//  Created by Charlie Scheer on 4/11/24.
+//  Copyright © 2024 Simperium. All rights reserved.
+//
+
+import Foundation
+import CoreData
+
+extension NSManagedObjectContext {
+    @objc(fetchObjectsForEntityName: withPredicate: error:)
+    func fetchObjects(for entityName: String, withPredicate predicate: NSPredicate) throws -> Array<NSFetchRequestResult> {
+        let fetchRequest = NSFetchRequest<NSFetchRequestResult>()
+        let entityDescription = NSEntityDescription.entity(forEntityName: entityName, in: self)
+
+        fetchRequest.entity = entityDescription
+
+        return try fetch(fetchRequest)
+    }
+}

--- a/Simplenote/NoteEditorViewController.m
+++ b/Simplenote/NoteEditorViewController.m
@@ -148,6 +148,8 @@ static NSString * const SPMarkdownPreferencesKey        = @"kMarkdownPreferences
 	[self.saveTimer invalidate];
 	self.saveTimer = nil;
 
+    [[CSSearchableIndex defaultSearchableIndex] indexSearchableNote:self.note];
+
     if (editorHasFocus) {
         [[NSApp keyWindow] makeFirstResponder:self.noteEditor];
 

--- a/Simplenote/NoteEditorViewController.m
+++ b/Simplenote/NoteEditorViewController.m
@@ -406,6 +406,7 @@ static NSString * const SPMarkdownPreferencesKey        = @"kMarkdownPreferences
         [SPTracker trackEditorNoteDeleted];
         noteToDelete.deleted = YES;
         [self.noteActionsDelegate editorController:self deletedNoteWithSimperiumKey:noteToDelete.simperiumKey];
+        [[CSSearchableIndex defaultSearchableIndex] deleteSearchableNote:noteToDelete];
     }
 
     [self save];

--- a/Simplenote/NoteListViewController.swift
+++ b/Simplenote/NoteListViewController.swift
@@ -812,6 +812,7 @@ extension NoteListViewController {
         for note in selectedNotes {
             SPTracker.trackListNoteDeleted()
             note.deleted = true
+            CSSearchableIndex.default().deleteSearchableNote(note)
         }
 
         simperium.save()

--- a/Simplenote/NoteListViewController.swift
+++ b/Simplenote/NoteListViewController.swift
@@ -1,5 +1,6 @@
 import Foundation
 import SimplenoteSearch
+import CoreSpotlight
 
 // MARK: - NotesControllerDelegate
 //
@@ -865,6 +866,7 @@ extension NoteListViewController {
         note.deleted = false
         simperium.save()
 
+        CSSearchableIndex.default().indexSearchableNote(note)
         SPTracker.trackListNoteRestored()
     }
 }

--- a/Simplenote/Options.swift
+++ b/Simplenote/Options.swift
@@ -140,6 +140,19 @@ extension Options {
             NotificationCenter.default.post(name: .FontSizeDidChange, object: nil)
         }
     }
+
+    /// Index notes for spotlight
+    ///
+    @objc
+    var indexNotesForSpotlight: Bool {
+        get {
+            defaults.bool(forKey: .indexNotesForSpotlight)
+        }
+
+        set {
+            defaults.set(newValue, forKey: .indexNotesForSpotlight)
+        }
+    }
 }
 
 // MARK: - Migrations

--- a/Simplenote/Preferences.storyboard
+++ b/Simplenote/Preferences.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="19455"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="22689"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -38,14 +38,14 @@
             <objects>
                 <viewController id="ReV-pG-fyt" customClass="PreferencesViewController" customModule="Simplenote" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" id="dpg-9k-XwW" customClass="BackgroundView" customModule="Simplenote" customModuleProvider="target">
-                        <rect key="frame" x="0.0" y="0.0" width="586" height="532"/>
+                        <rect key="frame" x="0.0" y="0.0" width="586" height="561"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <stackView distribution="fill" orientation="vertical" alignment="centerX" spacing="0.0" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="D3n-a2-skK">
-                                <rect key="frame" x="20" y="0.0" width="546" height="532"/>
+                                <rect key="frame" x="20" y="0.0" width="546" height="561"/>
                                 <subviews>
                                     <customView translatesAutoresizingMaskIntoConstraints="NO" id="Yoe-6O-zlp" customClass="BackgroundView" customModule="Simplenote" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="443" width="546" height="89"/>
+                                        <rect key="frame" x="0.0" y="472" width="546" height="89"/>
                                         <subviews>
                                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="tMt-d6-VMG">
                                                 <rect key="frame" x="65" y="54" width="58" height="16"/>
@@ -97,10 +97,10 @@
                                         </constraints>
                                     </customView>
                                     <customView translatesAutoresizingMaskIntoConstraints="NO" id="h39-Ga-h8l" customClass="BackgroundView" customModule="Simplenote" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="294" width="546" height="149"/>
+                                        <rect key="frame" x="0.0" y="294" width="546" height="178"/>
                                         <subviews>
                                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="J0b-De-aS5">
-                                                <rect key="frame" x="29" y="110" width="101" height="16"/>
+                                                <rect key="frame" x="29" y="139" width="101" height="16"/>
                                                 <textFieldCell key="cell" lineBreakMode="clipping" title="Note sort order:" id="OyD-gF-dLa">
                                                     <font key="font" metaFont="system"/>
                                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -108,7 +108,7 @@
                                                 </textFieldCell>
                                             </textField>
                                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="8Oy-Hc-uVh">
-                                                <rect key="frame" x="26" y="79" width="104" height="16"/>
+                                                <rect key="frame" x="26" y="108" width="104" height="16"/>
                                                 <textFieldCell key="cell" lineBreakMode="clipping" title="Note line length:" id="vRW-QM-Yad">
                                                     <font key="font" metaFont="system"/>
                                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -116,7 +116,7 @@
                                                 </textFieldCell>
                                             </textField>
                                             <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="ug2-qE-z2S">
-                                                <rect key="frame" x="175" y="104" width="375" height="25"/>
+                                                <rect key="frame" x="175" y="133" width="375" height="25"/>
                                                 <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" id="xK5-q2-is2">
                                                     <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                                                     <font key="font" metaFont="menu"/>
@@ -127,7 +127,7 @@
                                                 </connections>
                                             </popUpButton>
                                             <button identifier="lineFullButton" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="AHv-TO-sDj">
-                                                <rect key="frame" x="176" y="78" width="48" height="18"/>
+                                                <rect key="frame" x="176" y="107" width="48" height="18"/>
                                                 <buttonCell key="cell" type="radio" title="Full" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="SyX-h2-BBn">
                                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                     <font key="font" metaFont="system"/>
@@ -137,7 +137,7 @@
                                                 </connections>
                                             </button>
                                             <button identifier="noteDisplayCondensedButton" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="mMH-Pp-tjv">
-                                                <rect key="frame" x="176" y="48" width="154" height="18"/>
+                                                <rect key="frame" x="176" y="77" width="154" height="18"/>
                                                 <buttonCell key="cell" type="check" title="Condensed Note List" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="IU7-9R-R65">
                                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                     <font key="font" metaFont="system"/>
@@ -147,7 +147,7 @@
                                                 </connections>
                                             </button>
                                             <button identifier="lineNarrowButton" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="g1z-1g-qip">
-                                                <rect key="frame" x="234" y="78" width="70" height="18"/>
+                                                <rect key="frame" x="234" y="107" width="70" height="18"/>
                                                 <buttonCell key="cell" type="radio" title="Narrow" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="ahc-Xw-WLx">
                                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                     <font key="font" metaFont="system"/>
@@ -157,7 +157,7 @@
                                                 </connections>
                                             </button>
                                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="BmD-nr-cLR">
-                                                <rect key="frame" x="176" y="19" width="173" height="18"/>
+                                                <rect key="frame" x="176" y="48" width="173" height="18"/>
                                                 <buttonCell key="cell" type="check" title="Sort Tags Alphabetically" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="agd-zA-CF3">
                                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                     <font key="font" metaFont="system"/>
@@ -166,10 +166,21 @@
                                                     <action selector="sortTagsAlphabeticallyPressed:" target="ReV-pG-fyt" id="YMh-gb-3rn"/>
                                                 </connections>
                                             </button>
+                                            <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="wte-3r-Hh8">
+                                                <rect key="frame" x="176" y="19" width="171" height="18"/>
+                                                <buttonCell key="cell" type="check" title="Index Notes in Spotlight" bezelStyle="regularSquare" imagePosition="left" inset="2" id="fOY-Cb-mPJ">
+                                                    <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                    <font key="font" metaFont="system"/>
+                                                </buttonCell>
+                                                <connections>
+                                                    <action selector="indexNotesWasPressed:" target="ReV-pG-fyt" id="k81-bu-aiI"/>
+                                                </connections>
+                                            </button>
                                         </subviews>
                                         <constraints>
                                             <constraint firstItem="mMH-Pp-tjv" firstAttribute="top" secondItem="AHv-TO-sDj" secondAttribute="bottom" constant="14" id="3ug-RH-CL7"/>
                                             <constraint firstItem="BmD-nr-cLR" firstAttribute="leading" secondItem="mMH-Pp-tjv" secondAttribute="leading" id="7s0-Nx-E7g"/>
+                                            <constraint firstItem="wte-3r-Hh8" firstAttribute="leading" secondItem="BmD-nr-cLR" secondAttribute="leading" id="AB6-6H-s4c"/>
                                             <constraint firstItem="AHv-TO-sDj" firstAttribute="leading" secondItem="ug2-qE-z2S" secondAttribute="leading" id="Gvb-60-nb9"/>
                                             <constraint firstItem="g1z-1g-qip" firstAttribute="centerY" secondItem="AHv-TO-sDj" secondAttribute="centerY" id="HF2-Nc-5sj"/>
                                             <constraint firstItem="AHv-TO-sDj" firstAttribute="centerY" secondItem="8Oy-Hc-uVh" secondAttribute="centerY" id="J1D-9n-DMU"/>
@@ -178,12 +189,13 @@
                                             <constraint firstAttribute="trailing" secondItem="ug2-qE-z2S" secondAttribute="leading" constant="368" id="PDv-8k-5PR"/>
                                             <constraint firstItem="ug2-qE-z2S" firstAttribute="centerY" secondItem="J0b-De-aS5" secondAttribute="centerY" id="U5X-Ro-IK2"/>
                                             <constraint firstItem="8Oy-Hc-uVh" firstAttribute="trailing" secondItem="J0b-De-aS5" secondAttribute="trailing" id="btn-b2-XKC"/>
-                                            <constraint firstAttribute="bottom" secondItem="BmD-nr-cLR" secondAttribute="bottom" constant="20" id="eX9-7Z-3dO"/>
+                                            <constraint firstItem="wte-3r-Hh8" firstAttribute="top" secondItem="BmD-nr-cLR" secondAttribute="bottom" constant="13" id="eX9-7Z-3dO"/>
                                             <constraint firstItem="mMH-Pp-tjv" firstAttribute="leading" secondItem="AHv-TO-sDj" secondAttribute="leading" id="jIv-ok-dPn"/>
                                             <constraint firstAttribute="trailing" secondItem="ug2-qE-z2S" secondAttribute="trailing" id="mZ3-E3-auo"/>
                                             <constraint firstItem="BmD-nr-cLR" firstAttribute="top" secondItem="mMH-Pp-tjv" secondAttribute="bottom" constant="13" id="nst-sw-Av4"/>
                                             <constraint firstItem="g1z-1g-qip" firstAttribute="leading" secondItem="AHv-TO-sDj" secondAttribute="trailing" constant="12" id="qqZ-Uk-tMa"/>
                                             <constraint firstItem="8Oy-Hc-uVh" firstAttribute="top" secondItem="J0b-De-aS5" secondAttribute="bottom" constant="15" id="y71-0M-WCU"/>
+                                            <constraint firstAttribute="bottom" secondItem="wte-3r-Hh8" secondAttribute="bottom" constant="20" id="ypH-mO-HAj"/>
                                         </constraints>
                                     </customView>
                                     <customView translatesAutoresizingMaskIntoConstraints="NO" id="cxa-pV-CY8" customClass="BackgroundView" customModule="Simplenote" customModuleProvider="target">
@@ -353,6 +365,7 @@
                         <outlet property="condensedNoteListCheckbox" destination="mMH-Pp-tjv" id="x3n-d7-9dd"/>
                         <outlet property="deleteAccountButton" destination="Fm6-Vq-xaX" id="adK-5g-NFp"/>
                         <outlet property="emailLabel" destination="ZUw-Xc-VSa" id="W3l-aV-uA0"/>
+                        <outlet property="indexNotesButton" destination="fOY-Cb-mPJ" id="YXT-qy-Gcn"/>
                         <outlet property="layoutSectionBackground" destination="h39-Ga-h8l" id="0c9-Mb-LQZ"/>
                         <outlet property="lineLengthFullRadio" destination="AHv-TO-sDj" id="C3F-jP-GsT"/>
                         <outlet property="lineLengthLabel" destination="8Oy-Hc-uVh" id="HSi-IK-9sD"/>

--- a/Simplenote/PreferencesViewController.swift
+++ b/Simplenote/PreferencesViewController.swift
@@ -1,4 +1,5 @@
 import Cocoa
+import CoreSpotlight
 
 class PreferencesViewController: NSViewController {
     private var simperium: Simperium {
@@ -32,7 +33,8 @@ class PreferencesViewController: NSViewController {
     @IBOutlet private var themePopUp: NSPopUpButton!
     @IBOutlet private var textSizeSlider: NSSlider!
     @IBOutlet private var shareAnalyticsCheckbox: NSButton!
-
+    @IBOutlet weak var indexNotesButton: NSButtonCell!
+    
     // MARK: Background Views
     @IBOutlet private var accountSectionBackground: BackgroundView!
     @IBOutlet private var layoutSectionBackground: BackgroundView!
@@ -65,6 +67,7 @@ class PreferencesViewController: NSViewController {
         updateLineLength()
         updateCondensedNoteListCheckBox()
         updateSortTagsAlphabeticallyCheckbox()
+        updateIndexNotesCheckbox()
 
         updateSelectedTheme()
 
@@ -168,6 +171,10 @@ class PreferencesViewController: NSViewController {
 
     private func updateSortTagsAlphabeticallyCheckbox() {
         sortTagsAlphabeticallyCheckbox.state = Options.shared.alphabeticallySortTags ? .on : .off
+    }
+
+    private func updateIndexNotesCheckbox() {
+        indexNotesButton.state = Options.shared.indexNotesForSpotlight ? .on : .off
     }
 
     @objc
@@ -292,6 +299,19 @@ class PreferencesViewController: NSViewController {
 
         let isEnabled = sender.state == .on
         Options.shared.analyticsEnabled = isEnabled
+    }
+
+    @IBAction func indexNotesWasPressed(_ sender: Any) {
+        Options.shared.indexNotesForSpotlight.toggle()
+
+        if Options.shared.indexNotesForSpotlight {
+            let context = NSManagedObjectContext(concurrencyType: .privateQueueConcurrencyType)
+            context.parent = SimplenoteAppDelegate.shared().simperium.managedObjectContext()
+
+            CSSearchableIndex.default().indexSpotlightItems(in: context)
+        } else {
+            CSSearchableIndex.default().deleteAllSearchableItems()
+        }
     }
 }
 

--- a/Simplenote/PreferencesViewController.swift
+++ b/Simplenote/PreferencesViewController.swift
@@ -34,7 +34,7 @@ class PreferencesViewController: NSViewController {
     @IBOutlet private var textSizeSlider: NSSlider!
     @IBOutlet private var shareAnalyticsCheckbox: NSButton!
     @IBOutlet weak var indexNotesButton: NSButtonCell!
-    
+
     // MARK: Background Views
     @IBOutlet private var accountSectionBackground: BackgroundView!
     @IBOutlet private var layoutSectionBackground: BackgroundView!

--- a/Simplenote/PreferencesViewController.swift
+++ b/Simplenote/PreferencesViewController.swift
@@ -302,9 +302,14 @@ class PreferencesViewController: NSViewController {
     }
 
     @IBAction func indexNotesWasPressed(_ sender: Any) {
-        Options.shared.indexNotesForSpotlight.toggle()
+        guard let sender = sender as? NSButton else {
+            return
+        }
 
-        if Options.shared.indexNotesForSpotlight {
+        let isEnabled = sender.state == .on
+        Options.shared.indexNotesForSpotlight = isEnabled
+
+        if isEnabled {
             let context = NSManagedObjectContext(concurrencyType: .privateQueueConcurrencyType)
             context.parent = SimplenoteAppDelegate.shared().simperium.managedObjectContext()
 

--- a/Simplenote/SimplenoteAppDelegate+Swift.swift
+++ b/Simplenote/SimplenoteAppDelegate+Swift.swift
@@ -241,7 +241,7 @@ extension SimplenoteAppDelegate {
 
     @objc
     func handleUserActivity(_ userActivity: NSUserActivity) -> Bool {
-        if userActivity.activityType == "com.apple.corespotlightitem" {
+        if userActivity.activityType == CSSearchableItemActionType {
             presentNote(for: userActivity)
             return true
         }

--- a/Simplenote/SimplenoteAppDelegate+Swift.swift
+++ b/Simplenote/SimplenoteAppDelegate+Swift.swift
@@ -246,20 +246,13 @@ extension SimplenoteAppDelegate {
 
     @objc
     func handleUserActivity(_ userActivity: NSUserActivity) -> Bool {
-        if userActivity.activityType == CSSearchableItemActionType {
-            presentNote(for: userActivity)
+        if userActivity.activityType == CSSearchableItemActionType,
+           let simperiumKey = userActivity.userInfo?[CSSearchableItemActivityIdentifier] as? String {
+            displayNote(simperiumKey: simperiumKey)
             return true
         }
 
         return false
-    }
-
-    func presentNote(for userActivity: NSUserActivity) {
-        guard let uniqueIdentifier = userActivity.userInfo?[CSSearchableItemActivityIdentifier] as? String else {
-            return
-        }
-
-        displayNote(simperiumKey: uniqueIdentifier)
     }
 }
 

--- a/Simplenote/SimplenoteAppDelegate+Swift.swift
+++ b/Simplenote/SimplenoteAppDelegate+Swift.swift
@@ -1,6 +1,7 @@
 import Foundation
 import SimplenoteSearch
 import Simperium_OSX
+import CoreSpotlight
 
 // MARK: - Initialization
 //
@@ -236,6 +237,22 @@ extension SimplenoteAppDelegate {
         refreshStatusController()
 
         SPTracker.trackSettingsStatusBarDisplayMode(hidden: Options.shared.statusBarHidden)
+    }
+
+    @objc
+    func handleUserActivity(_ userActivity: NSUserActivity) {
+        if userActivity.activityType == "com.apple.corespotlightitem" {
+            presentNote(for: userActivity)
+            return
+        }
+    }
+
+    func presentNote(for userActivity: NSUserActivity) {
+        guard let uniqueIdentifier = userActivity.userInfo?[CSSearchableItemActivityIdentifier] as? String else {
+            return
+        }
+
+        displayNote(simperiumKey: uniqueIdentifier)
     }
 }
 

--- a/Simplenote/SimplenoteAppDelegate+Swift.swift
+++ b/Simplenote/SimplenoteAppDelegate+Swift.swift
@@ -240,11 +240,13 @@ extension SimplenoteAppDelegate {
     }
 
     @objc
-    func handleUserActivity(_ userActivity: NSUserActivity) {
+    func handleUserActivity(_ userActivity: NSUserActivity) -> Bool {
         if userActivity.activityType == "com.apple.corespotlightitem" {
             presentNote(for: userActivity)
-            return
+            return true
         }
+
+        return false
     }
 
     func presentNote(for userActivity: NSUserActivity) {

--- a/Simplenote/SimplenoteAppDelegate.m
+++ b/Simplenote/SimplenoteAppDelegate.m
@@ -251,6 +251,8 @@
     [self.crashLogging clearCachedUser];
 
     [self.noteEditorMetadataCache removeAll];
+
+    [[CSSearchableIndex defaultSearchableIndex] deleteAllSearchableItemsWithCompletionHandler:nil];
 }
 
 - (void)simperium:(Simperium *)simperium didFailWithError:(NSError *)error

--- a/Simplenote/SimplenoteAppDelegate.m
+++ b/Simplenote/SimplenoteAppDelegate.m
@@ -232,6 +232,10 @@
     [self.aboutWindowController showWindow:self];
 }
 
+- (BOOL)application:(NSApplication *)application continueUserActivity:(NSUserActivity *)userActivity restorationHandler:(void (^)(NSArray<id<NSUserActivityRestoring>> * _Nonnull))restorationHandler
+{
+    [self handleUserActivity:userActivity];
+}
 
 #pragma mark - Simperium Delegates
 

--- a/Simplenote/SimplenoteAppDelegate.m
+++ b/Simplenote/SimplenoteAppDelegate.m
@@ -579,9 +579,6 @@
 
 - (void)indexSpotlightItemsIfNeeded
 {
-    if ([[Options shared] indexNotesForSpotlight] == NO) {
-        return;
-    }
     // This process should be executed *just once*, and only if the user is already logged in (AKA "Upgrade")
     NSString *kSpotlightDidRunKey = @"SpotlightDidRunKey";
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];

--- a/Simplenote/SimplenoteAppDelegate.m
+++ b/Simplenote/SimplenoteAppDelegate.m
@@ -579,6 +579,9 @@
 
 - (void)indexSpotlightItemsIfNeeded
 {
+    if ([[Options shared] indexNotesForSpotlight] == NO) {
+        return;
+    }
     // This process should be executed *just once*, and only if the user is already logged in (AKA "Upgrade")
     NSString *kSpotlightDidRunKey = @"SpotlightDidRunKey";
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
@@ -602,13 +605,7 @@
     NSManagedObjectContext *context = [[NSManagedObjectContext alloc] initWithConcurrencyType:NSPrivateQueueConcurrencyType];
     [context setParentContext:self.simperium.managedObjectContext];
 
-    [context performBlock:^{
-        NSArray *deleted = [context fetchObjectsForEntityName:@"Note" withPredicate:[NSPredicate predicateWithFormat:@"deleted == YES"] error:nil];
-        [[CSSearchableIndex defaultSearchableIndex] deleteSearchableNotes:deleted];
-
-        NSArray *notes = [context fetchObjectsForEntityName:@"Note" withPredicate:[NSPredicate predicateWithFormat:@"deleted == NO"] error:nil];
-        [[CSSearchableIndex defaultSearchableIndex] indexSearchableNotes:notes];
-    }];
+    [[CSSearchableIndex defaultSearchableIndex] indexSpotlightItemsIn:context];
 }
 
 @end

--- a/Simplenote/SimplenoteAppDelegate.m
+++ b/Simplenote/SimplenoteAppDelegate.m
@@ -236,7 +236,7 @@
 
 - (BOOL)application:(NSApplication *)application continueUserActivity:(NSUserActivity *)userActivity restorationHandler:(void (^)(NSArray<id<NSUserActivityRestoring>> * _Nonnull))restorationHandler
 {
-    [self handleUserActivity:userActivity];
+    return [self handleUserActivity:userActivity];
 }
 
 #pragma mark - Simperium Delegates

--- a/Simplenote/SimplenoteAppDelegate.m
+++ b/Simplenote/SimplenoteAppDelegate.m
@@ -286,6 +286,13 @@
                 }
 
                 [self.noteEditorMetadataCache didUpdateNote:note];
+
+                if (note && !note.deleted) {
+                    [[CSSearchableIndex defaultSearchableIndex] indexSearchableNote:note];
+                } else {
+                    [[CSSearchableIndex defaultSearchableIndex] deleteSearchableItemsWithIdentifiers:@[key] completionHandler:nil];
+                }
+                
                 break;
             }
             

--- a/Simplenote/SimplenoteAppDelegate.m
+++ b/Simplenote/SimplenoteAppDelegate.m
@@ -124,8 +124,6 @@
     [self cleanupTags];
     [self startListeningForThemeNotifications];
 
-    [self indexSpotlightItemsIfNeeded];
-
     [SPTracker trackApplicationLaunched];
 }
 
@@ -571,39 +569,6 @@
 - (NSUndoManager *)windowWillReturnUndoManager:(NSWindow *)window
 {
     return [[self managedObjectContext] undoManager];
-}
-
-
-#pragma mark ================================================================================
-#pragma mark Spotlight
-#pragma mark ================================================================================
-
-- (void)indexSpotlightItemsIfNeeded
-{
-    // This process should be executed *just once*, and only if the user is already logged in (AKA "Upgrade")
-    NSString *kSpotlightDidRunKey = @"SpotlightDidRunKey";
-    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-
-    if ([defaults boolForKey:kSpotlightDidRunKey] == true) {
-        return;
-    }
-
-    [defaults setBool:true forKey:kSpotlightDidRunKey];
-    [defaults synchronize];
-
-    if (self.simperium.user.authenticated == false) {
-        return;
-    }
-
-    [self indexSpotlightItems];
-}
-
-- (void)indexSpotlightItems
-{
-    NSManagedObjectContext *context = [[NSManagedObjectContext alloc] initWithConcurrencyType:NSPrivateQueueConcurrencyType];
-    [context setParentContext:self.simperium.managedObjectContext];
-
-    [[CSSearchableIndex defaultSearchableIndex] indexSpotlightItemsIn:context];
 }
 
 @end

--- a/Simplenote/UserDefaults+Simplenote.swift
+++ b/Simplenote/UserDefaults+Simplenote.swift
@@ -14,6 +14,7 @@ extension UserDefaults {
         case statusBarHidden
         case themeName = "VSThemeManagerThemePrefKey"
         case fontSize = "kFontSizePreferencesKey"
+        case indexNotesForSpotlight
     }
 }
 


### PR DESCRIPTION
### Fix
It was requested in #1000 to index all of the notes in Simplenote so they can be searched for in spotlight.  This is a great idea, so I have done just that!

With this PR you will be able to type in the text or title of any note into spotlight and the not will appear in the search results.  Then you will be able to launch Simplenote directly to that note from spotlight.

fixes #1000 

### Test
Prep:
We want to confirm indexing and removing indexing before confirming the one time indexing of all of the existing notes.  So at first we want to not run that indexing.... so:

1. Go to SimplenoteAppDelegate L.126 and comment out the line `[self indexSpotlightItemsIfNeeded];` so we don't index all your notes right away

Test adding and removing notes from the spotlight index:
1. Open up Simplenote on another device that is logged into the same account and look for a note with some text.  Open up spotlight and type that text in to the search field.  Confirm that the note does not appear
2. Open Simplenote on this device, open up that same note, add some text to it and then open a different note to force a save
3. Return to Spotlight and search for some of the text in that note.  Confirm that the note appears in spotlight as a search result
4. select that search result.  Confirm that Simplenote opens and goes to the note in question
5. Now put that note in the trash.  Go back to spotlight and search the same text, confirm that you do not see the note appear.


One time index:
6. now uncomment out the code we disabled before in the SimplenoteAppDelegate
7. relaunch the app.  Give the app some time to do the indexing, this will happen in the background so you won't notice or get any indication that it is doing so.
8. Now search for text from any of your notes.  Confirm it appears in spotlight
9. Put a break point in SimplenoteAppDelegate L602.  Run the app again and confirm you do not hit this breakpoint.  We only want to run that indexing once.

### Review
***(Required)*** Add instructions for reviewers.  For example:
> Only one developer is required to review these changes, but anyone can perform the review.

### Release
***(Required)*** Add a concise statement to `RELEASE-NOTES.txt` if the changes should be included in release notes. Include details about updating the notes in this section. For example:
> `RELEASE-NOTES.txt` was updated in ca5d1a with:
> 
> > Added spotlight search support for notes


