### PR TITLE
Fixed issue where the navigation buttons were invisible in markdown view

### DIFF
--- a/Simplenote/MarkdownViewController.swift
+++ b/Simplenote/MarkdownViewController.swift
@@ -169,7 +169,7 @@ private extension MarkdownViewController {
     }
 
     func refreshStyle() {
-        backgroundView.fillColor = .simplenoteSecondaryBackgroundColor
+        backgroundView.fillColor = .clear
     }
 
     func refreshHTML() {


### PR DESCRIPTION
### Fix
On Mac, when you tap on the Markdown view button we display the note text in a webkit view.  The background color of this view is currently blocking out the navigation buttons so you can't see where they are to turn off the markdown view.  

In this PR I have updated markdown view background color to clear.  The other views backgrounds still supply the background color so the markdown view appearance is the same but you can see the buttons.

### Test
1. Open a note that has markdown enabled
2. tap on the markdown button

- [ ] confirm you can see the markdown and can still see the toolbar buttons

### Review
***(Required)*** Add instructions for reviewers.  For example:
> Only one developer is required to review these changes, but anyone can perform the review.

### Release
***(Required)*** Add a concise statement to `RELEASE-NOTES.txt` if the changes should be included in release notes. Include details about updating the notes in this section. For example:
> `RELEASE-NOTES.txt` was updated in 74f0d3 with:
> 
> > Fixed issue where toolbar buttons couldn't be seen while viewing markdown