### PR TITLE
Updates linter rules

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -46,9 +46,9 @@ only_rules:
   - trailing_semicolon
 
   # Lines should not have trailing whitespace.
-  - trailing_whitespace
+#  - trailing_whitespace
 
-  - vertical_whitespace
+#  - vertical_whitespace
 
   - custom_rules
 


### PR DESCRIPTION
### Fix
In this PR we're adjusting SwiftLint rules, so that we stop seeing warnings about newlines.

### Test
- [ ] Verify the app builds correctly

### Release
> These changes do not require release notes.
