### PR TITLE
Magic Link Login: Mk 3

### DIFF
--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -133,6 +133,7 @@
 		B542FE5325D42EA600A3582D /* SPTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6BBDA3225501398005C8343 /* SPTextView.swift */; };
 		B542FE5725D42EC700A3582D /* Storage.m in Sources */ = {isa = PBXBuildFile; fileRef = A6084B2B25D1B77000DDFAB2 /* Storage.m */; };
 		B5438013246358BA00F34B1C /* Icons.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B543800F246355FA00F34B1C /* Icons.xcassets */; };
+		B545DDD22C2313BA00A8FD89 /* AuthenticationMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = B545DDD12C2313BA00A8FD89 /* AuthenticationMode.swift */; };
 		B5469FCB2587DE3F007ED7BE /* SortMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5469FC92587DE3F007ED7BE /* SortMode.swift */; };
 		B5469FD12587FCD9007ED7BE /* NSSortDescriptor+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5469FCF2587FCD9007ED7BE /* NSSortDescriptor+Simplenote.swift */; };
 		B5469FDA25880128007ED7BE /* OptionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5469FD925880128007ED7BE /* OptionsTests.swift */; };
@@ -557,6 +558,7 @@
 		B53BF1A324AC38C100938C34 /* VersionsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VersionsController.swift; sourceTree = "<group>"; };
 		B53FF5462476F9450014E928 /* Constants.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		B543800F246355FA00F34B1C /* Icons.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Icons.xcassets; sourceTree = "<group>"; };
+		B545DDD12C2313BA00A8FD89 /* AuthenticationMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationMode.swift; sourceTree = "<group>"; };
 		B5469FC92587DE3F007ED7BE /* SortMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SortMode.swift; sourceTree = "<group>"; };
 		B5469FCF2587FCD9007ED7BE /* NSSortDescriptor+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSSortDescriptor+Simplenote.swift"; sourceTree = "<group>"; };
 		B5469FD925880128007ED7BE /* OptionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionsTests.swift; sourceTree = "<group>"; };
@@ -1302,6 +1304,7 @@
 				B5E96B651BDE732500D707F5 /* AuthViewController.m */,
 				B5177CBA25EEB01600A8D834 /* AuthViewController+Swift.swift */,
 				B597429225E97ADC0063DDD2 /* AuthViewController.xib */,
+				B545DDD12C2313BA00A8FD89 /* AuthenticationMode.swift */,
 				B5177CC325EEBF6900A8D834 /* SignupVerificationViewController.swift */,
 				B5177CC925EEBF8200A8D834 /* SignupVerificationViewController.xib */,
 			);
@@ -2217,6 +2220,7 @@
 				B51AFE6E25D30A1800A196DF /* SearchField.swift in Sources */,
 				B51E9FE222E615FA004F16B4 /* SPExporter.swift in Sources */,
 				B5562436253E328400836E20 /* ReferenceTableViewCell.swift in Sources */,
+				B545DDD22C2313BA00A8FD89 /* AuthenticationMode.swift in Sources */,
 				BA5A65972C091D0600F605A6 /* CoreDataValidator.swift in Sources */,
 				466FFECF17CC10A800399652 /* TagListViewController.m in Sources */,
 				B52F8FDA24644DD00062B8ED /* NSFont+Theme.swift in Sources */,

--- a/Simplenote/AuthViewController+Swift.swift
+++ b/Simplenote/AuthViewController+Swift.swift
@@ -18,7 +18,6 @@ extension AuthViewController {
         passwordField.delegate = self
 
         // Forgot Password!
-        forgotPasswordButton.title = Localization.forgotAction.uppercased()
         forgotPasswordButton.contentTintColor = .simplenoteBrandColor
 
         // Toggle Signup: Tip
@@ -62,21 +61,18 @@ extension AuthViewController {
     }
 
     func refreshButtonTitles() {
-        let actionText    = signingIn ? Localization.signInAction   : Localization.signUpAction
-        let tipText       = signingIn ? Localization.signUpTip      : Localization.signInTip
-        let switchText    = signingIn ? Localization.signUpAction   : Localization.signInAction
-
-        actionButton.title         = actionText
-        switchTipField.stringValue = tipText.uppercased()
-        switchActionButton.title   = switchText.uppercased()
+        actionButton.title          = mode.primaryActionText
+        forgotPasswordButton.title  = mode.secondaryActionText?.uppercased() ?? ""
+        switchTipField.stringValue  = mode.switchActionTip.uppercased()
+        switchActionButton.title    = mode.switchActionText.uppercased()
     }
 
     /// Makes sure unused components (in the current mode) are effectively disabled
     ///
     func refreshEnabledComponents() {
-        passwordField.isEnabled = signingIn
-        forgotPasswordButton.isEnabled = signingIn
-        wordPressSSOButton.isEnabled = signingIn
+        passwordField.isEnabled = mode.isPasswordVisible
+        forgotPasswordButton.isEnabled = mode.isSecondaryActionVisible
+        wordPressSSOButton.isEnabled = mode.isWordPressVisible
     }
 
     /// Shows / Hides relevant components, based on the specified state
@@ -94,32 +90,29 @@ extension AuthViewController {
     ///         Notice that AppKit requires us to go thru `animator()`.
     ///
     func refreshVisibleComponentsWithoutAnimation() {
-        passwordFieldHeightConstraint.constant   = Metrics.passwordHeight(signingIn: signingIn)
-        forgotPasswordHeightConstraint.constant  = Metrics.forgotHeight(signingIn: signingIn)
-        wordPressSSOHeightConstraint.constant    = Metrics.wordPressHeight(signingIn: signingIn)
+        passwordFieldHeightConstraint.constant  = mode.passwordFieldHeight
+        forgotPasswordHeightConstraint.constant = mode.secondaryActionFieldHeight
+        wordPressSSOHeightConstraint.constant   = mode.wordPressSSOFieldHeight
 
-        let fields      = [passwordField, forgotPasswordButton, wordPressSSOButton].compactMap { $0 }
-
-        fields.updateAlphaValue(AppKitConstants.alpha0_0)
+        passwordField.alphaValue        = mode.passwordFieldAlpha
+        forgotPasswordButton.alphaValue = mode.secondaryActionFieldAlpha
+        wordPressSSOButton.alphaValue   = mode.wordPressSSOFieldAlpha
     }
 
     /// Animates Visible / Invisible components, based on the specified state
     ///
     func refreshVisibleComponentsWithAnimation() {
-        let fields      = [passwordField, forgotPasswordButton, wordPressSSOButton].compactMap { $0 }
-        let alphaStart  = signingIn ? AppKitConstants.alpha0_0 : AppKitConstants.alpha1_0
-        let alphaEnd    = signingIn ? AppKitConstants.alpha1_0 : AppKitConstants.alpha0_0
-
-        fields.updateAlphaValue(alphaStart)
-
         NSAnimationContext.runAnimationGroup { context in
             context.duration = AppKitConstants.duration0_2
 
-            passwordFieldHeightConstraint.animator().constant   = Metrics.passwordHeight(signingIn: signingIn)
-            forgotPasswordHeightConstraint.animator().constant  = Metrics.forgotHeight(signingIn: signingIn)
-            wordPressSSOHeightConstraint.animator().constant    = Metrics.wordPressHeight(signingIn: signingIn)
+            passwordFieldHeightConstraint.animator().constant   = mode.passwordFieldHeight
+            forgotPasswordHeightConstraint.animator().constant  = mode.secondaryActionFieldHeight
+            wordPressSSOHeightConstraint.animator().constant    = mode.wordPressSSOFieldHeight
 
-            fields.updateAlphaValue(alphaEnd)
+            passwordField.alphaValue        = mode.passwordFieldAlpha
+            forgotPasswordButton.alphaValue = mode.secondaryActionFieldAlpha
+            wordPressSSOButton.alphaValue   = mode.wordPressSSOFieldAlpha
+            
             view.layoutSubtreeIfNeeded()
         }
     }

--- a/Simplenote/AuthViewController+Swift.swift
+++ b/Simplenote/AuthViewController+Swift.swift
@@ -174,7 +174,7 @@ extension AuthViewController {
     
     @objc
     func performSignupRequest() {
-        startSignupAnimation()
+        startActionAnimation()
         setInterfaceEnabled(false)
 
         let email = usernameText
@@ -190,7 +190,7 @@ extension AuthViewController {
                 self.showAuthenticationError(forCode: result.statusCode, responseString: nil)
             }
 
-            self.stopSignupAnimation()
+            self.stopActionAnimation()
             self.setInterfaceEnabled(true)
         }
     }
@@ -205,6 +205,24 @@ extension AuthViewController {
         if field.isEqual(usernameField.textField), mode.isPasswordVisible == false {
             performMainAction(field)
         }
+    }
+}
+
+
+// MARK: - Animations
+//
+extension AuthViewController {
+    
+    @objc
+    func startActionAnimation() {
+        actionButton.title = mode.primaryActionAnimationText
+        actionProgress.startAnimation(nil)
+    }
+
+    @objc
+    func stopActionAnimation() {
+        actionButton.title = mode.primaryActionText
+        actionProgress.stopAnimation(nil)
     }
 }
 

--- a/Simplenote/AuthViewController+Swift.swift
+++ b/Simplenote/AuthViewController+Swift.swift
@@ -17,8 +17,8 @@ extension AuthViewController {
         passwordField.placeholderString = Localization.passwordPlaceholder
         passwordField.delegate = self
 
-        // Forgot Password!
-        forgotPasswordButton.contentTintColor = .simplenoteBrandColor
+        // Secondary Action
+        secondaryActionButton.contentTintColor = .simplenoteBrandColor
 
         // Toggle Signup: Tip
         switchTipField.textColor = .simplenoteTertiaryTextColor
@@ -62,7 +62,7 @@ extension AuthViewController {
 
     func refreshButtonTitles() {
         actionButton.title          = mode.primaryActionText
-        forgotPasswordButton.title  = mode.secondaryActionText?.uppercased() ?? ""
+        secondaryActionButton.title = mode.secondaryActionText?.uppercased() ?? ""
         switchTipField.stringValue  = mode.switchActionTip.uppercased()
         switchActionButton.title    = mode.switchActionText.uppercased()
     }
@@ -70,9 +70,9 @@ extension AuthViewController {
     /// Makes sure unused components (in the current mode) are effectively disabled
     ///
     func refreshEnabledComponents() {
-        passwordField.isEnabled = mode.isPasswordVisible
-        forgotPasswordButton.isEnabled = mode.isSecondaryActionVisible
-        wordPressSSOButton.isEnabled = mode.isWordPressVisible
+        passwordField.isEnabled         = mode.isPasswordVisible
+        secondaryActionButton.isEnabled = mode.isSecondaryActionVisible
+        wordPressSSOButton.isEnabled    = mode.isWordPressVisible
     }
 
     /// Shows / Hides relevant components, based on the specified state
@@ -91,12 +91,12 @@ extension AuthViewController {
     ///
     func refreshVisibleComponentsWithoutAnimation() {
         passwordFieldHeightConstraint.constant  = mode.passwordFieldHeight
-        forgotPasswordHeightConstraint.constant = mode.secondaryActionFieldHeight
+        secondaryActionHeightConstraint.constant = mode.secondaryActionFieldHeight
         wordPressSSOHeightConstraint.constant   = mode.wordPressSSOFieldHeight
 
-        passwordField.alphaValue        = mode.passwordFieldAlpha
-        forgotPasswordButton.alphaValue = mode.secondaryActionFieldAlpha
-        wordPressSSOButton.alphaValue   = mode.wordPressSSOFieldAlpha
+        passwordField.alphaValue                = mode.passwordFieldAlpha
+        secondaryActionButton.alphaValue        = mode.secondaryActionFieldAlpha
+        wordPressSSOButton.alphaValue           = mode.wordPressSSOFieldAlpha
     }
 
     /// Animates Visible / Invisible components, based on the specified state
@@ -106,12 +106,12 @@ extension AuthViewController {
             context.duration = AppKitConstants.duration0_2
 
             passwordFieldHeightConstraint.animator().constant   = mode.passwordFieldHeight
-            forgotPasswordHeightConstraint.animator().constant  = mode.secondaryActionFieldHeight
+            secondaryActionHeightConstraint.animator().constant = mode.secondaryActionFieldHeight
             wordPressSSOHeightConstraint.animator().constant    = mode.wordPressSSOFieldHeight
 
-            passwordField.alphaValue        = mode.passwordFieldAlpha
-            forgotPasswordButton.alphaValue = mode.secondaryActionFieldAlpha
-            wordPressSSOButton.alphaValue   = mode.wordPressSSOFieldAlpha
+            passwordField.alphaValue            = mode.passwordFieldAlpha
+            secondaryActionButton.alphaValue    = mode.secondaryActionFieldAlpha
+            wordPressSSOButton.alphaValue       = mode.wordPressSSOFieldAlpha
             
             view.layoutSubtreeIfNeeded()
         }
@@ -234,7 +234,6 @@ extension AuthViewController {
 private enum Localization {
     static let emailPlaceholder = NSLocalizedString("Email", comment: "Placeholder text for login field")
     static let passwordPlaceholder = NSLocalizedString("Password", comment: "Placeholder text for password field")
-    
     static let dotcomSSOAction = NSLocalizedString("Log in with WordPress.com", comment: "button title for wp.com sign in button")
     static let compromisedPasswordAlert = NSLocalizedString("Compromised Password", comment: "Compromised passsword alert title")
     static let compromisedPasswordMessage = NSLocalizedString("This password has appeared in a data breach, which puts your account at high risk of compromise. To protect your data, you'll need to update your password before being able to log in again.", comment: "Compromised password alert message")

--- a/Simplenote/AuthViewController+Swift.swift
+++ b/Simplenote/AuthViewController+Swift.swift
@@ -228,30 +228,13 @@ extension AuthViewController {
     }
 }
 
-// MARK: - Metrics
-//
-private enum Metrics {
-    static func passwordHeight(signingIn: Bool) -> CGFloat {
-        signingIn ? CGFloat(40) : .zero
-    }
-    static func forgotHeight(signingIn: Bool) -> CGFloat {
-        signingIn ? CGFloat(20) : .zero
-    }
-    static func wordPressHeight(signingIn: Bool) -> CGFloat {
-        signingIn ? CGFloat(72) : .zero
-    }
-}
 
 // MARK: - Localization
 //
 private enum Localization {
     static let emailPlaceholder = NSLocalizedString("Email", comment: "Placeholder text for login field")
     static let passwordPlaceholder = NSLocalizedString("Password", comment: "Placeholder text for password field")
-    static let signInAction = NSLocalizedString("Log In", comment: "Title of button for logging in")
-    static let signUpAction = NSLocalizedString("Sign Up", comment: "Title of button for signing up")
-    static let signInTip = NSLocalizedString("Already have an account?", comment: "Link to sign in to an account")
-    static let signUpTip = NSLocalizedString("Need an account?", comment: "Link to create an account")
-    static let forgotAction = NSLocalizedString("Forgot your Password?", comment: "Forgot Password Button")
+    
     static let dotcomSSOAction = NSLocalizedString("Log in with WordPress.com", comment: "button title for wp.com sign in button")
     static let compromisedPasswordAlert = NSLocalizedString("Compromised Password", comment: "Compromised passsword alert title")
     static let compromisedPasswordMessage = NSLocalizedString("This password has appeared in a data breach, which puts your account at high risk of compromise. To protect your data, you'll need to update your password before being able to log in again.", comment: "Compromised password alert message")

--- a/Simplenote/AuthViewController+Swift.swift
+++ b/Simplenote/AuthViewController+Swift.swift
@@ -146,6 +146,18 @@ extension AuthViewController {
         refreshInterface(animated: true)
         ensureUsernameIsFirstResponder()
     }
+    
+    @objc
+    func handleNewlineInField(_ field: NSControl) {
+        if field.isEqual(passwordField.textField) {
+            performMainAction(field)
+            return
+        }
+        
+        if field.isEqual(usernameField.textField), mode.isPasswordVisible == false {
+            performMainAction(field)
+        }
+    }
 
     @objc
     func performSignupRequest() {

--- a/Simplenote/AuthViewController+Swift.swift
+++ b/Simplenote/AuthViewController+Swift.swift
@@ -133,7 +133,7 @@ extension AuthViewController {
     }
 }
 
-// MARK: - Action Handlers
+// MARK: - IBAction Handlers
 //
 extension AuthViewController {
 
@@ -147,18 +147,31 @@ extension AuthViewController {
         ensureUsernameIsFirstResponder()
     }
     
-    @objc
-    func handleNewlineInField(_ field: NSControl) {
-        if field.isEqual(passwordField.textField) {
-            performMainAction(field)
+    @IBAction
+    func performMainAction(_ sender: Any) {
+        performSelector(onMainThread: mode.primaryActionSelector, with: nil, waitUntilDone: false)
+    }
+    
+    @IBAction
+    func performSecondaryAction(_ sender: Any) {
+        guard let secondaryActionSelector = mode.secondaryActionSelector else {
             return
         }
         
-        if field.isEqual(usernameField.textField), mode.isPasswordVisible == false {
-            performMainAction(field)
-        }
+        performSelector(onMainThread: secondaryActionSelector, with: nil, waitUntilDone: false)
     }
+}
 
+
+// MARK: - Handlers
+//
+extension AuthViewController {
+
+    @IBAction
+    func switchToPasswordAuth(_ sender: Any) {
+        mode = .loginWithPassword
+    }
+    
     @objc
     func performSignupRequest() {
         startSignupAnimation()
@@ -181,7 +194,20 @@ extension AuthViewController {
             self.setInterfaceEnabled(true)
         }
     }
+    
+    @IBAction
+    func handleNewlineInField(_ field: NSControl) {
+        if field.isEqual(passwordField.textField) {
+            performMainAction(field)
+            return
+        }
+        
+        if field.isEqual(usernameField.textField), mode.isPasswordVisible == false {
+            performMainAction(field)
+        }
+    }
 }
+
 
 // MARK: - Presenting!
 //

--- a/Simplenote/AuthViewController.h
+++ b/Simplenote/AuthViewController.h
@@ -36,9 +36,6 @@
 
 - (void)setInterfaceEnabled:(BOOL)enabled;
 
-- (void)startSignupAnimation;
-- (void)stopSignupAnimation;
-
 - (void)presentPasswordResetAlert;
 - (void)showAuthenticationErrorForCode:(NSInteger)responseCode responseString:(NSString *)responseString;
 

--- a/Simplenote/AuthViewController.h
+++ b/Simplenote/AuthViewController.h
@@ -2,6 +2,8 @@
 #import <AppKit/AppKit.h>
 @import Simperium_OSX;
 
+@class AuthenticationMode;
+
 
 // MARK: - AuthViewController: Simperium's Authentication UI
 
@@ -25,6 +27,7 @@
 @property (nonatomic, strong) IBOutlet NSLayoutConstraint           *wordPressSSOHeightConstraint;
 
 @property (nonatomic, strong) SPAuthenticator                       *authenticator;
+@property (nonatomic, strong) AuthenticationMode                    *mode;
 @property (nonatomic, assign) BOOL                                  signingIn;
 
 - (void)setInterfaceEnabled:(BOOL)enabled;

--- a/Simplenote/AuthViewController.h
+++ b/Simplenote/AuthViewController.h
@@ -16,14 +16,14 @@
 @property (nonatomic, strong) IBOutlet SPAuthenticationTextField    *passwordField;
 @property (nonatomic, strong) IBOutlet NSButton                     *actionButton;
 @property (nonatomic, strong) IBOutlet NSProgressIndicator          *actionProgress;
-@property (nonatomic, strong) IBOutlet NSButton                     *forgotPasswordButton;
+@property (nonatomic, strong) IBOutlet NSButton                     *secondaryActionButton;
 @property (nonatomic, strong) IBOutlet NSTextField                  *switchTipField;
 @property (nonatomic, strong) IBOutlet NSButton                     *switchActionButton;
 @property (nonatomic, strong) IBOutlet NSView                       *wordPressSSOContainerView;
 @property (nonatomic, strong) IBOutlet NSButton                     *wordPressSSOButton;
 
 @property (nonatomic, strong) IBOutlet NSLayoutConstraint           *passwordFieldHeightConstraint;
-@property (nonatomic, strong) IBOutlet NSLayoutConstraint           *forgotPasswordHeightConstraint;
+@property (nonatomic, strong) IBOutlet NSLayoutConstraint           *secondaryActionHeightConstraint;
 @property (nonatomic, strong) IBOutlet NSLayoutConstraint           *wordPressSSOHeightConstraint;
 
 @property (nonatomic, strong) SPAuthenticator                       *authenticator;

--- a/Simplenote/AuthViewController.h
+++ b/Simplenote/AuthViewController.h
@@ -28,9 +28,11 @@
 
 @property (nonatomic, strong) SPAuthenticator                       *authenticator;
 @property (nonatomic, strong) AuthenticationMode                    *mode;
-@property (nonatomic, assign) BOOL                                  signingIn;
 
-- (IBAction)performMainAction:(id)sender;
+- (void)pressedLogInWithPassword;
+- (void)pressedLoginWithMagicLink;
+- (void)pressedSignUp;
+- (void)openForgotPasswordURL;
 
 - (void)setInterfaceEnabled:(BOOL)enabled;
 

--- a/Simplenote/AuthViewController.h
+++ b/Simplenote/AuthViewController.h
@@ -30,6 +30,8 @@
 @property (nonatomic, strong) AuthenticationMode                    *mode;
 @property (nonatomic, assign) BOOL                                  signingIn;
 
+- (IBAction)performMainAction:(id)sender;
+
 - (void)setInterfaceEnabled:(BOOL)enabled;
 
 - (void)startSignupAnimation;

--- a/Simplenote/AuthViewController.m
+++ b/Simplenote/AuthViewController.m
@@ -139,7 +139,7 @@ static NSString *SPAuthSessionKey = @"SPAuthSessionKey";
 }
 
 - (void)pressedLoginWithMagicLink {
-    
+    NSLog(@"# TODO: Request Magic Link!!");
 }
 
 - (void)pressedSignUp {

--- a/Simplenote/AuthViewController.m
+++ b/Simplenote/AuthViewController.m
@@ -53,7 +53,7 @@ static NSString *SPAuthSessionKey = @"SPAuthSessionKey";
 
 #pragma mark - Action Handlers
 
-- (IBAction)forgotPassword:(id)sender {
+- (void)openForgotPasswordURL {
     NSString *forgotPasswordURL = [SPCredentials simperiumForgotPasswordURL];
     NSString *username = self.usernameText;
 
@@ -65,7 +65,7 @@ static NSString *SPAuthSessionKey = @"SPAuthSessionKey";
     [[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString:forgotPasswordURL]];
 }
 
-- (IBAction)toggleAuthenticationMode:(id)sender {
+- (IBAction)switchAuthenticationMode:(id)sender {
     self.mode = [self.mode nextMode];
 }
 
@@ -122,16 +122,7 @@ static NSString *SPAuthSessionKey = @"SPAuthSessionKey";
 
 #pragma mark - Actions
 
-- (IBAction)performMainAction:(id)sender {
-    if (self.signingIn) {
-        [self signInAction:sender];
-        return;
-    }
-
-    [self signUpAction:sender];
-}
-
-- (IBAction)signInAction:(id)sender {
+- (void)pressedLogInWithPassword {
     [SPTracker trackUserSignedIn];
     [self clearAuthenticationError];
 
@@ -144,10 +135,14 @@ static NSString *SPAuthSessionKey = @"SPAuthSessionKey";
         return;
     }
 
-    [self performAuthentication];
+    [self performLoginWithPassword];
 }
 
-- (IBAction)signUpAction:(id)sender {
+- (void)pressedLoginWithMagicLink {
+    
+}
+
+- (void)pressedSignUp {
     [SPTracker trackUserSignedUp];
     [self clearAuthenticationError];
 
@@ -203,7 +198,7 @@ static NSString *SPAuthSessionKey = @"SPAuthSessionKey";
     }];
 }
 
-- (void)performAuthentication {
+- (void)performLoginWithPassword {
     [self startLoginAnimation];
     [self setInterfaceEnabled:NO];
 

--- a/Simplenote/AuthViewController.m
+++ b/Simplenote/AuthViewController.m
@@ -84,6 +84,7 @@ static NSString *SPAuthSessionKey = @"SPAuthSessionKey";
     [self.usernameField setEnabled:enabled];
     [self.passwordField setEnabled:enabled];
     [self.actionButton setEnabled:enabled];
+    [self.secondaryActionButton setEnabled:enabled];
     [self.switchActionButton setEnabled:enabled];
     [self.wordPressSSOButton setEnabled:enabled];
 }
@@ -158,55 +159,32 @@ static NSString *SPAuthSessionKey = @"SPAuthSessionKey";
 }
 
 
-#pragma mark - Displaying Porgress
-
-- (void)startLoginAnimation {
-    self.actionButton.title = NSLocalizedString(@"Logging In...", @"Displayed temporarily while logging in");
-    [self.actionProgress startAnimation:self];
-}
-
-- (void)stopLoginAnimation {
-    self.actionButton.title = NSLocalizedString(@"Log In", @"Title of button for login");
-    [self.actionProgress stopAnimation:self];
-}
-
-- (void)startSignupAnimation {
-    self.actionButton.title = NSLocalizedString(@"Signing Up...", @"Displayed temoprarily while signing up");
-    [self.actionProgress startAnimation:self];
-}
-
-- (void)stopSignupAnimation {
-    self.actionButton.title = NSLocalizedString(@"Sign Up", @"Title of button for signing up");
-    [self.actionProgress stopAnimation:self];
-}
-
-
 #pragma mark - Authentication Wrappers
 
 - (void)performCredentialsValidation {
-    [self startLoginAnimation];
+    [self startActionAnimation];
     [self setInterfaceEnabled:NO];
 
     [self.authenticator validateWithUsername:self.usernameText password:self.passwordText success:^{
-        [self stopLoginAnimation];
+        [self stopActionAnimation];
         [self setInterfaceEnabled:YES];
         [self presentPasswordResetAlert];
     } failure:^(NSInteger responseCode, NSString *responseString, NSError *error) {
         [self showAuthenticationErrorForCode:responseCode responseString:responseString];
-        [self stopLoginAnimation];
+        [self stopActionAnimation];
         [self setInterfaceEnabled:YES];
     }];
 }
 
 - (void)performLoginWithPassword {
-    [self startLoginAnimation];
+    [self startActionAnimation];
     [self setInterfaceEnabled:NO];
 
     [self.authenticator authenticateWithUsername:self.usernameText password:self.passwordText success:^{
         // NO-OP
     } failure:^(NSInteger responseCode, NSString *responseString, NSError *error) {
         [self showAuthenticationErrorForCode:responseCode responseString: responseString];
-        [self stopLoginAnimation];
+        [self stopActionAnimation];
         [self setInterfaceEnabled:YES];
     }];
 }

--- a/Simplenote/AuthViewController.m
+++ b/Simplenote/AuthViewController.m
@@ -29,7 +29,7 @@ static NSString *SPAuthSessionKey = @"SPAuthSessionKey";
 {
     if (self = [super init]) {
         self.validator = [SPAuthenticationValidator new];
-        self.signingIn = NO;
+        self.mode = [AuthenticationMode signup];
     }
 
     return self;
@@ -66,14 +66,14 @@ static NSString *SPAuthSessionKey = @"SPAuthSessionKey";
 }
 
 - (IBAction)toggleAuthenticationMode:(id)sender {
-    self.signingIn = !self.signingIn;
+    self.mode = [self.mode nextMode];
 }
 
 
 #pragma mark - Dynamic Properties
 
-- (void)setSigningIn:(BOOL)signingIn {
-    _signingIn = signingIn;
+- (void)setMode:(AuthenticationMode *)mode {
+    _mode = mode;
     [self didUpdateAuthenticationMode];
 }
 

--- a/Simplenote/AuthViewController.m
+++ b/Simplenote/AuthViewController.m
@@ -400,15 +400,4 @@ static NSString *SPAuthSessionKey = @"SPAuthSessionKey";
     }
 }
 
-- (void)handleNewlineInField:(NSControl *)field {
-    if (_signingIn && [field isEqual:self.passwordField.textField]) {
-        [self signInAction:nil];
-        return;
-    }
-
-    if (!_signingIn && [field isEqual:self.usernameField.textField]) {
-        [self signUpAction:nil];
-    }
-}
-
 @end

--- a/Simplenote/AuthViewController.xib
+++ b/Simplenote/AuthViewController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="17701" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17701"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="22690"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -11,11 +11,11 @@
                 <outlet property="actionButton" destination="Lid-6Q-zHR" id="k1R-7A-0Fc"/>
                 <outlet property="actionProgress" destination="GMB-3v-AEQ" id="Qv3-0X-3xO"/>
                 <outlet property="errorField" destination="lwM-mh-i3o" id="hCf-XY-GKI"/>
-                <outlet property="forgotPasswordButton" destination="y1M-Np-v9m" id="wMf-VC-rpx"/>
-                <outlet property="forgotPasswordHeightConstraint" destination="HrL-ss-QSd" id="grM-HB-9fi"/>
                 <outlet property="logoImageView" destination="W9h-HS-WbG" id="GV7-vy-NaT"/>
                 <outlet property="passwordField" destination="2bk-bk-VfG" id="JQn-Xi-XNs"/>
                 <outlet property="passwordFieldHeightConstraint" destination="Cah-V8-aCS" id="saQ-Mz-zu6"/>
+                <outlet property="secondaryActionButton" destination="y1M-Np-v9m" id="z7i-Qa-Tye"/>
+                <outlet property="secondaryActionHeightConstraint" destination="HrL-ss-QSd" id="Vg3-A9-yCH"/>
                 <outlet property="stackView" destination="PWa-EY-51O" id="jUJ-sH-HgC"/>
                 <outlet property="switchActionButton" destination="5np-Xn-oop" id="KYi-sy-yoJ"/>
                 <outlet property="switchTipField" destination="0yP-IQ-Unz" id="jvk-lr-cHO"/>
@@ -42,7 +42,7 @@
                             </constraints>
                             <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="icon_simplenote_login" id="2Fh-2C-hTH"/>
                         </imageView>
-                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="lwM-mh-i3o">
+                        <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="lwM-mh-i3o">
                             <rect key="frame" x="-2" y="368" width="324" height="16"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="16" id="Pcu-pb-Ma8"/>
@@ -73,13 +73,13 @@
                             <subviews>
                                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Lid-6Q-zHR" userLabel="Main Action Button" customClass="SPAuthenticationButton">
                                     <rect key="frame" x="0.0" y="0.0" width="320" height="40"/>
-                                    <constraints>
-                                        <constraint firstAttribute="height" constant="40" id="UVW-gz-8cN"/>
-                                    </constraints>
                                     <buttonCell key="cell" type="bevel" title="[Main Action]" bezelStyle="rounded" alignment="center" imageScaling="proportionallyDown" inset="2" id="2il-zd-A17" customClass="SPAuthenticationButtonCell">
                                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                         <font key="font" metaFont="system"/>
                                     </buttonCell>
+                                    <constraints>
+                                        <constraint firstAttribute="height" constant="40" id="UVW-gz-8cN"/>
+                                    </constraints>
                                     <connections>
                                         <action selector="performMainAction:" target="-2" id="oQR-Zg-shZ"/>
                                     </connections>
@@ -99,13 +99,13 @@
                         </customView>
                         <button wantsLayer="YES" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="y1M-Np-v9m" userLabel="Forgot Button">
                             <rect key="frame" x="0.0" y="154" width="320" height="20"/>
-                            <constraints>
-                                <constraint firstAttribute="height" constant="20" id="HrL-ss-QSd"/>
-                            </constraints>
                             <buttonCell key="cell" type="bevel" title="[Forgot Action]" bezelStyle="rounded" alignment="center" imageScaling="proportionallyDown" inset="2" id="zjo-dD-vux">
                                 <behavior key="behavior" lightByContents="YES"/>
                                 <font key="font" metaFont="systemMedium" size="13"/>
                             </buttonCell>
+                            <constraints>
+                                <constraint firstAttribute="height" constant="20" id="HrL-ss-QSd"/>
+                            </constraints>
                             <connections>
                                 <action selector="forgotPassword:" target="-2" id="pEz-hB-6Tz"/>
                             </connections>
@@ -113,7 +113,7 @@
                         <customView translatesAutoresizingMaskIntoConstraints="NO" id="mRM-75-7tv" userLabel="Switch View">
                             <rect key="frame" x="0.0" y="84" width="320" height="58"/>
                             <subviews>
-                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0yP-IQ-Unz" userLabel="Switch Tip">
+                                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0yP-IQ-Unz" userLabel="Switch Tip">
                                     <rect key="frame" x="-2" y="20" width="324" height="20"/>
                                     <constraints>
                                         <constraint firstAttribute="height" constant="20" id="5GW-OX-wF2"/>
@@ -127,14 +127,14 @@
                                 </textField>
                                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="5np-Xn-oop" userLabel="Switch Button">
                                     <rect key="frame" x="0.0" y="0.0" width="320" height="20"/>
-                                    <constraints>
-                                        <constraint firstAttribute="width" constant="320" id="3N3-wW-P6F"/>
-                                        <constraint firstAttribute="height" constant="20" id="3pI-cn-CI2"/>
-                                    </constraints>
                                     <buttonCell key="cell" type="bevel" title="[Switch Action]" bezelStyle="rounded" alignment="center" imageScaling="proportionallyDown" inset="2" id="nb6-bt-sFC">
                                         <behavior key="behavior" lightByContents="YES"/>
                                         <font key="font" metaFont="systemSemibold" size="13"/>
                                     </buttonCell>
+                                    <constraints>
+                                        <constraint firstAttribute="width" constant="320" id="3N3-wW-P6F"/>
+                                        <constraint firstAttribute="height" constant="20" id="3pI-cn-CI2"/>
+                                    </constraints>
                                     <connections>
                                         <action selector="toggleAuthenticationMode:" target="-2" id="MRn-Y7-TWp"/>
                                     </connections>
@@ -155,13 +155,13 @@
                             <subviews>
                                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="sc9-DH-ug9" userLabel="WordPress SSO Button">
                                     <rect key="frame" x="0.0" y="0.0" width="320" height="40"/>
-                                    <constraints>
-                                        <constraint firstAttribute="height" priority="999" constant="40" id="ynU-1V-xiN"/>
-                                    </constraints>
                                     <buttonCell key="cell" type="bevel" title="[WordPress SSO]" bezelStyle="rounded" image="icon_wp" imagePosition="left" alignment="center" imageScaling="proportionallyDown" inset="2" id="Mzh-LI-XpK">
                                         <behavior key="behavior" lightByContents="YES"/>
                                         <font key="font" metaFont="system" size="16"/>
                                     </buttonCell>
+                                    <constraints>
+                                        <constraint firstAttribute="height" priority="999" constant="40" id="ynU-1V-xiN"/>
+                                    </constraints>
                                     <connections>
                                         <action selector="wpccSignInAction:" target="-2" id="XuG-cb-poD"/>
                                     </connections>

--- a/Simplenote/AuthViewController.xib
+++ b/Simplenote/AuthViewController.xib
@@ -85,13 +85,13 @@
                                     </connections>
                                 </button>
                                 <progressIndicator maxValue="100" displayedWhenStopped="NO" indeterminate="YES" controlSize="small" style="spinning" translatesAutoresizingMaskIntoConstraints="NO" id="GMB-3v-AEQ" userLabel="Main Action Progress Indicator">
-                                    <rect key="frame" x="274" y="12" width="16" height="16"/>
+                                    <rect key="frame" x="289" y="12" width="16" height="16"/>
                                 </progressIndicator>
                             </subviews>
                             <constraints>
                                 <constraint firstAttribute="trailing" secondItem="Lid-6Q-zHR" secondAttribute="trailing" id="2c9-c1-cVE"/>
                                 <constraint firstItem="Lid-6Q-zHR" firstAttribute="leading" secondItem="Epn-oY-sfo" secondAttribute="leading" id="4E7-z2-N5C"/>
-                                <constraint firstItem="GMB-3v-AEQ" firstAttribute="trailing" secondItem="Lid-6Q-zHR" secondAttribute="trailing" constant="-30" id="A5n-zf-7v0"/>
+                                <constraint firstItem="GMB-3v-AEQ" firstAttribute="trailing" secondItem="Lid-6Q-zHR" secondAttribute="trailing" constant="-15" id="A5n-zf-7v0"/>
                                 <constraint firstItem="GMB-3v-AEQ" firstAttribute="centerY" secondItem="Lid-6Q-zHR" secondAttribute="centerY" id="EtT-i8-ImS"/>
                                 <constraint firstItem="Lid-6Q-zHR" firstAttribute="top" secondItem="Epn-oY-sfo" secondAttribute="top" constant="26" id="eJb-sz-gE7"/>
                                 <constraint firstAttribute="bottom" secondItem="Lid-6Q-zHR" secondAttribute="bottom" id="lmu-Jy-hXf"/>

--- a/Simplenote/AuthViewController.xib
+++ b/Simplenote/AuthViewController.xib
@@ -81,7 +81,7 @@
                                         <constraint firstAttribute="height" constant="40" id="UVW-gz-8cN"/>
                                     </constraints>
                                     <connections>
-                                        <action selector="performMainAction:" target="-2" id="oQR-Zg-shZ"/>
+                                        <action selector="performMainAction:" target="-2" id="t7F-Eu-cMm"/>
                                     </connections>
                                 </button>
                                 <progressIndicator maxValue="100" displayedWhenStopped="NO" indeterminate="YES" controlSize="small" style="spinning" translatesAutoresizingMaskIntoConstraints="NO" id="GMB-3v-AEQ" userLabel="Main Action Progress Indicator">
@@ -97,9 +97,9 @@
                                 <constraint firstAttribute="bottom" secondItem="Lid-6Q-zHR" secondAttribute="bottom" id="lmu-Jy-hXf"/>
                             </constraints>
                         </customView>
-                        <button wantsLayer="YES" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="y1M-Np-v9m" userLabel="Forgot Button">
+                        <button wantsLayer="YES" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="y1M-Np-v9m" userLabel="Secondary Action Button">
                             <rect key="frame" x="0.0" y="154" width="320" height="20"/>
-                            <buttonCell key="cell" type="bevel" title="[Forgot Action]" bezelStyle="rounded" alignment="center" imageScaling="proportionallyDown" inset="2" id="zjo-dD-vux">
+                            <buttonCell key="cell" type="bevel" title="[Secondary Action]" bezelStyle="rounded" alignment="center" imageScaling="proportionallyDown" inset="2" id="zjo-dD-vux" userLabel="[Secondary Action]">
                                 <behavior key="behavior" lightByContents="YES"/>
                                 <font key="font" metaFont="systemMedium" size="13"/>
                             </buttonCell>
@@ -107,7 +107,7 @@
                                 <constraint firstAttribute="height" constant="20" id="HrL-ss-QSd"/>
                             </constraints>
                             <connections>
-                                <action selector="forgotPassword:" target="-2" id="pEz-hB-6Tz"/>
+                                <action selector="performSecondaryAction:" target="-2" id="hjL-sS-hbT"/>
                             </connections>
                         </button>
                         <customView translatesAutoresizingMaskIntoConstraints="NO" id="mRM-75-7tv" userLabel="Switch View">
@@ -136,7 +136,7 @@
                                         <constraint firstAttribute="height" constant="20" id="3pI-cn-CI2"/>
                                     </constraints>
                                     <connections>
-                                        <action selector="toggleAuthenticationMode:" target="-2" id="MRn-Y7-TWp"/>
+                                        <action selector="switchAuthenticationMode:" target="-2" id="5M2-AR-yd6"/>
                                     </connections>
                                 </button>
                             </subviews>

--- a/Simplenote/AuthenticationMode.swift
+++ b/Simplenote/AuthenticationMode.swift
@@ -5,6 +5,7 @@ import Foundation
 //
 class AuthenticationMode: NSObject {
     let primaryActionText: String
+    let primaryActionAnimationText: String
     let primaryActionSelector: Selector
     
     let secondaryActionText: String?
@@ -18,8 +19,9 @@ class AuthenticationMode: NSObject {
     let isSecondaryActionVisible: Bool
     let isWordPressVisible: Bool
     
-    init(primaryActionText: String, primaryActionSelector: Selector, secondaryActionText: String?, secondaryActionSelector: Selector?, switchActionText: String, switchActionTip: String, switchTargetMode: @escaping () -> AuthenticationMode, isPasswordVisible: Bool, isSecondaryActionVisible: Bool, isWordPressVisible: Bool) {
+    init(primaryActionText: String, primaryActionAnimationText: String, primaryActionSelector: Selector, secondaryActionText: String?, secondaryActionSelector: Selector?, switchActionText: String, switchActionTip: String, switchTargetMode: @escaping () -> AuthenticationMode, isPasswordVisible: Bool, isSecondaryActionVisible: Bool, isWordPressVisible: Bool) {
         self.primaryActionText = primaryActionText
+        self.primaryActionAnimationText =  primaryActionAnimationText
         self.primaryActionSelector = primaryActionSelector
         self.secondaryActionText = secondaryActionText
         self.secondaryActionSelector = secondaryActionSelector
@@ -76,6 +78,7 @@ extension AuthenticationMode {
     @objc
     static var loginWithPassword: AuthenticationMode {
         AuthenticationMode(primaryActionText: LoginStrings.primaryAction,
+                           primaryActionAnimationText: LoginStrings.primaryAnimationText,
                            primaryActionSelector: #selector(AuthViewController.pressedLogInWithPassword),
                            secondaryActionText: LoginStrings.secondaryAction,
                            secondaryActionSelector: #selector(AuthViewController.openForgotPasswordURL),
@@ -92,6 +95,7 @@ extension AuthenticationMode {
     @objc
     static var loginWithMagicLink: AuthenticationMode {
         AuthenticationMode(primaryActionText: MagicLinkStrings.primaryAction,
+                           primaryActionAnimationText: MagicLinkStrings.primaryAnimationText,
                            primaryActionSelector: #selector(AuthViewController.pressedLoginWithMagicLink),
                            secondaryActionText: MagicLinkStrings.secondaryAction,
                            secondaryActionSelector: #selector(AuthViewController.switchToPasswordAuth),
@@ -108,6 +112,7 @@ extension AuthenticationMode {
     @objc
     static var signup: AuthenticationMode {
         AuthenticationMode(primaryActionText: SignupStrings.primaryAction,
+                           primaryActionAnimationText: SignupStrings.primaryAnimationText,
                            primaryActionSelector: #selector(AuthViewController.pressedSignUp),
                            secondaryActionText: nil,
                            secondaryActionSelector: nil,
@@ -124,21 +129,24 @@ extension AuthenticationMode {
 // MARK: - Localization
 //
 private enum LoginStrings {
-    static let primaryAction    = NSLocalizedString("Log In", comment: "Title of button for logging in")
-    static let secondaryAction  = NSLocalizedString("Forgot your Password?", comment: "Forgot Password Button")
-    static let switchAction     = NSLocalizedString("Sign Up", comment: "Title of button for signing up")
-    static let switchTip        = NSLocalizedString("Need an account?", comment: "Link to create an account")
+    static let primaryAction        = NSLocalizedString("Log In", comment: "Title of button for logging in")
+    static let primaryAnimationText = NSLocalizedString("Logging In...", comment: "Title of button for logging in")
+    static let secondaryAction      = NSLocalizedString("Forgot your Password?", comment: "Forgot Password Button")
+    static let switchAction         = NSLocalizedString("Sign Up", comment: "Title of button for signing up")
+    static let switchTip            = NSLocalizedString("Need an account?", comment: "Link to create an account")
 }
 
 private enum MagicLinkStrings {
-    static let primaryAction    = NSLocalizedString("Instantly Log In with Email", comment: "Title of button for logging in")
-    static let secondaryAction  = NSLocalizedString("Continue with Password", comment: "Continue with Password Action")
-    static let switchAction     = NSLocalizedString("Sign Up", comment: "Title of button for signing up")
-    static let switchTip        = NSLocalizedString("Need an account?", comment: "Link to create an account")
+    static let primaryAction        = NSLocalizedString("Instantly Log In with Email", comment: "Title of button for logging in")
+    static let primaryAnimationText = NSLocalizedString("Requesting Email...", comment: "Title of button for logging in")
+    static let secondaryAction      = NSLocalizedString("Continue with Password", comment: "Continue with Password Action")
+    static let switchAction         = NSLocalizedString("Sign Up", comment: "Title of button for signing up")
+    static let switchTip            = NSLocalizedString("Need an account?", comment: "Link to create an account")
 }
 
 private enum SignupStrings {
-    static let primaryAction    = NSLocalizedString("Sign Up", comment: "Title of button for signing up")
-    static let switchAction     = NSLocalizedString("Log In", comment: "Title of button for logging in up")
-    static let switchTip        = NSLocalizedString("Already have an account?", comment: "Link to sign in to an account")
+    static let primaryAction        = NSLocalizedString("Sign Up", comment: "Title of button for signing up")
+    static let primaryAnimationText = NSLocalizedString("Signing Up...", comment: "Title of button for logging in")
+    static let switchAction         = NSLocalizedString("Log In", comment: "Title of button for logging in up")
+    static let switchTip            = NSLocalizedString("Already have an account?", comment: "Link to sign in to an account")
 }

--- a/Simplenote/AuthenticationMode.swift
+++ b/Simplenote/AuthenticationMode.swift
@@ -1,0 +1,131 @@
+import Foundation
+
+
+// MARK: - AuthenticationMode
+//
+class AuthenticationMode: NSObject {
+    let primaryActionText: String
+    
+    let secondaryActionText: String?
+    
+    let switchActionText: String
+    let switchActionTip: String
+    let switchTargetMode: () -> AuthenticationMode
+    
+    let isPasswordVisible: Bool
+    let isSecondaryActionVisible: Bool
+    let isWordPressVisible: Bool
+    
+    init(primaryActionText: String, secondaryActionText: String?, switchActionText: String, switchActionTip: String, switchTargetMode: @escaping () -> AuthenticationMode, isPasswordVisible: Bool, isSecondaryActionVisible: Bool, isWordPressVisible: Bool) {
+        self.primaryActionText = primaryActionText
+        self.secondaryActionText = secondaryActionText
+        self.switchActionText = switchActionText
+        self.switchActionTip = switchActionTip
+        self.switchTargetMode = switchTargetMode
+        self.isPasswordVisible = isPasswordVisible
+        self.isSecondaryActionVisible = isSecondaryActionVisible
+        self.isWordPressVisible = isWordPressVisible
+    }
+}
+
+
+extension AuthenticationMode {
+    
+    @objc
+    func nextMode() -> AuthenticationMode {
+        switchTargetMode()
+    }
+    
+    var passwordFieldHeight: CGFloat {
+        isPasswordVisible ? CGFloat(40) : .zero
+    }
+    
+    var secondaryActionFieldHeight: CGFloat {
+        isSecondaryActionVisible ? CGFloat(20) : .zero
+    }
+    
+    var wordPressSSOFieldHeight: CGFloat {
+        isWordPressVisible ? CGFloat(72) : .zero
+    }
+    
+    var passwordFieldAlpha: CGFloat {
+        isPasswordVisible ? AppKitConstants.alpha1_0 : AppKitConstants.alpha0_0
+    }
+    
+    var secondaryActionFieldAlpha: CGFloat {
+        isSecondaryActionVisible ? AppKitConstants.alpha1_0 : AppKitConstants.alpha0_0
+    }
+    
+    var wordPressSSOFieldAlpha: CGFloat {
+        isWordPressVisible ? AppKitConstants.alpha1_0 : AppKitConstants.alpha0_0
+    }
+}
+
+
+extension AuthenticationMode {
+    
+    /// Auth Mode: Login with Username + Password
+    ///
+    @objc
+    static var loginWithPassword: AuthenticationMode {
+        AuthenticationMode(primaryActionText: LoginStrings.primaryAction,
+                           secondaryActionText: LoginStrings.secondaryAction,
+                           switchActionText: LoginStrings.switchAction,
+                           switchActionTip: LoginStrings.switchTip,
+                           switchTargetMode: { .signup },
+                           isPasswordVisible: true,
+                           isSecondaryActionVisible: true,
+                           isWordPressVisible: true)
+    }
+
+    /// Auth Mode: Login is handled via Magic Links!
+    ///
+    @objc
+    static var loginWithMagicLink: AuthenticationMode {
+        AuthenticationMode(primaryActionText: MagicLinkStrings.primaryAction,
+                           secondaryActionText: MagicLinkStrings.secondaryAction,
+                           switchActionText: MagicLinkStrings.switchAction,
+                           switchActionTip: MagicLinkStrings.switchTip,
+                           switchTargetMode: { .loginWithPassword },
+                           isPasswordVisible: false,
+                           isSecondaryActionVisible: true,
+                           isWordPressVisible: true)
+    }
+
+    /// Auth Mode: SignUp
+    ///
+    @objc
+    static var signup: AuthenticationMode {
+        AuthenticationMode(primaryActionText: SignupStrings.primaryAction,
+                           secondaryActionText: nil,
+                           switchActionText: SignupStrings.switchAction,
+                           switchActionTip: SignupStrings.switchTip,
+                           switchTargetMode: { .loginWithMagicLink },
+                           isPasswordVisible: false,
+                           isSecondaryActionVisible: false,
+                           isWordPressVisible: false)
+    }
+}
+
+
+// MARK: - Localization
+//
+private enum LoginStrings {
+    static let primaryAction    = NSLocalizedString("Log In", comment: "Title of button for logging in")
+    static let secondaryAction  = NSLocalizedString("Forgot your Password?", comment: "Forgot Password Button")
+    static let switchAction     = NSLocalizedString("Sign Up", comment: "Title of button for signing up")
+    static let switchTip        = NSLocalizedString("Need an account?", comment: "Link to create an account")
+}
+
+private enum MagicLinkStrings {
+    static let primaryAction    = NSLocalizedString("Instantly Log In with Email", comment: "Title of button for logging in")
+    static let secondaryAction  = NSLocalizedString("Continue with Password", comment: "Continue with Password Action")
+    static let switchAction     = NSLocalizedString("Sign Up", comment: "Title of button for signing up")
+    static let switchTip        = NSLocalizedString("Need an account?", comment: "Link to create an account")
+}
+
+private enum SignupStrings {
+    static let primaryAction    = NSLocalizedString("Sign Up", comment: "Title of button for signing up")
+    static let switchAction     = NSLocalizedString("Log In", comment: "Title of button for logging in up")
+    static let switchTip        = NSLocalizedString("Already have an account?", comment: "Link to sign in to an account")
+}

--- a/Simplenote/AuthenticationMode.swift
+++ b/Simplenote/AuthenticationMode.swift
@@ -86,7 +86,7 @@ extension AuthenticationMode {
                            secondaryActionText: MagicLinkStrings.secondaryAction,
                            switchActionText: MagicLinkStrings.switchAction,
                            switchActionTip: MagicLinkStrings.switchTip,
-                           switchTargetMode: { .loginWithPassword },
+                           switchTargetMode: { .signup },
                            isPasswordVisible: false,
                            isSecondaryActionVisible: true,
                            isWordPressVisible: true)

--- a/Simplenote/AuthenticationMode.swift
+++ b/Simplenote/AuthenticationMode.swift
@@ -5,9 +5,11 @@ import Foundation
 //
 class AuthenticationMode: NSObject {
     let primaryActionText: String
+    let primaryActionSelector: Selector
     
     let secondaryActionText: String?
-    
+    let secondaryActionSelector: Selector?
+
     let switchActionText: String
     let switchActionTip: String
     let switchTargetMode: () -> AuthenticationMode
@@ -16,9 +18,11 @@ class AuthenticationMode: NSObject {
     let isSecondaryActionVisible: Bool
     let isWordPressVisible: Bool
     
-    init(primaryActionText: String, secondaryActionText: String?, switchActionText: String, switchActionTip: String, switchTargetMode: @escaping () -> AuthenticationMode, isPasswordVisible: Bool, isSecondaryActionVisible: Bool, isWordPressVisible: Bool) {
+    init(primaryActionText: String, primaryActionSelector: Selector, secondaryActionText: String?, secondaryActionSelector: Selector?, switchActionText: String, switchActionTip: String, switchTargetMode: @escaping () -> AuthenticationMode, isPasswordVisible: Bool, isSecondaryActionVisible: Bool, isWordPressVisible: Bool) {
         self.primaryActionText = primaryActionText
+        self.primaryActionSelector = primaryActionSelector
         self.secondaryActionText = secondaryActionText
+        self.secondaryActionSelector = secondaryActionSelector
         self.switchActionText = switchActionText
         self.switchActionTip = switchActionTip
         self.switchTargetMode = switchTargetMode
@@ -28,7 +32,8 @@ class AuthenticationMode: NSObject {
     }
 }
 
-
+// MARK: - Dynamic Properties
+//
 extension AuthenticationMode {
     
     @objc
@@ -62,6 +67,8 @@ extension AuthenticationMode {
 }
 
 
+// MARK: - Static Properties
+//
 extension AuthenticationMode {
     
     /// Auth Mode: Login with Username + Password
@@ -69,7 +76,9 @@ extension AuthenticationMode {
     @objc
     static var loginWithPassword: AuthenticationMode {
         AuthenticationMode(primaryActionText: LoginStrings.primaryAction,
+                           primaryActionSelector: #selector(AuthViewController.pressedLogInWithPassword),
                            secondaryActionText: LoginStrings.secondaryAction,
+                           secondaryActionSelector: #selector(AuthViewController.openForgotPasswordURL),
                            switchActionText: LoginStrings.switchAction,
                            switchActionTip: LoginStrings.switchTip,
                            switchTargetMode: { .signup },
@@ -83,7 +92,9 @@ extension AuthenticationMode {
     @objc
     static var loginWithMagicLink: AuthenticationMode {
         AuthenticationMode(primaryActionText: MagicLinkStrings.primaryAction,
+                           primaryActionSelector: #selector(AuthViewController.pressedLoginWithMagicLink),
                            secondaryActionText: MagicLinkStrings.secondaryAction,
+                           secondaryActionSelector: #selector(AuthViewController.switchToPasswordAuth),
                            switchActionText: MagicLinkStrings.switchAction,
                            switchActionTip: MagicLinkStrings.switchTip,
                            switchTargetMode: { .signup },
@@ -97,7 +108,9 @@ extension AuthenticationMode {
     @objc
     static var signup: AuthenticationMode {
         AuthenticationMode(primaryActionText: SignupStrings.primaryAction,
+                           primaryActionSelector: #selector(AuthViewController.pressedSignUp),
                            secondaryActionText: nil,
+                           secondaryActionSelector: nil,
                            switchActionText: SignupStrings.switchAction,
                            switchActionTip: SignupStrings.switchTip,
                            switchTargetMode: { .loginWithMagicLink },


### PR DESCRIPTION
### Details
In this PR we're enhancing `AuthViewController` so that its UI and state is derived from the `AuthenticationMode` object.

This allows us to reuse the same UI for **Login with Password** + **Login with Magic Link** and **Signup**.

### Test: Signup
1. Launch Simplenote

- [x] Verify the Authentication UI starts in Signup Mode
- [x] Verify that the blue button reads `Sign Up`
- [x] Verify that the footer reads `Already have an account? Log In`
- [x] Verify that if you enter an email, and click Sign Up, a spinner shows up, and the UI gets locked up
- [x] Verify that while the spinner is onscreen, the blue button reads `Signing Up...`

### Test: Login with Magic Link
1. Launch Simplenote
2. Click on the `Log In` button

- [x] Verify that the blue button reads `Instantly Log In with Email`
- [x] Verify that the text `Continue with Password` shows up below
- [x] Verify that clicking `Sign Up` gets you back to the Sign Up UI
- [x] Verify that clicking `Log In with WordPress.com` opens the WPCOM SSO

**Important:** Magic Link Auth isn't wired in this PR, so the main action is a NO-OP.
This will be implemented in #1181.

Thank you!!

### Test: Login with Password
1. Launch Simplenote
2. Click on the `Log In` button
3. Click on `Continue with password`

- [x] Verify that clicking on `Forgot your password` opens the Password Reset Web
- [x] Verify that clicking on `Sign Up` gets you back to the Signup UI
- [x] Verify that entering a Username **but not a password** gets you an error onscreen
- [x] Verify that clicking `Log In with WordPress.com` opens the WPCOM SSO
- [x] Verify that if you enter your Username + Password, you get logged into your account

### Release
> These changes do not require release notes.
