### PR TITLE
Add `Base.xcconfig` and push most code signing settings there

### DIFF
--- a/Base.xcconfig
+++ b/Base.xcconfig
@@ -1,0 +1,4 @@
+#include "Version.public.xcconfig"
+
+CODE_SIGN_STYLE = Manual
+DEVELOPMENT_TEAM = PZYM8XX95Q

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -444,6 +444,7 @@
 		37F742EA202A382400A47D3A /* AboutViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutViewController.swift; sourceTree = "<group>"; };
 		39ACEAE8218A03C6C22DC662 /* Pods-Automattic-Simplenote.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Automattic-Simplenote.release.xcconfig"; path = "Target Support Files/Pods-Automattic-Simplenote/Pods-Automattic-Simplenote.release.xcconfig"; sourceTree = "<group>"; };
 		3F1FC4212C0EBEF10066B187 /* Simplenote.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = Simplenote.xctestplan; sourceTree = "<group>"; };
+		3F6C39912C33C11100776C37 /* Base.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Base.xcconfig; sourceTree = "<group>"; };
 		466FFF2F17CC10A800399652 /* Simplenote.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Simplenote.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		469512CB17CD23100014A2BF /* Simplenote-Info-Hockey.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "Simplenote-Info-Hockey.plist"; sourceTree = "<group>"; };
 		46A0BEB8175BFD540050E864 /* Simplenote.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = Simplenote.entitlements; sourceTree = SOURCE_ROOT; };
@@ -1122,6 +1123,7 @@
 				8C902F8C22D3EE350018D654 /* Version.public.xcconfig */,
 				8C902F8722D3ED910018D654 /* Simplenote.release.xcconfig */,
 				8C902F8E22D3EFE60018D654 /* Simplenote.debug.xcconfig */,
+				3F6C39912C33C11100776C37 /* Base.xcconfig */,
 			);
 			name = config;
 			sourceTree = "<group>";
@@ -2547,13 +2549,10 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = "AppIcon-Beta";
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Simplenote/SimplenoteDebug.entitlements;
-				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEVELOPMENT_TEAM = PZYM8XX95Q;
-				"DEVELOPMENT_TEAM[sdk=macosx*]" = PZYM8XX95Q;
 				ENABLE_HARDENED_RUNTIME = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -2584,8 +2583,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.SimplenoteMac.Development;
 				PRODUCT_NAME = Simplenote;
 				PROVISIONING_PROFILE = "";
-				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "Simplenote Mac - Development";
+				PROVISIONING_PROFILE_SPECIFIER = "Simplenote Mac - Development";
 				SDKROOT = macosx;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -2602,11 +2600,9 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Simplenote.entitlements;
-				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEAD_CODE_STRIPPING = YES;
-				DEVELOPMENT_TEAM = PZYM8XX95Q;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"$(SRCROOT)/External\"/**",
@@ -2766,12 +2762,8 @@
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CODE_SIGN_ENTITLEMENTS = "IntentsExtension/Support Files/IntentsExtensionDebug.entitlements";
-				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = $BUILD_NUMBER;
 				DEBUG_INFORMATION_FORMAT = dwarf;
-				DEVELOPMENT_TEAM = "";
-				"DEVELOPMENT_TEAM[sdk=macosx*]" = PZYM8XX95Q;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
@@ -2793,8 +2785,7 @@
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.SimplenoteMac.Development.IntentsExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "Simplenote Mac Intents Extension - Development";
+				PROVISIONING_PROFILE_SPECIFIER = "Simplenote Mac Intents Extension - Development";
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited) APP_EXTENSION";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -2820,12 +2811,8 @@
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CODE_SIGN_ENTITLEMENTS = "IntentsExtension/Support Files/IntentsExtension.entitlements";
-				CODE_SIGN_IDENTITY = "Apple Distribution";
-				CODE_SIGN_STYLE = Manual;
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = $BUILD_NUMBER;
-				DEVELOPMENT_TEAM = "";
-				"DEVELOPMENT_TEAM[sdk=macosx*]" = PZYM8XX95Q;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
@@ -2848,8 +2835,7 @@
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.SimplenoteMac.IntentsExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "Simplenote Mac Development Intents";
+				PROVISIONING_PROFILE_SPECIFIER = "match AppStore com.automattic.SimplenoteMac.IntentsExtension macos";
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = APP_EXTENSION;
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/config/Simplenote.debug.xcconfig
+++ b/config/Simplenote.debug.xcconfig
@@ -1,1 +1,3 @@
-#include "Version.public.xcconfig"
+#include "Base.xcconfig"
+
+CODE_SIGN_IDENTITY = Apple Development

--- a/config/Simplenote.debug.xcconfig
+++ b/config/Simplenote.debug.xcconfig
@@ -1,3 +1,6 @@
 #include "Base.xcconfig"
 
 CODE_SIGN_IDENTITY = Apple Development
+
+// Notice we don't have a PROVISIONING_PROFILE_SPECIFIER defined here because this xcconfig is used at the project-level but that settings need to be target-level.
+// Once we'll have target-level xcconfigs, we shall add the setting there

--- a/config/Simplenote.release.xcconfig
+++ b/config/Simplenote.release.xcconfig
@@ -1,1 +1,3 @@
-#include "Version.public.xcconfig"
+#include "Base.xcconfig"
+
+CODE_SIGN_IDENTITY = Apple Distribution

--- a/config/Simplenote.release.xcconfig
+++ b/config/Simplenote.release.xcconfig
@@ -1,3 +1,6 @@
 #include "Base.xcconfig"
 
 CODE_SIGN_IDENTITY = Apple Distribution
+
+// Notice we don't have a PROVISIONING_PROFILE_SPECIFIER defined here because this xcconfig is used at the project-level but that settings need to be target-level.
+// Once we'll have target-level xcconfigs, we shall add the setting there


### PR DESCRIPTION
### Fix

This was prompted by some changes in the app identifiers (plural because we have one for release and one for debug) that required regenerating the provisioning profiles.

Internal ref pdnsEh-1Kz-p2

Adds a `Base.xcconfig` file and moves code signing settings there, so they are DRY and we don't need to deal with Xcode adding many lines to the project file every time we tweak them.

The only setting that stayed in the project itself (i.e. we'd need to use the Build Settings GUI to modify it) is `PROVISIONING_PROFILE_SPECIFIER` because this is a per-target setting and we don't have that level of granularity in the `xcconfig`s

### Test
You should be able to run a development build successfully after having downloaded a new development bundle from our Mission Control (Automatticians only).

I run a build locally in release mode to verify that mode builds, too.
![image](https://github.com/Automattic/simplenote-macos/assets/1218433/65742ec4-dcfa-4c28-95eb-56fec46ccd7e)


### Review
Only one developer or infra engineer required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.