### PR TITLE
Magic Links: Wires new Endpoints

### DIFF
--- a/Simplenote/LoginRemote.swift
+++ b/Simplenote/LoginRemote.swift
@@ -5,12 +5,12 @@ import Foundation
 class LoginRemote: Remote {
 
     func requestLoginEmail(email: String) async throws {
-        let request = requestForLoginRequest(with: email)
+        let request = requestForLoginRequest(email: email)
         try await performDataTask(with: request)
     }
 
-    func requestLoginConfirmation(authKey: String, authCode: String) async throws -> LoginConfirmationResponse {
-        let request = requestForLoginCompletion(authKey: authKey, authCode: authCode)
+    func requestLoginConfirmation(email: String, authCode: String) async throws -> LoginConfirmationResponse {
+        let request = requestForLoginCompletion(email: email, authCode: authCode)
         return try await performDataTask(with: request, type: LoginConfirmationResponse.self)
     }
 }
@@ -28,7 +28,7 @@ struct LoginConfirmationResponse: Codable, Equatable {
 //
 private extension LoginRemote {
 
-    func requestForLoginRequest(with email: String) -> URLRequest {
+    func requestForLoginRequest(email: String) -> URLRequest {
         let url = URL(string: SimplenoteConstants.loginRequestURL)!
         return requestForURL(url, method: RemoteConstants.Method.POST, httpBody: [
             "request_source": SimplenoteConstants.simplenotePlatformName,
@@ -36,10 +36,10 @@ private extension LoginRemote {
         ])
     }
 
-    func requestForLoginCompletion(authKey: String, authCode: String) -> URLRequest {
+    func requestForLoginCompletion(email: String, authCode: String) -> URLRequest {
         let url = URL(string: SimplenoteConstants.loginCompletionURL)!
         return requestForURL(url, method: RemoteConstants.Method.POST, httpBody: [
-            "auth_key": authKey,
+            "username": email,
             "auth_code": authCode
         ])
     }

--- a/Simplenote/LoginRemoteProtocol.swift
+++ b/Simplenote/LoginRemoteProtocol.swift
@@ -5,7 +5,7 @@ import Foundation
 //
 protocol LoginRemoteProtocol {
     func requestLoginEmail(email: String) async throws
-    func requestLoginConfirmation(authKey: String, authCode: String) async throws -> LoginConfirmationResponse
+    func requestLoginConfirmation(email: String, authCode: String) async throws -> LoginConfirmationResponse
 }
 
 

--- a/Simplenote/MagicLinkAuthenticator.swift
+++ b/Simplenote/MagicLinkAuthenticator.swift
@@ -56,19 +56,19 @@ private extension MagicLinkAuthenticator {
 
     @discardableResult
     func attemptLoginWithAuthCode(queryItems: [URLQueryItem]) -> Bool {
-        guard let authKey = queryItems.value(for: Constants.authKeyField),
+        guard let email = queryItems.base64DecodedValue(for: Constants.emailField),
               let authCode = queryItems.value(for: Constants.authCodeField),
-              !authKey.isEmpty, !authCode.isEmpty
+              !email.isEmpty, !authCode.isEmpty
         else {
             return false
         }
 
-        NSLog("[MagicLinkAuthenticator] Requesting SyncToken for \(authKey) and \(authCode)")
+        NSLog("[MagicLinkAuthenticator] Requesting SyncToken for \(email) and \(authCode)")
         NotificationCenter.default.post(name: .magicLinkAuthWillStart, object: nil)
         
         Task { @MainActor in
             do {
-                let confirmation = try await loginRemote.requestLoginConfirmation(authKey: authKey, authCode: authCode)
+                let confirmation = try await loginRemote.requestLoginConfirmation(email: email, authCode: authCode)
               
                 NSLog("[MagicLinkAuthenticator] Should auth with token \(confirmation.syncToken)")
                 authenticator.authenticate(withUsername: confirmation.username, token: confirmation.syncToken)
@@ -114,6 +114,5 @@ private struct AllowedHosts {
 private struct Constants {
     static let emailField = "email"
     static let tokenField = "token"
-    static let authKeyField = "auth_key"
     static let authCodeField = "auth_code"
 }

--- a/Simplenote/SimplenoteConstants.swift
+++ b/Simplenote/SimplenoteConstants.swift
@@ -31,8 +31,8 @@ class SimplenoteConstants: NSObject {
 
     /// URL(s)
     ///
-    static let loginRequestURL              = googleAppEngineBaseURL.appendingPathComponent("/account/request-login")
-    static let loginCompletionURL           = googleAppEngineBaseURL.appendingPathComponent("/account/complete-login")
+    static let loginRequestURL              = "https://magic-code-dot-simple-note-hrd.appspot.com/account/request-login" //googleAppEngineBaseURL.appendingPathComponent("/account/request-login")
+    static let loginCompletionURL           = "https://magic-code-dot-simple-note-hrd.appspot.com/account/complete-login" //googleAppEngineBaseURL.appendingPathComponent("/account/complete-login")
     static let simplenoteSettingsURL        = googleAppEngineBaseURL.appendingPathComponent("/settings")
     static let simplenoteVerificationURL    = googleAppEngineBaseURL.appendingPathComponent("/account/verify-email/")
     static let simplenoteRequestSignupURL   = googleAppEngineBaseURL.appendingPathComponent("/account/request-signup")

--- a/Simplenote/SimplenoteConstants.swift
+++ b/Simplenote/SimplenoteConstants.swift
@@ -31,8 +31,8 @@ class SimplenoteConstants: NSObject {
 
     /// URL(s)
     ///
-    static let loginRequestURL              = "https://magic-code-dot-simple-note-hrd.appspot.com/account/request-login" //googleAppEngineBaseURL.appendingPathComponent("/account/request-login")
-    static let loginCompletionURL           = "https://magic-code-dot-simple-note-hrd.appspot.com/account/complete-login" //googleAppEngineBaseURL.appendingPathComponent("/account/complete-login")
+    static let loginRequestURL              = googleAppEngineBaseURL.appendingPathComponent("/account/request-login")
+    static let loginCompletionURL           = googleAppEngineBaseURL.appendingPathComponent("/account/complete-login")
     static let simplenoteSettingsURL        = googleAppEngineBaseURL.appendingPathComponent("/settings")
     static let simplenoteVerificationURL    = googleAppEngineBaseURL.appendingPathComponent("/account/verify-email/")
     static let simplenoteRequestSignupURL   = googleAppEngineBaseURL.appendingPathComponent("/account/request-signup")

--- a/SimplenoteTests/LoginRemoteTests.swift
+++ b/SimplenoteTests/LoginRemoteTests.swift
@@ -42,7 +42,7 @@ class LoginRemoteTests: XCTestCase {
         /// Verify
         let body: Dictionary<String, String> = try XCTUnwrap(urlSession.lastRequest?.decodeHtmlBody())
 
-        XCTAssertEqual(body["email"], "1234@567.com")
+        XCTAssertEqual(body["username"], "1234@567.com")
         XCTAssertEqual(body["auth_code"], "5678")
         
         XCTAssertEqual(expectedResponse, decodedResponse)

--- a/SimplenoteTests/LoginRemoteTests.swift
+++ b/SimplenoteTests/LoginRemoteTests.swift
@@ -37,12 +37,12 @@ class LoginRemoteTests: XCTestCase {
         mockSessionResponse(statusCode: 200, payload: encodedResponseBody)
         
         /// Run
-        let decodedResponse = try await loginRemote.requestLoginConfirmation(authKey: "1234", authCode: "5678")
+        let decodedResponse = try await loginRemote.requestLoginConfirmation(email: "1234@567.com", authCode: "5678")
 
         /// Verify
         let body: Dictionary<String, String> = try XCTUnwrap(urlSession.lastRequest?.decodeHtmlBody())
 
-        XCTAssertEqual(body["auth_key"], "1234")
+        XCTAssertEqual(body["email"], "1234@567.com")
         XCTAssertEqual(body["auth_code"], "5678")
         
         XCTAssertEqual(expectedResponse, decodedResponse)

--- a/SimplenoteTests/MagicLinkAuthenticatorTests.swift
+++ b/SimplenoteTests/MagicLinkAuthenticatorTests.swift
@@ -26,9 +26,9 @@ final class MagicLinkAuthenticatorTests: XCTestCase {
     
     func testMagicLinkURLResultsInLoginConfirmationRequest() async throws {
         let expectation = expectation(description: "LoginConfirmationRequest")
-        loginRemote.onLoginConfirmationRequest = { (authKey, authCode) in
+        loginRemote.onLoginConfirmationRequest = { (email, authCode) in
             XCTAssertEqual(authCode, MagicLinkTestConstants.expectedCode)
-            XCTAssertEqual(authKey, MagicLinkTestConstants.expectedKey)
+            XCTAssertEqual(email, MagicLinkTestConstants.expectedUsername)
             
             expectation.fulfill()
             
@@ -64,6 +64,7 @@ private enum MagicLinkTestConstants {
     static let expectedSyncToken = "12345678"
     static let expectedKey = "1234"
     static let expectedCode = "5678"
-    static let sampleValidURL = URL(string: "simplenotemac://login?auth_key=\(expectedKey)&auth_code=\(expectedCode)")!
-    static let sampleInvalidURL = URL(string: "simplenotemac://login?auth_key=&auth_code=")!
+    static let encodedUsername = expectedUsername.data(using: .utf8)!.base64EncodedString()
+    static let sampleValidURL = URL(string: "simplenotemac://login?email=\(encodedUsername)&auth_code=\(expectedCode)")!
+    static let sampleInvalidURL = URL(string: "simplenotemac://login?email=&auth_code=")!
 }

--- a/SimplenoteTests/MockLoginRemote.swift
+++ b/SimplenoteTests/MockLoginRemote.swift
@@ -7,7 +7,7 @@ import Foundation
 class MockLoginRemote: LoginRemoteProtocol {
     var lastLoginRequestEmail: String?
     
-    var onLoginConfirmationRequest: ((_ authKey: String, _ authCode: String) -> LoginConfirmationResponse)?
+    var onLoginConfirmationRequest: ((_ email: String, _ authCode: String) -> LoginConfirmationResponse)?
     
     func requestLoginEmail(email: String) async throws {
         lastLoginRequestEmail = email

--- a/SimplenoteTests/MockLoginRemote.swift
+++ b/SimplenoteTests/MockLoginRemote.swift
@@ -13,8 +13,8 @@ class MockLoginRemote: LoginRemoteProtocol {
         lastLoginRequestEmail = email
     }
     
-    func requestLoginConfirmation(authKey: String, authCode: String) async throws -> LoginConfirmationResponse {
-        guard let response = onLoginConfirmationRequest?(authKey, authCode) else {
+    func requestLoginConfirmation(email: String, authCode: String) async throws -> LoginConfirmationResponse {
+        guard let response = onLoginConfirmationRequest?(email, authCode) else {
             throw RemoteError.network
         }
 


### PR DESCRIPTION
### ⚠️ Important
- [x] Make sure the new endpoints are deployed before merging
- [x] Remove the staging URL!

### Fix
In this PR we're wiring the new code-based endpoints.

Ref. #1187

### Test
1. Logout from Simplenote macOS
2. Click on the `Log In` button
3. Enter your email
4. Click on `Instantly Log In with Email`

- [ ] Verify that shortly after you get the Auth Email
- [ ] Verify that clicking on `Log Into Simplenote` button causes the mac app to Log In
- [ ] Verify the Unit Test pass

### Release
> These changes do not require release notes.
