### PR TITLE
Magic Links: Adjusting Copy

### DIFF
--- a/Simplenote/AuthViewController.m
+++ b/Simplenote/AuthViewController.m
@@ -140,7 +140,7 @@ static NSString *SPAuthSessionKey = @"SPAuthSessionKey";
 }
 
 - (void)pressedLoginWithMagicLink {
-    [SPTracker trackUserRequestedLoginLink];
+    [SPTracker trackLoginLinkRequested];
     
     [self clearAuthenticationError];
     

--- a/Simplenote/MagicLinkAuthenticator.swift
+++ b/Simplenote/MagicLinkAuthenticator.swift
@@ -74,11 +74,12 @@ private extension MagicLinkAuthenticator {
                 authenticator.authenticate(withUsername: confirmation.username, token: confirmation.syncToken)
 
                 NotificationCenter.default.post(name: .magicLinkAuthDidSucceed, object: nil)
-                SPTracker.trackUserConfirmedLoginLink()
+                SPTracker.trackLoginLinkConfirmationSuccess()
 
             } catch {
                 NSLog("[MagicLinkAuthenticator] Magic Link TokenExchange Error: \(error)")
                 NotificationCenter.default.post(name: .magicLinkAuthDidFail, object: error)
+                SPTracker.trackLoginLinkConfirmationFailure()
             }
         }
 

--- a/Simplenote/MagicLinkConfirmationView.swift
+++ b/Simplenote/MagicLinkConfirmationView.swift
@@ -43,7 +43,7 @@ struct MagicLinkConfirmationView: View {
     }
     
     private var invalidLinkText: some View {
-        Text("Link was no longer valid")
+        Text("Link no longer valid")
             .font(.title3)
             .foregroundColor(.gray)
     }

--- a/Simplenote/SPTracker.h
+++ b/Simplenote/SPTracker.h
@@ -74,8 +74,11 @@ NS_ASSUME_NONNULL_BEGIN
 + (void)trackUserSignedUp;
 + (void)trackUserSignedIn;
 + (void)trackUserSignedOut;
-+ (void)trackUserRequestedLoginLink;
-+ (void)trackUserConfirmedLoginLink;
+
+#pragma mark - Login Links
++ (void)trackLoginLinkRequested;
++ (void)trackLoginLinkConfirmationSuccess;
++ (void)trackLoginLinkConfirmationFailure;
 
 #pragma mark - WP.com Sign In
 + (void)trackWPCCButtonPressed;

--- a/Simplenote/SPTracker.m
+++ b/Simplenote/SPTracker.m
@@ -262,14 +262,22 @@
     [self trackAutomatticEventWithName:@"user_signed_out" properties:nil];
 }
 
-+ (void)trackUserRequestedLoginLink
+
+#pragma mark - Login Links
+
++ (void)trackLoginLinkRequested
 {
-    [self trackAutomatticEventWithName:@"user_requested_login_link" properties:nil];
+    [self trackAutomatticEventWithName:@"login_link_requested" properties:nil];
 }
 
-+ (void)trackUserConfirmedLoginLink
++ (void)trackLoginLinkConfirmationSuccess
 {
-   [self trackAutomatticEventWithName:@"user_confirmed_login_link" properties:nil];
+   [self trackAutomatticEventWithName:@"login_link_confirmation_success" properties:nil];
+}
+
++ (void)trackLoginLinkConfirmationFailure
+{
+   [self trackAutomatticEventWithName:@"login_link_confirmation_failure" properties:nil];
 }
 
 


### PR DESCRIPTION
### Fix
In this PR we're adjusting the copy of the "Invalid Link" UI, along with adding tracks events for Magic Link Auth Failure.

### Test
1. Paste this into iMessage (or any other messaging app you've got in your mac!!): https://app.simplenote.com/login?email=eW91cmVtYWlsQGxhbGFsYS5jb20==&auth_code=A000
2. Click on the link

- [x] Verify Simplenote macOS ends up in the foreground
- [x] Verify that you get a UI indicating that the link is no longer valid
- [x] Verify that the changes make sense!

### Screenshots
<img width="300" src="https://github.com/Automattic/simplenote-macos/assets/1195260/4ab1d1ef-3705-4625-a435-b6f405ab60a2">


### Release
> These changes do not require release notes.
