### PR TITLE
Charlie/passkey registration

### DIFF
--- a/Simplenote.entitlements
+++ b/Simplenote.entitlements
@@ -5,6 +5,7 @@
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>applinks:app.simplenote.com</string>
+		<string>webcredentials:passkey-dev-dot-simple-note-hrd.appspot.com</string>
 	</array>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -269,6 +269,7 @@
 		BA1B70122C1CD8D5008282D7 /* RecoveryArchiver.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA1B70112C1CD8D5008282D7 /* RecoveryArchiver.swift */; };
 		BA2BF3402C07C75500A7C894 /* FindNoteIntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA2BF33F2C07C75500A7C894 /* FindNoteIntentHandler.swift */; };
 		BA2C65CF26FE996A00FA84E1 /* NSButton+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA2C65CA26FE996100FA84E1 /* NSButton+Extensions.swift */; };
+		BA45AD522C483C81002E0D27 /* NSAlert+Passkeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA45AD512C483C81002E0D27 /* NSAlert+Passkeys.swift */; };
 		BA4C6D16264CA8C000B723A7 /* SignupRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA4C6D15264CA8C000B723A7 /* SignupRemoteTests.swift */; };
 		BA4C6D18264CAAF800B723A7 /* URLRequest+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA4C6D17264CAAF800B723A7 /* URLRequest+Simplenote.swift */; };
 		BA4F223E2C1255A500144EDA /* SPCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E196C0230F5F5300F5658A /* SPCredentials.swift */; };
@@ -761,6 +762,7 @@
 		BA2C65CA26FE996100FA84E1 /* NSButton+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSButton+Extensions.swift"; sourceTree = "<group>"; };
 		BA39C4542C0133F30004B2A9 /* SimplenoteDebug.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = SimplenoteDebug.entitlements; sourceTree = "<group>"; };
 		BA39C4552C0134180004B2A9 /* IntentsExtensionDebug.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = IntentsExtensionDebug.entitlements; sourceTree = "<group>"; };
+		BA45AD512C483C81002E0D27 /* NSAlert+Passkeys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSAlert+Passkeys.swift"; sourceTree = "<group>"; };
 		BA4C6D15264CA8C000B723A7 /* SignupRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignupRemoteTests.swift; sourceTree = "<group>"; };
 		BA4C6D17264CAAF800B723A7 /* URLRequest+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLRequest+Simplenote.swift"; sourceTree = "<group>"; };
 		BA52005A2BC878F1003F1B75 /* CSSearchable+Helpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CSSearchable+Helpers.swift"; sourceTree = "<group>"; };
@@ -1702,6 +1704,7 @@
 				BA6689652C45C54B009D4E84 /* PasskeyRegistrationResponse.swift */,
 				BA6689672C45C59E009D4E84 /* PasskeyError.swift */,
 				BA66896B2C45C64C009D4E84 /* PasskeyTypeAliases.swift */,
+				BA45AD512C483C81002E0D27 /* NSAlert+Passkeys.swift */,
 			);
 			name = Passkeys;
 			sourceTree = "<group>";
@@ -2106,6 +2109,7 @@
 				B518D37C2507BFA4006EA7F8 /* Note+Interlinks.swift in Sources */,
 				B58117E925B9EE7B00927E0C /* Button.swift in Sources */,
 				B5E086292448B57200DEF476 /* HeaderTableCellView.swift in Sources */,
+				BA45AD522C483C81002E0D27 /* NSAlert+Passkeys.swift in Sources */,
 				375D294721E033D1007AB25A /* version.c in Sources */,
 				466FFEA917CC10A800399652 /* SimplenoteAppDelegate.m in Sources */,
 				B5D3FCCD201F906E00A813B7 /* StatusChecker.m in Sources */,

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -283,6 +283,10 @@
 		BA5A65972C091D0600F605A6 /* CoreDataValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA5A65962C091D0600F605A6 /* CoreDataValidator.swift */; };
 		BA5A65992C091E6000F605A6 /* MockStorageValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA5A65982C091E6000F605A6 /* MockStorageValidator.swift */; };
 		BA5F020626BB57F000581E92 /* NSAlert+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA5F020426BB57F000581E92 /* NSAlert+Simplenote.swift */; };
+		BA6689612C45C507009D4E84 /* PasskeyRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA66895F2C45C4B4009D4E84 /* PasskeyRemote.swift */; };
+		BA6689642C45C52B009D4E84 /* PasskeyRegistrationChallenge.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA6689632C45C52B009D4E84 /* PasskeyRegistrationChallenge.swift */; };
+		BA6689662C45C54B009D4E84 /* PasskeyRegistrationResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA6689652C45C54B009D4E84 /* PasskeyRegistrationResponse.swift */; };
+		BA6689682C45C59E009D4E84 /* PasskeyError.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA6689672C45C59E009D4E84 /* PasskeyError.swift */; };
 		BA71EC242BC88FD000F42CB1 /* CSSearchable+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA52005A2BC878F1003F1B75 /* CSSearchable+Helpers.swift */; };
 		BA71EC252BC88FFC00F42CB1 /* NSManagedObjectContext+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA52005C2BC88397003F1B75 /* NSManagedObjectContext+Simplenote.swift */; };
 		BA78AF712B5B2BC300DCF896 /* AutomatticTracks in Frameworks */ = {isa = PBXBuildFile; productRef = BA78AF702B5B2BC300DCF896 /* AutomatticTracks */; };
@@ -769,6 +773,10 @@
 		BA5A65962C091D0600F605A6 /* CoreDataValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataValidator.swift; sourceTree = "<group>"; };
 		BA5A65982C091E6000F605A6 /* MockStorageValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockStorageValidator.swift; sourceTree = "<group>"; };
 		BA5F020426BB57F000581E92 /* NSAlert+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSAlert+Simplenote.swift"; sourceTree = "<group>"; };
+		BA66895F2C45C4B4009D4E84 /* PasskeyRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PasskeyRemote.swift; path = SimplenoteTests/PasskeyRemote.swift; sourceTree = SOURCE_ROOT; };
+		BA6689632C45C52B009D4E84 /* PasskeyRegistrationChallenge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasskeyRegistrationChallenge.swift; sourceTree = "<group>"; };
+		BA6689652C45C54B009D4E84 /* PasskeyRegistrationResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasskeyRegistrationResponse.swift; sourceTree = "<group>"; };
+		BA6689672C45C59E009D4E84 /* PasskeyError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasskeyError.swift; sourceTree = "<group>"; };
 		BA8CF21B2BFD20770087F33D /* Intents.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Intents.framework; path = System/Library/Frameworks/Intents.framework; sourceTree = SDKROOT; };
 		BA938CEB26ACFF4A00BE5A1D /* Remote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Remote.swift; sourceTree = "<group>"; };
 		BA938CED26AD055400BE5A1D /* AccountVerificationController+TestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AccountVerificationController+TestHelpers.swift"; sourceTree = "<group>"; };
@@ -1168,6 +1176,7 @@
 				B5F5414D25EFFC2A00CAF52C /* RemoteConstants.swift */,
 				B502C1DC25BA2EB700145D6C /* AccountRemote.swift */,
 				B587D7DD2C21FDDF006645CF /* LoginRemote.swift */,
+				BA66895F2C45C4B4009D4E84 /* PasskeyRemote.swift */,
 				B5F5414725EFFC2200CAF52C /* SignupRemote.swift */,
 				BA938CEB26ACFF4A00BE5A1D /* Remote.swift */,
 				BAA0A87926B9F0B50006260E /* RemoteError.swift */,
@@ -1394,6 +1403,7 @@
 		B587D7E82C221503006645CF /* Authentication */ = {
 			isa = PBXGroup;
 			children = (
+				BA6689622C45C51C009D4E84 /* Passkeys */,
 				B5F5415325F0137100CAF52C /* MagicLinkAuthenticator.swift */,
 				B587D7E92C221575006645CF /* SimperiumAuthenticatorProtocol.swift */,
 				B587D7ED2C2217B1006645CF /* LoginRemoteProtocol.swift */,
@@ -1675,6 +1685,16 @@
 				BA5A658E2C090FEC00F605A6 /* FileManagerProtocol.swift */,
 			);
 			name = Protocols;
+			sourceTree = "<group>";
+		};
+		BA6689622C45C51C009D4E84 /* Passkeys */ = {
+			isa = PBXGroup;
+			children = (
+				BA6689632C45C52B009D4E84 /* PasskeyRegistrationChallenge.swift */,
+				BA6689652C45C54B009D4E84 /* PasskeyRegistrationResponse.swift */,
+				BA6689672C45C59E009D4E84 /* PasskeyError.swift */,
+			);
+			name = Passkeys;
 			sourceTree = "<group>";
 		};
 		BAAA71D32C07A0F000244C01 /* Models */ = {
@@ -2143,6 +2163,7 @@
 				B5F807CD2481982B0048CBD7 /* Note+Simplenote.swift in Sources */,
 				A6C1E21525E010140076ADF7 /* SPApplication.swift in Sources */,
 				466FFEB417CC10A800399652 /* DateTransformer.m in Sources */,
+				BA6689662C45C54B009D4E84 /* PasskeyRegistrationResponse.swift in Sources */,
 				BA71EC252BC88FFC00F42CB1 /* NSManagedObjectContext+Simplenote.swift in Sources */,
 				BAB261752BFFD319009A98D7 /* OpenNewNoteIntentHandler.swift in Sources */,
 				B5132FA923C4B9760065DD80 /* NSTextStorage+Simplenote.swift in Sources */,
@@ -2177,6 +2198,7 @@
 				B55C312D24A530A500B23B3F /* MetricsViewController.swift in Sources */,
 				B56FA7932437C672002CB9FF /* NSColor+Theme.swift in Sources */,
 				B5C63338251E6A5A00C8BF46 /* InterlinkViewController.swift in Sources */,
+				BA6689612C45C507009D4E84 /* PasskeyRemote.swift in Sources */,
 				375D293321E033D1007AB25A /* buffer.c in Sources */,
 				BAFB545126CCA7F1006E037C /* NSProgressIndicator+Simplenote.swift in Sources */,
 				B5AF76CC24A3F27E00B7D530 /* TagListRow.swift in Sources */,
@@ -2198,6 +2220,7 @@
 				B54F9A6824D0B21D00BCF754 /* NSNotification+Simplenote.swift in Sources */,
 				B532F8A820C71C1000EA3506 /* WPAuthHandler.m in Sources */,
 				466FFEC117CC10A800399652 /* NSMutableAttributedString+Styling.m in Sources */,
+				BA6689642C45C52B009D4E84 /* PasskeyRegistrationChallenge.swift in Sources */,
 				B5BB8CD524DB51670024E4C5 /* NSSearchField+Simplenote.swift in Sources */,
 				BA553F0927065E20007737E9 /* FontSettings.swift in Sources */,
 				375D294921E033D1007AB25A /* html_blocks.c in Sources */,
@@ -2219,6 +2242,7 @@
 				B58117E325B9E5D200927E0C /* AccountVerificationController.swift in Sources */,
 				B5F5414925EFFC2200CAF52C /* SignupRemote.swift in Sources */,
 				B5EB3AD82458CDB50089858D /* ThemeOption.swift in Sources */,
+				BA6689682C45C59E009D4E84 /* PasskeyError.swift in Sources */,
 				B59848831BCDB95A005EFBBE /* SPTracker.m in Sources */,
 				B5283BD123B679C00085826F /* NSMutableAttributedString+Simplenote.swift in Sources */,
 				B56FA7992437C79D002CB9FF /* SPUserInterface.swift in Sources */,

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -287,6 +287,8 @@
 		BA6689642C45C52B009D4E84 /* PasskeyRegistrationChallenge.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA6689632C45C52B009D4E84 /* PasskeyRegistrationChallenge.swift */; };
 		BA6689662C45C54B009D4E84 /* PasskeyRegistrationResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA6689652C45C54B009D4E84 /* PasskeyRegistrationResponse.swift */; };
 		BA6689682C45C59E009D4E84 /* PasskeyError.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA6689672C45C59E009D4E84 /* PasskeyError.swift */; };
+		BA66896A2C45C60E009D4E84 /* PasskeyRegistrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA6689692C45C60E009D4E84 /* PasskeyRegistrator.swift */; };
+		BA66896C2C45C64C009D4E84 /* PasskeyTypeAliases.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA66896B2C45C64C009D4E84 /* PasskeyTypeAliases.swift */; };
 		BA71EC242BC88FD000F42CB1 /* CSSearchable+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA52005A2BC878F1003F1B75 /* CSSearchable+Helpers.swift */; };
 		BA71EC252BC88FFC00F42CB1 /* NSManagedObjectContext+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA52005C2BC88397003F1B75 /* NSManagedObjectContext+Simplenote.swift */; };
 		BA78AF712B5B2BC300DCF896 /* AutomatticTracks in Frameworks */ = {isa = PBXBuildFile; productRef = BA78AF702B5B2BC300DCF896 /* AutomatticTracks */; };
@@ -777,6 +779,8 @@
 		BA6689632C45C52B009D4E84 /* PasskeyRegistrationChallenge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasskeyRegistrationChallenge.swift; sourceTree = "<group>"; };
 		BA6689652C45C54B009D4E84 /* PasskeyRegistrationResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasskeyRegistrationResponse.swift; sourceTree = "<group>"; };
 		BA6689672C45C59E009D4E84 /* PasskeyError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasskeyError.swift; sourceTree = "<group>"; };
+		BA6689692C45C60E009D4E84 /* PasskeyRegistrator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PasskeyRegistrator.swift; sourceTree = "<group>"; };
+		BA66896B2C45C64C009D4E84 /* PasskeyTypeAliases.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasskeyTypeAliases.swift; sourceTree = "<group>"; };
 		BA8CF21B2BFD20770087F33D /* Intents.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Intents.framework; path = System/Library/Frameworks/Intents.framework; sourceTree = SDKROOT; };
 		BA938CEB26ACFF4A00BE5A1D /* Remote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Remote.swift; sourceTree = "<group>"; };
 		BA938CED26AD055400BE5A1D /* AccountVerificationController+TestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AccountVerificationController+TestHelpers.swift"; sourceTree = "<group>"; };
@@ -1690,9 +1694,11 @@
 		BA6689622C45C51C009D4E84 /* Passkeys */ = {
 			isa = PBXGroup;
 			children = (
+				BA6689692C45C60E009D4E84 /* PasskeyRegistrator.swift */,
 				BA6689632C45C52B009D4E84 /* PasskeyRegistrationChallenge.swift */,
 				BA6689652C45C54B009D4E84 /* PasskeyRegistrationResponse.swift */,
 				BA6689672C45C59E009D4E84 /* PasskeyError.swift */,
+				BA66896B2C45C64C009D4E84 /* PasskeyTypeAliases.swift */,
 			);
 			name = Passkeys;
 			sourceTree = "<group>";
@@ -2276,8 +2282,10 @@
 				B57CB882244E421400BA7969 /* SPTextField.swift in Sources */,
 				B5F807D02481A2010048CBD7 /* Simperium+Simplenote.swift in Sources */,
 				B5A9FE492576D25A0084F176 /* NSBox+Simplenote.swift in Sources */,
+				BA66896A2C45C60E009D4E84 /* PasskeyRegistrator.swift in Sources */,
 				B501AAD32437E5600084CDA3 /* AppKitConstants.swift in Sources */,
 				B57CB87F244DED2300BA7969 /* Bundle+Simplenote.swift in Sources */,
+				BA66896C2C45C64C009D4E84 /* PasskeyTypeAliases.swift in Sources */,
 				3712FC831FE1ACAA008544AC /* Storage.swift in Sources */,
 				B587D7DE2C21FDDF006645CF /* LoginRemote.swift in Sources */,
 				375D293521E033D1007AB25A /* autolink.c in Sources */,

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -291,6 +291,7 @@
 		BA66896C2C45C64C009D4E84 /* PasskeyTypeAliases.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA66896B2C45C64C009D4E84 /* PasskeyTypeAliases.swift */; };
 		BA71EC242BC88FD000F42CB1 /* CSSearchable+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA52005A2BC878F1003F1B75 /* CSSearchable+Helpers.swift */; };
 		BA71EC252BC88FFC00F42CB1 /* NSManagedObjectContext+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA52005C2BC88397003F1B75 /* NSManagedObjectContext+Simplenote.swift */; };
+		BA7575E62C45E269009C08FC /* BlockingActivityIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA7575E52C45E269009C08FC /* BlockingActivityIndicator.swift */; };
 		BA78AF712B5B2BC300DCF896 /* AutomatticTracks in Frameworks */ = {isa = PBXBuildFile; productRef = BA78AF702B5B2BC300DCF896 /* AutomatticTracks */; };
 		BA938CEE26AD055400BE5A1D /* AccountVerificationController+TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA938CED26AD055400BE5A1D /* AccountVerificationController+TestHelpers.swift */; };
 		BA94CB652C0E46CC00B34EA7 /* Uploader.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA94CB642C0E46CC00B34EA7 /* Uploader.swift */; };
@@ -781,6 +782,7 @@
 		BA6689672C45C59E009D4E84 /* PasskeyError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasskeyError.swift; sourceTree = "<group>"; };
 		BA6689692C45C60E009D4E84 /* PasskeyRegistrator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PasskeyRegistrator.swift; sourceTree = "<group>"; };
 		BA66896B2C45C64C009D4E84 /* PasskeyTypeAliases.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasskeyTypeAliases.swift; sourceTree = "<group>"; };
+		BA7575E52C45E269009C08FC /* BlockingActivityIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockingActivityIndicator.swift; sourceTree = "<group>"; };
 		BA8CF21B2BFD20770087F33D /* Intents.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Intents.framework; path = System/Library/Frameworks/Intents.framework; sourceTree = SDKROOT; };
 		BA938CEB26ACFF4A00BE5A1D /* Remote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Remote.swift; sourceTree = "<group>"; };
 		BA938CED26AD055400BE5A1D /* AccountVerificationController+TestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AccountVerificationController+TestHelpers.swift"; sourceTree = "<group>"; };
@@ -1133,6 +1135,7 @@
 				3700E97521C1E390004771C9 /* SPTextAttachment.swift */,
 				B57CB880244E421400BA7969 /* SPTextField.swift */,
 				A667305325C9751B00090DE3 /* SearchMapView.swift */,
+				BA7575E52C45E269009C08FC /* BlockingActivityIndicator.swift */,
 			);
 			name = Views;
 			sourceTree = "<group>";
@@ -2164,6 +2167,7 @@
 				BACA687B2C0A7634005409C1 /* KeychainPasswordItem.swift in Sources */,
 				375D294321E033D1007AB25A /* html5_blocks.c in Sources */,
 				B51AFE7725D36CDD00A196DF /* NSFont+Simplenote.swift in Sources */,
+				BA7575E62C45E269009C08FC /* BlockingActivityIndicator.swift in Sources */,
 				375D293D21E033D1007AB25A /* hash.c in Sources */,
 				B574CA74242D552100F8D02F /* TextViewInputHandler.swift in Sources */,
 				B5F807CD2481982B0048CBD7 /* Note+Simplenote.swift in Sources */,

--- a/Simplenote/BlockingActivityIndicator.swift
+++ b/Simplenote/BlockingActivityIndicator.swift
@@ -1,0 +1,61 @@
+import Appkit
+
+class BlockingActivityIndicator: NSView {
+    let activityIndicator: NSProgressIndicator
+
+    init(indicatorFrame: NSRect) {
+        self.activityIndicator = NSProgressIndicator(frame: indicatorFrame)
+        super.init(frame: .zero)
+        setupView()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setupView() {
+        wantsLayer = true
+        layer?.backgroundColor = NSColor.black.withAlphaComponent(0.3).cgColor
+        translatesAutoresizingMaskIntoConstraints = false
+
+        activityIndicator.style = .spinning
+        activityIndicator.translatesAutoresizingMaskIntoConstraints = false
+
+        addSubview(activityIndicator)
+
+        NSLayoutConstraint.activate([
+            activityIndicator.centerXAnchor.constraint(equalTo: centerXAnchor),
+            activityIndicator.centerYAnchor.constraint(equalTo: centerYAnchor)
+        ])
+
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        // Blocking lower views from receiving events
+    }
+
+    func startAnimation() {
+        activityIndicator.startAnimation(nil)
+    }
+
+    func stopAnimation() {
+        activityIndicator.stopAnimation(nil)
+        removeFromSuperview()
+    }
+
+    static func showIndicator(in view: NSView, spinnerRect: NSRect = NSRect(x: 0, y: 0, width: 50, height: 50)) -> BlockingActivityIndicator {
+        let indicator = BlockingActivityIndicator(indicatorFrame: spinnerRect)
+
+        view.addSubview(indicator)
+        NSLayoutConstraint.activate([
+            indicator.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            indicator.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            indicator.topAnchor.constraint(equalTo: view.topAnchor),
+            indicator.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+
+        indicator.startAnimation()
+
+        return indicator
+    }
+}

--- a/Simplenote/BlockingActivityIndicator.swift
+++ b/Simplenote/BlockingActivityIndicator.swift
@@ -16,7 +16,6 @@ class BlockingActivityIndicator: NSView {
     private func setupView() {
         wantsLayer = true
         layer?.backgroundColor = NSColor.black.withAlphaComponent(0.3).cgColor
-        translatesAutoresizingMaskIntoConstraints = false
 
         activityIndicator.style = .spinning
         activityIndicator.translatesAutoresizingMaskIntoConstraints = false
@@ -45,7 +44,8 @@ class BlockingActivityIndicator: NSView {
 
     static func showIndicator(in view: NSView, spinnerRect: NSRect = NSRect(x: 0, y: 0, width: 50, height: 50)) -> BlockingActivityIndicator {
         let indicator = BlockingActivityIndicator(indicatorFrame: spinnerRect)
-
+        indicator.translatesAutoresizingMaskIntoConstraints = false
+        
         view.addSubview(indicator)
         NSLayoutConstraint.activate([
             indicator.leadingAnchor.constraint(equalTo: view.leadingAnchor),

--- a/Simplenote/BlockingActivityIndicator.swift
+++ b/Simplenote/BlockingActivityIndicator.swift
@@ -1,4 +1,4 @@
-import Appkit
+import AppKit
 
 class BlockingActivityIndicator: NSView {
     let activityIndicator: NSProgressIndicator

--- a/Simplenote/NSAlert+Passkeys.swift
+++ b/Simplenote/NSAlert+Passkeys.swift
@@ -1,0 +1,47 @@
+//
+//  NSAlert+Passkeys.swift
+//  Simplenote
+//
+//  Created by Charlie Scheer on 7/17/24.
+//  Copyright © 2024 Simperium. All rights reserved.
+//
+
+import Foundation
+
+extension NSAlert {
+    static func presentPasskeyRegistrationAlert(onSubmit: @escaping (String) -> Void) {
+        let alert = NSAlert(messageText: PasskeyAuthentication.alertTitle, informativeText: PasskeyAuthentication.message)
+        let passwordField = NSSecureTextField(frame: NSRect(x: 0, y: 0, width: 200, height: 24))
+        alert.accessoryView = passwordField
+        alert.addButton(withTitle: PasskeyAuthentication.submit)
+        alert.addButton(withTitle: PasskeyAuthentication.cancel)
+
+        let modalResult = alert.runModal()
+        
+        guard modalResult == .alertFirstButtonReturn else {
+            return
+        }
+
+        onSubmit(passwordField.stringValue)
+    }
+
+    static func presentPasskeyResolvedAlert(succeeded: Bool) {
+        let title = succeeded ? PasskeyAuthentication.successTitle : PasskeyAuthentication.failureTitle
+        let message = succeeded ? PasskeyAuthentication.successMessage : PasskeyAuthentication.failureMessage
+        let alert = NSAlert(messageText: title, informativeText: message)
+        alert.addButton(withTitle: PasskeyAuthentication.okay)
+        alert.runModal()
+    }
+}
+
+private struct PasskeyAuthentication {
+    static let alertTitle = NSLocalizedString("Passkey Setup", comment: "Alert title for setting up passkeys")
+    static let message = NSLocalizedString("To add passkeys you must enter your password", comment: "Message prompting user for password to create passkey")
+    static let submit = NSLocalizedString("Submit", comment: "Submit button title")
+    static let cancel = NSLocalizedString("Cancel", comment: "Cancel button title")
+    static let failureTitle = NSLocalizedString("Passkey Registration Failed", comment: "Title for alert when passkey registration fails")
+    static let failureMessage = NSLocalizedString("Could not register passkey.  Please try again later", comment: "Message for when passkey registration fails")
+    static let okay = NSLocalizedString("Okay", comment: "confirm button title")
+    static let successTitle = NSLocalizedString("Success!!", comment: "Title for alert when passkey registration succeeds")
+    static let successMessage = NSLocalizedString("Passkey Registration Succeeded", comment: "message for alert when passkey registration succeeds")
+}

--- a/Simplenote/PasskeyError.swift
+++ b/Simplenote/PasskeyError.swift
@@ -1,0 +1,19 @@
+enum PasskeyError: Error {
+    case couldNotRequestRegistrationChallenge
+    case couldNotFetchAuthChallenge
+    case authFailed
+    case registrationFailed
+
+    var localizedDescription: String {
+        switch self {
+        case .couldNotRequestRegistrationChallenge:
+            return NSLocalizedString("Could not prepare an registration challenge", comment: "Error message that registering passkeys could not receive needed challeng")
+        case .couldNotFetchAuthChallenge:
+            return NSLocalizedString("Could not prepare an authorization challenge", comment: "Error message that authorizing passkeys could not receive needed challeng")
+        case .authFailed:
+            return NSLocalizedString("Authorization Failed", comment: "Error message that passkey authorization failed")
+        case .registrationFailed:
+            return NSLocalizedString("Registration Failed", comment: "Error message that passkey registration failed")
+        }
+    }
+}

--- a/Simplenote/PasskeyRegistrationChallenge.swift
+++ b/Simplenote/PasskeyRegistrationChallenge.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+struct PasskeyRegistrationChallenge: Decodable {
+    private struct User: Decodable {
+        let name: String
+        let userID: String
+
+        enum CodingKeys: String, CodingKey {
+            case name
+            case userID = "id"
+        }
+    }
+
+    private struct RelayingParty: Decodable {
+        let id: String
+    }
+
+    private let relayingParty: PasskeyRegistrationChallenge.RelayingParty
+    private let user: PasskeyRegistrationChallenge.User
+    private let challenge: String
+
+    enum CodingKeys: String, CodingKey {
+        case relayingParty = "rp"
+        case user
+        case challenge
+    }
+
+    var relayingPartyIdentifier: String {
+        relayingParty.id
+    }
+
+    var challengeData: Data? {
+        challenge.data(using: .utf8)
+    }
+
+    var displayName: String {
+        user.name
+    }
+
+    var userID: Data? {
+        user.userID.data(using: .utf8)
+    }
+}

--- a/Simplenote/PasskeyRegistrationResponse.swift
+++ b/Simplenote/PasskeyRegistrationResponse.swift
@@ -1,0 +1,45 @@
+import Foundation
+import AuthenticationServices
+
+struct PasskeyRegistrationResponse: Encodable {
+    struct Response: Encodable {
+        let clientDataJSON: String
+        let attestationObject: String
+    }
+
+    private let email: String
+    private let id: String
+    private let rawId: String
+    private let type: String
+    private let response: PasskeyRegistrationResponse.Response
+
+    init(from credentialRegistration: ASAuthorizationPlatformPublicKeyCredentialRegistration, with email: String?) throws {
+        guard let email,
+        let clientJson = Self.prepareJSON(from: credentialRegistration.rawClientDataJSON),
+        let rawAttestationObject = credentialRegistration.rawAttestationObject else {
+            throw PasskeyError.registrationFailed
+        }
+
+        let idString = credentialRegistration.credentialID.base64EncodedString().toBase64url()
+        let response = Response(clientDataJSON: clientJson.base64EncodedString(), attestationObject: rawAttestationObject.base64EncodedString())
+
+        self.email = email
+        self.id = idString
+        self.rawId = idString
+        self.type = "public-key"
+        self.response = response
+    }
+
+    private static func prepareJSON(from data: Data) -> Data? {
+        guard var json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let base64challenge = json["challenge"] as? String,
+              let challengeData = Data(base64Encoded: base64challenge + "="),
+              let challenge = String(data: challengeData, encoding: .utf8) else {
+            return nil
+        }
+
+        json["challenge"] = challenge
+
+        return try? JSONSerialization.data(withJSONObject: json)
+    }
+}

--- a/Simplenote/PasskeyRegistrator.swift
+++ b/Simplenote/PasskeyRegistrator.swift
@@ -1,0 +1,81 @@
+import Foundation
+import AuthenticationServices
+
+class PasskeyRegistrationControllerDelegate: NSObject, ASAuthorizationControllerDelegate {
+    var onCompletion: ((Result<PublicKeyCredentialRegistration, Error>) -> Void)?
+
+    public func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: any Error) {
+        onCompletion?(.failure(error))
+    }
+
+    public func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
+        guard let credential = authorization.credential as? PublicKeyCredentialRegistration else {
+            onCompletion?(.failure(PasskeyError.couldNotRequestRegistrationChallenge))
+            return
+        }
+
+        onCompletion?(.success(credential))
+    }
+}
+
+class PasskeyRegistrator {
+    private let passkeyRemote: PasskeyRemote
+    private let internalAuthControllerDelegate: PasskeyRegistrationControllerDelegate
+    private var userEmail: String? = nil
+
+    init(passkeyRemote: PasskeyRemote = PasskeyRemote(), registrationDelegate: PasskeyRegistrationControllerDelegate = .init()) {
+        self.passkeyRemote = passkeyRemote
+        self.internalAuthControllerDelegate = registrationDelegate
+    }
+
+    func attemptPasskeyRegistration(for email: String, password: String, presentationContext: PresentationContext) async throws {
+        let challenge = try await requestChallenge(for: email, password: password)
+        let registrationResponse = try await attemptRegistration(with: challenge, presentationContext: presentationContext)
+        try await passkeyRemote.registerCredential(with: registrationResponse)
+    }
+
+    private func requestChallenge(for email: String, password: String) async throws -> PasskeyRegistrationChallenge {
+        userEmail = email
+        do {
+            return try await passkeyRemote.requestChallengeResponseToCreatePasskey(forEmail: email, password: password)
+        } catch {
+            throw PasskeyError.couldNotRequestRegistrationChallenge
+        }
+    }
+
+    private func attemptRegistration(with passkeyChallenge: PasskeyRegistrationChallenge, presentationContext: PresentationContext) async throws -> PasskeyRegistrationResponse {
+        guard let challengeData = passkeyChallenge.challengeData,
+              let userID = passkeyChallenge.userID else {
+            throw PasskeyError.couldNotRequestRegistrationChallenge
+        }
+
+        let platformProvider = ASAuthorizationPlatformPublicKeyCredentialProvider(relyingPartyIdentifier: passkeyChallenge.relayingPartyIdentifier)
+        let platformKeyRequest = platformProvider.createCredentialRegistrationRequest(challenge: challengeData, name: passkeyChallenge.displayName, userID: userID)
+        let authController = ASAuthorizationController(authorizationRequests: [platformKeyRequest])
+        authController.delegate = internalAuthControllerDelegate
+        authController.presentationContextProvider = presentationContext
+
+        return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<PasskeyRegistrationResponse, any Error>) in
+            internalAuthControllerDelegate.onCompletion = { [weak self] result in
+                guard let self else {
+                    continuation.resume(throwing: PasskeyError.registrationFailed)
+                    return
+                }
+
+                switch result {
+                case .success(let credential):
+                    do {
+                        let registrationData = try PasskeyRegistrationResponse(from: credential, with: userEmail)
+                        continuation.resume(returning: registrationData)
+                    } catch {
+                        continuation.resume(throwing: error)
+                    }
+                case .failure(let error):
+                    continuation.resume(throwing: error)
+                }
+            }
+
+            authController.performRequests()
+        }
+    }
+}

--- a/Simplenote/PasskeyTypeAliases.swift
+++ b/Simplenote/PasskeyTypeAliases.swift
@@ -1,0 +1,4 @@
+import AuthenticationServices
+
+typealias PresentationContext = ASAuthorizationControllerPresentationContextProviding
+typealias PublicKeyCredentialRegistration = ASAuthorizationPlatformPublicKeyCredentialRegistration

--- a/Simplenote/Preferences.storyboard
+++ b/Simplenote/Preferences.storyboard
@@ -88,10 +88,10 @@
                                                 <buttonCell key="cell" type="push" title="Add Passkey Sign in" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="naG-xr-o4o">
                                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                                     <font key="font" metaFont="system"/>
-                                                    <connections>
-                                                        <action selector="addPasskeyWasPressed:" target="ReV-pG-fyt" id="hCX-tN-f8q"/>
-                                                    </connections>
                                                 </buttonCell>
+                                                <connections>
+                                                    <action selector="passkeyRegistrationTapped:" target="ReV-pG-fyt" id="PIW-D1-m6F"/>
+                                                </connections>
                                             </button>
                                         </subviews>
                                         <constraints>

--- a/Simplenote/Preferences.storyboard
+++ b/Simplenote/Preferences.storyboard
@@ -2,7 +2,7 @@
 <document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="22689"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="22690"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -47,7 +47,7 @@
                                     <customView translatesAutoresizingMaskIntoConstraints="NO" id="Yoe-6O-zlp" customClass="BackgroundView" customModule="Simplenote" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="472" width="546" height="89"/>
                                         <subviews>
-                                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="tMt-d6-VMG">
+                                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="tMt-d6-VMG">
                                                 <rect key="frame" x="65" y="54" width="58" height="16"/>
                                                 <textFieldCell key="cell" lineBreakMode="clipping" title="Account:" id="0Yp-Xd-4cJ">
                                                     <font key="font" metaFont="system"/>
@@ -55,7 +55,7 @@
                                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                 </textFieldCell>
                                             </textField>
-                                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="ZUw-Xc-VSa">
+                                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="ZUw-Xc-VSa">
                                                 <rect key="frame" x="176" y="54" width="134" height="16"/>
                                                 <textFieldCell key="cell" lineBreakMode="clipping" title="example@email.com" id="eCT-aj-qs9">
                                                     <font key="font" metaFont="systemSemibold" size="13"/>
@@ -64,7 +64,7 @@
                                                 </textFieldCell>
                                             </textField>
                                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Fm6-Vq-xaX">
-                                                <rect key="frame" x="248" y="13" width="127" height="32"/>
+                                                <rect key="frame" x="398" y="13" width="127" height="32"/>
                                                 <buttonCell key="cell" type="push" title="Delete Account" bezelStyle="rounded" imagePosition="overlaps" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="bct-IO-zCI">
                                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                                     <font key="font" metaFont="system"/>
@@ -74,7 +74,7 @@
                                                 </connections>
                                             </button>
                                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="9Qf-fu-o41">
-                                                <rect key="frame" x="171" y="13" width="83" height="32"/>
+                                                <rect key="frame" x="321" y="13" width="83" height="32"/>
                                                 <buttonCell key="cell" type="push" title="Log Out" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="R4S-Cb-oxw">
                                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                                     <font key="font" metaFont="system"/>
@@ -83,23 +83,35 @@
                                                     <action selector="logOutWasPressed:" target="ReV-pG-fyt" id="gcm-qW-zMx"/>
                                                 </connections>
                                             </button>
+                                            <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="ohS-2g-IUa">
+                                                <rect key="frame" x="171" y="13" width="156" height="32"/>
+                                                <buttonCell key="cell" type="push" title="Add Passkey Sign in" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="naG-xr-o4o">
+                                                    <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                                    <font key="font" metaFont="system"/>
+                                                    <connections>
+                                                        <action selector="addPasskeyWasPressed:" target="ReV-pG-fyt" id="hCX-tN-f8q"/>
+                                                    </connections>
+                                                </buttonCell>
+                                            </button>
                                         </subviews>
                                         <constraints>
+                                            <constraint firstItem="9Qf-fu-o41" firstAttribute="leading" secondItem="ohS-2g-IUa" secondAttribute="trailing" constant="8" id="1dj-kY-DHg"/>
                                             <constraint firstItem="Fm6-Vq-xaX" firstAttribute="leading" secondItem="9Qf-fu-o41" secondAttribute="trailing" constant="8" id="5sD-bG-wTb"/>
                                             <constraint firstItem="ZUw-Xc-VSa" firstAttribute="centerY" secondItem="tMt-d6-VMG" secondAttribute="centerY" id="71E-Ag-0a7"/>
+                                            <constraint firstItem="ohS-2g-IUa" firstAttribute="centerY" secondItem="9Qf-fu-o41" secondAttribute="centerY" id="CdU-Sk-6Gz"/>
                                             <constraint firstAttribute="trailing" secondItem="ZUw-Xc-VSa" secondAttribute="leading" constant="368" id="S5S-cQ-ow3"/>
                                             <constraint firstAttribute="bottom" secondItem="9Qf-fu-o41" secondAttribute="bottom" constant="20" id="WtW-Dh-K1j"/>
                                             <constraint firstItem="Fm6-Vq-xaX" firstAttribute="centerY" secondItem="9Qf-fu-o41" secondAttribute="centerY" id="azI-i0-l2D"/>
+                                            <constraint firstItem="ohS-2g-IUa" firstAttribute="leading" secondItem="ZUw-Xc-VSa" secondAttribute="leading" id="cav-qt-Zpc"/>
                                             <constraint firstItem="9Qf-fu-o41" firstAttribute="top" secondItem="ZUw-Xc-VSa" secondAttribute="bottom" constant="14" id="iEg-9b-O5R"/>
                                             <constraint firstItem="tMt-d6-VMG" firstAttribute="top" secondItem="Yoe-6O-zlp" secondAttribute="top" constant="19" id="mt6-WN-Irf"/>
-                                            <constraint firstItem="9Qf-fu-o41" firstAttribute="leading" secondItem="ZUw-Xc-VSa" secondAttribute="leading" id="qLF-3f-5nJ"/>
                                             <constraint firstItem="tMt-d6-VMG" firstAttribute="trailing" secondItem="Yoe-6O-zlp" secondAttribute="leading" constant="121" id="wsP-Pm-OmA"/>
                                         </constraints>
                                     </customView>
                                     <customView translatesAutoresizingMaskIntoConstraints="NO" id="h39-Ga-h8l" customClass="BackgroundView" customModule="Simplenote" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="294" width="546" height="178"/>
                                         <subviews>
-                                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="J0b-De-aS5">
+                                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="J0b-De-aS5">
                                                 <rect key="frame" x="29" y="139" width="101" height="16"/>
                                                 <textFieldCell key="cell" lineBreakMode="clipping" title="Note sort order:" id="OyD-gF-dLa">
                                                     <font key="font" metaFont="system"/>
@@ -107,7 +119,7 @@
                                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                 </textFieldCell>
                                             </textField>
-                                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="8Oy-Hc-uVh">
+                                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="8Oy-Hc-uVh">
                                                 <rect key="frame" x="26" y="108" width="104" height="16"/>
                                                 <textFieldCell key="cell" lineBreakMode="clipping" title="Note line length:" id="vRW-QM-Yad">
                                                     <font key="font" metaFont="system"/>
@@ -201,7 +213,7 @@
                                     <customView translatesAutoresizingMaskIntoConstraints="NO" id="cxa-pV-CY8" customClass="BackgroundView" customModule="Simplenote" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="233" width="546" height="61"/>
                                         <subviews>
-                                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="gWg-1w-MAM">
+                                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="gWg-1w-MAM">
                                                 <rect key="frame" x="80" y="22" width="50" height="16"/>
                                                 <textFieldCell key="cell" lineBreakMode="clipping" title="Theme:" id="lDZ-Om-Wt6">
                                                     <font key="font" metaFont="system"/>
@@ -233,7 +245,7 @@
                                     <customView translatesAutoresizingMaskIntoConstraints="NO" id="UpJ-Bj-W5p" customClass="BackgroundView" customModule="Simplenote" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="146" width="546" height="87"/>
                                         <subviews>
-                                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="oZS-M5-Cee">
+                                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="oZS-M5-Cee">
                                                 <rect key="frame" x="69" y="36" width="61" height="16"/>
                                                 <textFieldCell key="cell" lineBreakMode="clipping" title="Text size:" id="qX0-g4-Fiv">
                                                     <font key="font" metaFont="system"/>
@@ -241,7 +253,7 @@
                                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                 </textFieldCell>
                                             </textField>
-                                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="mc3-70-5SW">
+                                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="mc3-70-5SW">
                                                 <rect key="frame" x="179" y="42" width="13" height="16"/>
                                                 <textFieldCell key="cell" lineBreakMode="clipping" title="A" id="yUN-kt-ceE">
                                                     <font key="font" metaFont="system"/>
@@ -249,7 +261,7 @@
                                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                 </textFieldCell>
                                             </textField>
-                                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="B5Y-HO-nR1">
+                                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="B5Y-HO-nR1">
                                                 <rect key="frame" x="529" y="42" width="17" height="24"/>
                                                 <textFieldCell key="cell" lineBreakMode="clipping" title="A" id="qhF-d4-AXA">
                                                     <font key="font" metaFont="system" size="20"/>
@@ -291,7 +303,7 @@
                                                     <action selector="shareAnalyticsWasPressed:" target="ReV-pG-fyt" id="BDN-sO-KVZ"/>
                                                 </connections>
                                             </button>
-                                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="I91-g0-Rn6">
+                                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="I91-g0-Rn6">
                                                 <rect key="frame" x="176" y="36" width="372" height="64"/>
                                                 <textFieldCell key="cell" allowsEditingTextAttributes="YES" id="v2B-Xp-znc">
                                                     <font key="font" metaFont="system"/>
@@ -300,7 +312,7 @@
                                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                 </textFieldCell>
                                             </textField>
-                                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="c5l-53-yQU">
+                                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="c5l-53-yQU">
                                                 <rect key="frame" x="176" y="20" width="173" height="16"/>
                                                 <textFieldCell key="cell" lineBreakMode="clipping" title="About Analytics and Privacy" allowsEditingTextAttributes="YES" id="21L-rN-gfn">
                                                     <font key="font" metaFont="system"/>

--- a/Simplenote/PreferencesViewController.swift
+++ b/Simplenote/PreferencesViewController.swift
@@ -348,7 +348,11 @@ extension PreferencesViewController {
             }
 
             Task { @MainActor in
+                let activityIndicator = BlockingActivityIndicator.showIndicator(in: view)
+
                 await attemptPasskeyRegistration(for: email, password: passwordField.stringValue)
+
+                activityIndicator.stopAnimation()
             }
         }
     }

--- a/Simplenote/PreferencesViewController.swift
+++ b/Simplenote/PreferencesViewController.swift
@@ -1,4 +1,5 @@
 import Cocoa
+import AuthenticationServices
 import CoreSpotlight
 
 class PreferencesViewController: NSViewController {
@@ -222,6 +223,10 @@ class PreferencesViewController: NSViewController {
 
     }
 
+    @IBAction func passkeyRegistrationTapped(_ sender: Any) {
+        presentPasskeyRegistrationAlert()
+    }
+
     @IBAction private func deleteAccountWasPressed(_ sender: Any) {
         guard let user = simperium.user,
         let window = view.window else {
@@ -324,6 +329,59 @@ class PreferencesViewController: NSViewController {
     }
 }
 
+// MARK: - Passkeys
+//
+extension PreferencesViewController {
+    private func presentPasskeyRegistrationAlert() {
+        let alert = NSAlert(messageText: PasskeyAuthentication.alertTitle, informativeText: PasskeyAuthentication.message)
+        let passwordField = NSSecureTextField(frame: NSRect(x: 0, y: 0, width: 200, height: 24))
+        alert.accessoryView = passwordField
+        alert.addButton(withTitle: PasskeyAuthentication.submit)
+        alert.addButton(withTitle: PasskeyAuthentication.cancel)
+
+        let modalResult = alert.runModal()
+
+        if modalResult == .alertFirstButtonReturn {
+            guard let email = simperium.user?.email else {
+                presentPasskeyRegistrationAlert(succeeded: false)
+                return
+            }
+
+            Task { @MainActor in
+                await attemptPasskeyRegistration(for: email, password: passwordField.stringValue)
+            }
+        }
+    }
+
+    private func attemptPasskeyRegistration(for email: String, password: String) async {
+        do {
+            let registrator = PasskeyRegistrator()
+            try await registrator.attemptPasskeyRegistration(for: email, password: password, presentationContext: self)
+            presentPasskeyRegistrationAlert(succeeded: true)
+        } catch {
+            NSLog("[PasskeyRegistration] Could not register passkey: %@", error.localizedDescription)
+            presentPasskeyRegistrationAlert(succeeded: false)
+        }
+    }
+
+    private func presentPasskeyRegistrationAlert(succeeded: Bool) {
+        DispatchQueue.main.async {
+            let title = succeeded ? PasskeyAuthentication.successTitle : PasskeyAuthentication.failureTitle
+            let message = succeeded ? PasskeyAuthentication.successMessage : PasskeyAuthentication.failureMessage
+            let alert = NSAlert(messageText: title, informativeText: message)
+            alert.addButton(withTitle: PasskeyAuthentication.okay)
+            alert.runModal()
+        }
+    }
+}
+
+extension PreferencesViewController: ASAuthorizationControllerPresentationContextProviding {
+    public func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
+        view.window!
+    }
+
+}
+
 private struct Strings {
     static let account = NSLocalizedString("Account:", comment: "Account label")
     static let noteSortOrder = NSLocalizedString("Note sort order:", comment: "Note Sort Order label")
@@ -355,6 +413,18 @@ private struct Strings {
 
         return link
     }
+}
+
+private struct PasskeyAuthentication {
+    static let alertTitle = NSLocalizedString("Passkey Setup", comment: "Alert title for setting up passkeys")
+    static let message = NSLocalizedString("To add passkeys you must enter your password", comment: "Message prompting user for password to create passkey")
+    static let submit = NSLocalizedString("Submit", comment: "Submit button title")
+    static let cancel = NSLocalizedString("Cancel", comment: "Cancel button title")
+    static let failureTitle = NSLocalizedString("Passkey Registration Failed", comment: "Title for alert when passkey registration fails")
+    static let failureMessage = NSLocalizedString("Could not register passkey.  Please try again later", comment: "Message for when passkey registration fails")
+    static let okay = NSLocalizedString("Okay", comment: "confirm button title")
+    static let successTitle = NSLocalizedString("Success!!", comment: "Title for alert when passkey registration succeeds")
+    static let successMessage = NSLocalizedString("Passkey Registration Succeeded", comment: "message for alert when passkey registration succeeds")
 }
 
 // MARK: - Notifications

--- a/Simplenote/PreferencesViewController.swift
+++ b/Simplenote/PreferencesViewController.swift
@@ -333,27 +333,23 @@ class PreferencesViewController: NSViewController {
 //
 extension PreferencesViewController {
     private func presentPasskeyRegistrationAlert() {
-        let alert = NSAlert(messageText: PasskeyAuthentication.alertTitle, informativeText: PasskeyAuthentication.message)
-        let passwordField = NSSecureTextField(frame: NSRect(x: 0, y: 0, width: 200, height: 24))
-        alert.accessoryView = passwordField
-        alert.addButton(withTitle: PasskeyAuthentication.submit)
-        alert.addButton(withTitle: PasskeyAuthentication.cancel)
+        NSAlert.presentPasskeyRegistrationAlert { password in
+            self.lockViewAndAttemptRegistration(with: password)
+        }
+    }
 
-        let modalResult = alert.runModal()
+    private func lockViewAndAttemptRegistration(with password: String) {
+        guard let email = simperium.user?.email else {
+            presentPasskeyRegistrationAlert(succeeded: false)
+            return
+        }
 
-        if modalResult == .alertFirstButtonReturn {
-            guard let email = simperium.user?.email else {
-                presentPasskeyRegistrationAlert(succeeded: false)
-                return
-            }
+        Task { @MainActor in
+            let activityIndicator = BlockingActivityIndicator.showIndicator(in: view)
 
-            Task { @MainActor in
-                let activityIndicator = BlockingActivityIndicator.showIndicator(in: view)
+            await attemptPasskeyRegistration(for: email, password: password)
 
-                await attemptPasskeyRegistration(for: email, password: passwordField.stringValue)
-
-                activityIndicator.stopAnimation()
-            }
+            activityIndicator.stopAnimation()
         }
     }
 
@@ -370,11 +366,7 @@ extension PreferencesViewController {
 
     private func presentPasskeyRegistrationAlert(succeeded: Bool) {
         DispatchQueue.main.async {
-            let title = succeeded ? PasskeyAuthentication.successTitle : PasskeyAuthentication.failureTitle
-            let message = succeeded ? PasskeyAuthentication.successMessage : PasskeyAuthentication.failureMessage
-            let alert = NSAlert(messageText: title, informativeText: message)
-            alert.addButton(withTitle: PasskeyAuthentication.okay)
-            alert.runModal()
+            NSAlert.presentPasskeyResolvedAlert(succeeded: succeeded)
         }
     }
 }
@@ -417,18 +409,6 @@ private struct Strings {
 
         return link
     }
-}
-
-private struct PasskeyAuthentication {
-    static let alertTitle = NSLocalizedString("Passkey Setup", comment: "Alert title for setting up passkeys")
-    static let message = NSLocalizedString("To add passkeys you must enter your password", comment: "Message prompting user for password to create passkey")
-    static let submit = NSLocalizedString("Submit", comment: "Submit button title")
-    static let cancel = NSLocalizedString("Cancel", comment: "Cancel button title")
-    static let failureTitle = NSLocalizedString("Passkey Registration Failed", comment: "Title for alert when passkey registration fails")
-    static let failureMessage = NSLocalizedString("Could not register passkey.  Please try again later", comment: "Message for when passkey registration fails")
-    static let okay = NSLocalizedString("Okay", comment: "confirm button title")
-    static let successTitle = NSLocalizedString("Success!!", comment: "Title for alert when passkey registration succeeds")
-    static let successMessage = NSLocalizedString("Passkey Registration Succeeded", comment: "message for alert when passkey registration succeeds")
 }
 
 // MARK: - Notifications

--- a/Simplenote/PreferencesViewController.swift
+++ b/Simplenote/PreferencesViewController.swift
@@ -188,6 +188,10 @@ class PreferencesViewController: NSViewController {
 
     // MARK: Account Settings
 
+    @IBAction func addPasskeyWasPressed(_ sender: Any) {
+        
+    }
+
     @IBAction private func logOutWasPressed(_ sender: Any) {
         let appDelegate = SimplenoteAppDelegate.shared()
 

--- a/Simplenote/SimplenoteConstants.swift
+++ b/Simplenote/SimplenoteConstants.swift
@@ -37,4 +37,10 @@ class SimplenoteConstants: NSObject {
     static let simplenoteVerificationURL    = googleAppEngineBaseURL.appendingPathComponent("/account/verify-email/")
     static let simplenoteRequestSignupURL   = googleAppEngineBaseURL.appendingPathComponent("/account/request-signup")
     static let accountDeletionURL           = googleAppEngineBaseURL.appendingPathComponent("/account/request-delete/")
+
+    /// Passkey: Endpoints
+    ///
+    static let currentPasskeyBaseURL = URL(string: "https://passkey-dev-dot-simple-note-hrd.appspot.com")!
+    static let passkeyCredentialCreationURL = currentPasskeyBaseURL.appendingPathComponent("/api2/login")
+    static let passkeyRegistrationURL = currentPasskeyBaseURL.appendingPathComponent("/auth/add-credential")
 }

--- a/Simplenote/SimplenoteDebug.entitlements
+++ b/Simplenote/SimplenoteDebug.entitlements
@@ -5,6 +5,7 @@
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>applinks:app.simplenote.com</string>
+		<string>webcredentials:passkey-dev-dot-simple-note-hrd.appspot.com</string>
 	</array>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>

--- a/Simplenote/String+Simplenote.swift
+++ b/Simplenote/String+Simplenote.swift
@@ -98,6 +98,14 @@ extension String {
 
         return try? JSONSerialization.jsonObject(with: data)
     }
+
+    func toBase64url() -> String {
+        let base64url = self
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+        return base64url
+    }
 }
 
 // MARK: - Searching for the first / last characters

--- a/SimplenoteTests/PasskeyRemote.swift
+++ b/SimplenoteTests/PasskeyRemote.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+class PasskeyRemote: Remote {
+    private func passkeyCredentialCreationRequest(withEmail email: String, password: String) -> URLRequest {
+        let params = [
+            "email": email.lowercased(),
+            "password": password,
+            "webauthn": "true"
+        ] as [String: Any]
+
+        let boundary = "Boundary-\(UUID().uuidString)"
+        var request = URLRequest(url: SimplenoteConstants.passkeyCredentialCreationURL)
+        request.addValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+
+        request.httpMethod = RemoteConstants.Method.POST
+        request.httpBody = passkeyRegistrationBody(with: boundary, parameters: params)
+
+        return request
+    }
+
+    private func passkeyRegistrationBody(with boundary: String, parameters: [String: Any]) -> Data {
+        var body = String()
+
+        for param in parameters {
+            let paramName = param.key
+            body += "--\(boundary)\r\n"
+            body += "Content-Disposition:form-data; name=\"\(paramName)\""
+            let paramValue = param.value as! String
+            body += "\r\n\r\n\(paramValue)\r\n"
+        }
+
+        body += "--\(boundary)--\r\n"
+
+        return Data(body.utf8)
+    }
+
+    func requestChallengeResponseToCreatePasskey(forEmail email: String, password: String) async throws -> PasskeyRegistrationChallenge {
+        let request = passkeyCredentialCreationRequest(withEmail: email, password: password)
+        let data = try await performDataTask(with: request)
+
+        return try JSONDecoder().decode(PasskeyRegistrationChallenge.self, from: data)
+    }
+
+    private func requestForPasskeyCredentialRegistration(withData data: Data) -> URLRequest {
+        var urlRequest = URLRequest(url: SimplenoteConstants.passkeyRegistrationURL)
+        urlRequest.httpMethod = RemoteConstants.Method.POST
+        urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        urlRequest.httpBody = data
+
+        return urlRequest
+    }
+
+    func registerCredential(with response: PasskeyRegistrationResponse) async throws {
+        let data = try JSONEncoder().encode(response)
+        let request = requestForPasskeyCredentialRegistration(withData: data)
+        try await _ = performDataTask(with: request)
+    }
+}


### PR DESCRIPTION
### Fix
We are adding passkey support to SNMac!  This will come in a couple of stages, first in this PR we are adding the ability to register a passkey on your account.  Signing in with a passkey will come later.

With a signed in account, from the preferences view there is a new button "Add passkey sign in" tapping that will allow a user to authorize there account and create a new passkey in their iCloud Keychain.  Once added they should be able to use this passkey to sign into simplenote on Mac or iOS with the same passkey as long as that version of simplenote is updated with the passkey auth info.

### Test
1. Sign in to a simplenote account and open the preferences view
2. tap on the Add Passkey Sign in
3. Confirm that a blocking spinner appears while we fetch a challenge
4. If successful you should see an apple auth appear.  Dismiss it without verifying.  Confirm you see a failure alert and the spinner disappears
5. Tapp on the add passkey button again and this time when the apple auth appears continue to add a passkey.  When it is complete you should see a success message.  
6. Go to the passkey db and confirm your new passkey was added (ping me for a link if need be)

### Review
***(Required)*** Add instructions for reviewers.  For example:
> Only one developer is required to review these changes, but anyone can perform the review.

### Release
***(Required)*** Add a concise statement to `RELEASE-NOTES.txt` if the changes should be included in release notes. Include details about updating the notes in this section. For example:

> These changes do not require release notes.
