### PR TITLE
Passkeys: Passkey authentication

### DIFF
--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -295,6 +295,8 @@
 		BA7575E82C46FAF9009C08FC /* PasskeyAuthChallenge.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA7575E72C46FAF9009C08FC /* PasskeyAuthChallenge.swift */; };
 		BA7575EA2C46FB07009C08FC /* PasskeyAuthResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA7575E92C46FB07009C08FC /* PasskeyAuthResponse.swift */; };
 		BA7575EC2C46FB0B009C08FC /* PasskeyVerifyResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA7575EB2C46FB0B009C08FC /* PasskeyVerifyResponse.swift */; };
+		BA7575EE2C46FB30009C08FC /* PasskeyAuthenticator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA7575ED2C46FB30009C08FC /* PasskeyAuthenticator.swift */; };
+		BA7575F02C46FB80009C08FC /* Data+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA7575EF2C46FB80009C08FC /* Data+Simplenote.swift */; };
 		BA78AF712B5B2BC300DCF896 /* AutomatticTracks in Frameworks */ = {isa = PBXBuildFile; productRef = BA78AF702B5B2BC300DCF896 /* AutomatticTracks */; };
 		BA938CEE26AD055400BE5A1D /* AccountVerificationController+TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA938CED26AD055400BE5A1D /* AccountVerificationController+TestHelpers.swift */; };
 		BA94CB652C0E46CC00B34EA7 /* Uploader.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA94CB642C0E46CC00B34EA7 /* Uploader.swift */; };
@@ -789,6 +791,8 @@
 		BA7575E72C46FAF9009C08FC /* PasskeyAuthChallenge.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PasskeyAuthChallenge.swift; sourceTree = "<group>"; };
 		BA7575E92C46FB07009C08FC /* PasskeyAuthResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PasskeyAuthResponse.swift; sourceTree = "<group>"; };
 		BA7575EB2C46FB0B009C08FC /* PasskeyVerifyResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PasskeyVerifyResponse.swift; sourceTree = "<group>"; };
+		BA7575ED2C46FB30009C08FC /* PasskeyAuthenticator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PasskeyAuthenticator.swift; sourceTree = "<group>"; };
+		BA7575EF2C46FB80009C08FC /* Data+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+Simplenote.swift"; sourceTree = "<group>"; };
 		BA8CF21B2BFD20770087F33D /* Intents.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Intents.framework; path = System/Library/Frameworks/Intents.framework; sourceTree = SDKROOT; };
 		BA938CEB26ACFF4A00BE5A1D /* Remote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Remote.swift; sourceTree = "<group>"; };
 		BA938CED26AD055400BE5A1D /* AccountVerificationController+TestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AccountVerificationController+TestHelpers.swift"; sourceTree = "<group>"; };
@@ -1261,6 +1265,7 @@
 				BAFB544F26CCA7F1006E037C /* NSProgressIndicator+Simplenote.swift */,
 				BA2C65CA26FE996100FA84E1 /* NSButton+Extensions.swift */,
 				BA52005C2BC88397003F1B75 /* NSManagedObjectContext+Simplenote.swift */,
+				BA7575EF2C46FB80009C08FC /* Data+Simplenote.swift */,
 			);
 			name = Extensions;
 			sourceTree = "<group>";
@@ -1703,6 +1708,7 @@
 		BA6689622C45C51C009D4E84 /* Passkeys */ = {
 			isa = PBXGroup;
 			children = (
+				BA7575ED2C46FB30009C08FC /* PasskeyAuthenticator.swift */,
 				BA6689692C45C60E009D4E84 /* PasskeyRegistrator.swift */,
 				BA6689632C45C52B009D4E84 /* PasskeyRegistrationChallenge.swift */,
 				BA6689652C45C54B009D4E84 /* PasskeyRegistrationResponse.swift */,
@@ -2179,6 +2185,8 @@
 				B51AFE7725D36CDD00A196DF /* NSFont+Simplenote.swift in Sources */,
 				BA7575E62C45E269009C08FC /* BlockingActivityIndicator.swift in Sources */,
 				375D293D21E033D1007AB25A /* hash.c in Sources */,
+				BA7575F02C46FB80009C08FC /* Data+Simplenote.swift in Sources */,
+				BA7575EE2C46FB30009C08FC /* PasskeyAuthenticator.swift in Sources */,
 				B574CA74242D552100F8D02F /* TextViewInputHandler.swift in Sources */,
 				B5F807CD2481982B0048CBD7 /* Note+Simplenote.swift in Sources */,
 				A6C1E21525E010140076ADF7 /* SPApplication.swift in Sources */,

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -292,6 +292,9 @@
 		BA71EC242BC88FD000F42CB1 /* CSSearchable+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA52005A2BC878F1003F1B75 /* CSSearchable+Helpers.swift */; };
 		BA71EC252BC88FFC00F42CB1 /* NSManagedObjectContext+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA52005C2BC88397003F1B75 /* NSManagedObjectContext+Simplenote.swift */; };
 		BA7575E62C45E269009C08FC /* BlockingActivityIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA7575E52C45E269009C08FC /* BlockingActivityIndicator.swift */; };
+		BA7575E82C46FAF9009C08FC /* PasskeyAuthChallenge.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA7575E72C46FAF9009C08FC /* PasskeyAuthChallenge.swift */; };
+		BA7575EA2C46FB07009C08FC /* PasskeyAuthResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA7575E92C46FB07009C08FC /* PasskeyAuthResponse.swift */; };
+		BA7575EC2C46FB0B009C08FC /* PasskeyVerifyResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA7575EB2C46FB0B009C08FC /* PasskeyVerifyResponse.swift */; };
 		BA78AF712B5B2BC300DCF896 /* AutomatticTracks in Frameworks */ = {isa = PBXBuildFile; productRef = BA78AF702B5B2BC300DCF896 /* AutomatticTracks */; };
 		BA938CEE26AD055400BE5A1D /* AccountVerificationController+TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA938CED26AD055400BE5A1D /* AccountVerificationController+TestHelpers.swift */; };
 		BA94CB652C0E46CC00B34EA7 /* Uploader.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA94CB642C0E46CC00B34EA7 /* Uploader.swift */; };
@@ -783,6 +786,9 @@
 		BA6689692C45C60E009D4E84 /* PasskeyRegistrator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PasskeyRegistrator.swift; sourceTree = "<group>"; };
 		BA66896B2C45C64C009D4E84 /* PasskeyTypeAliases.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasskeyTypeAliases.swift; sourceTree = "<group>"; };
 		BA7575E52C45E269009C08FC /* BlockingActivityIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockingActivityIndicator.swift; sourceTree = "<group>"; };
+		BA7575E72C46FAF9009C08FC /* PasskeyAuthChallenge.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PasskeyAuthChallenge.swift; sourceTree = "<group>"; };
+		BA7575E92C46FB07009C08FC /* PasskeyAuthResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PasskeyAuthResponse.swift; sourceTree = "<group>"; };
+		BA7575EB2C46FB0B009C08FC /* PasskeyVerifyResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PasskeyVerifyResponse.swift; sourceTree = "<group>"; };
 		BA8CF21B2BFD20770087F33D /* Intents.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Intents.framework; path = System/Library/Frameworks/Intents.framework; sourceTree = SDKROOT; };
 		BA938CEB26ACFF4A00BE5A1D /* Remote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Remote.swift; sourceTree = "<group>"; };
 		BA938CED26AD055400BE5A1D /* AccountVerificationController+TestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AccountVerificationController+TestHelpers.swift"; sourceTree = "<group>"; };
@@ -1702,6 +1708,9 @@
 				BA6689652C45C54B009D4E84 /* PasskeyRegistrationResponse.swift */,
 				BA6689672C45C59E009D4E84 /* PasskeyError.swift */,
 				BA66896B2C45C64C009D4E84 /* PasskeyTypeAliases.swift */,
+				BA7575E72C46FAF9009C08FC /* PasskeyAuthChallenge.swift */,
+				BA7575E92C46FB07009C08FC /* PasskeyAuthResponse.swift */,
+				BA7575EB2C46FB0B009C08FC /* PasskeyVerifyResponse.swift */,
 			);
 			name = Passkeys;
 			sourceTree = "<group>";
@@ -2108,6 +2117,7 @@
 				B5E086292448B57200DEF476 /* HeaderTableCellView.swift in Sources */,
 				375D294721E033D1007AB25A /* version.c in Sources */,
 				466FFEA917CC10A800399652 /* SimplenoteAppDelegate.m in Sources */,
+				BA7575E82C46FAF9009C08FC /* PasskeyAuthChallenge.swift in Sources */,
 				B5D3FCCD201F906E00A813B7 /* StatusChecker.m in Sources */,
 				B52EE32825927D5100347F2B /* NoteListViewController.swift in Sources */,
 				B542FE4B25D42E7B00A3582D /* NoteContentHelper.swift in Sources */,
@@ -2218,6 +2228,7 @@
 				B5070E17245938D600715BCC /* NSUserInterfaceItemIdentifier+Simplenote.swift in Sources */,
 				BAAA71F32C07AB8E00244C01 /* IntentsConstants.swift in Sources */,
 				B5C6334A251E6E3200C8BF46 /* LinkTableCellView.swift in Sources */,
+				BA7575EA2C46FB07009C08FC /* PasskeyAuthResponse.swift in Sources */,
 				BAA0A88B26BA39150006260E /* Date+Simplenote.swift in Sources */,
 				B542FE4725D42E6D00A3582D /* SearchMapView.swift in Sources */,
 				B57CB875244DEBC300BA7969 /* Options.swift in Sources */,
@@ -2251,6 +2262,7 @@
 				B587D7E22C220765006645CF /* URLSessionProtocol.swift in Sources */,
 				B58117E325B9E5D200927E0C /* AccountVerificationController.swift in Sources */,
 				B5F5414925EFFC2200CAF52C /* SignupRemote.swift in Sources */,
+				BA7575EC2C46FB0B009C08FC /* PasskeyVerifyResponse.swift in Sources */,
 				B5EB3AD82458CDB50089858D /* ThemeOption.swift in Sources */,
 				BA6689682C45C59E009D4E84 /* PasskeyError.swift in Sources */,
 				B59848831BCDB95A005EFBBE /* SPTracker.m in Sources */,

--- a/Simplenote/AuthViewController+Swift.swift
+++ b/Simplenote/AuthViewController+Swift.swift
@@ -198,7 +198,13 @@ extension AuthViewController {
             self.setInterfaceEnabled(true)
         }
     }
-    
+
+    @objc
+    func performPasskeyAuthentication() {
+        //TODO: Login with Passkeys
+        print("# Logging in with passkeys!!!!")
+    }
+
     @objc
     func performLoginWithEmailRequest() {
         Task {

--- a/Simplenote/AuthViewController+Swift.swift
+++ b/Simplenote/AuthViewController+Swift.swift
@@ -1,4 +1,5 @@
 import Foundation
+import AuthenticationServices
 
 // MARK: - AuthViewController: Interface Initialization
 //
@@ -201,8 +202,20 @@ extension AuthViewController {
 
     @objc
     func performPasskeyAuthentication() {
-        //TODO: Login with Passkeys
-        print("# Logging in with passkeys!!!!")
+        startActionAnimation()
+        setInterfaceEnabled(false)
+
+        let passkeyAuthenticator = PasskeyAuthenticator()
+        Task { @MainActor in
+            do {
+                try await attemptPasskeyAuthentication(for: usernameText)
+            } catch {
+                passkeyAuthFailed(error)
+            }
+
+            stopActionAnimation()
+            setInterfaceEnabled(true)
+        }
     }
 
     @objc
@@ -332,6 +345,30 @@ extension AuthViewController {
     }
 }
 
+// MARK: - Passkeys
+//
+extension AuthViewController: ASAuthorizationControllerPresentationContextProviding {
+    public func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
+        view.window!
+    }
+
+    private func attemptPasskeyAuthentication(for email: String) async throws {
+        let passkeyAuthenticator = PasskeyAuthenticator()
+        let verify = try await passkeyAuthenticator.attemptPasskeyAuth(for: email, in: self)
+        authenticator.authenticate(withUsername: verify.username, token: verify.accessToken)
+    }
+
+    private func passkeyAuthFailed(_ error: any Error) {
+        presentPasskeyAuthError(error)
+    }
+
+    private func presentPasskeyAuthError(_ error: any Error) {
+        let alert = NSAlert(messageText: Localization.passkeyAuthFailureTitle, informativeText: error.localizedDescription)
+        alert.addButton(withTitle: Localization.cancelText)
+        alert.runModal()
+    }
+}
+
 
 // MARK: - Localization
 //
@@ -351,4 +388,5 @@ private enum Localization {
     static let unverifiedErrorMessage = NSLocalizedString("There was an preparing your verification email, please try again later", comment: "Request error alert message")
     static let verificationSentTitle = NSLocalizedString("Check your Email", comment: "Vefification sent alert title")
     static let verificationSentTemplate = NSLocalizedString("We’ve sent a verification email to %1$@. Please check your inbox and follow the instructions.", comment: "Confirmation that an email has been sent")
+    static let passkeyAuthFailureTitle = NSLocalizedString("Passkey Authentication Failed", comment: "Title for passkey authentication failure")
 }

--- a/Simplenote/AuthViewController.h
+++ b/Simplenote/AuthViewController.h
@@ -31,6 +31,7 @@
 
 - (void)pressedLogInWithPassword;
 - (void)pressedLoginWithMagicLink;
+- (void)pressedLoginWithPasskey;
 - (void)pressedSignUp;
 - (void)openForgotPasswordURL;
 

--- a/Simplenote/AuthViewController.m
+++ b/Simplenote/AuthViewController.m
@@ -159,8 +159,7 @@ static NSString *SPAuthSessionKey = @"SPAuthSessionKey";
         return;
     }
 
-    //TODO: Login with passkey
-    NSLog(@"# Logging in with passkeys!!");
+    [self performPasskeyAuthentication];
 }
 
 - (void)pressedSignUp {

--- a/Simplenote/AuthViewController.m
+++ b/Simplenote/AuthViewController.m
@@ -151,6 +151,18 @@ static NSString *SPAuthSessionKey = @"SPAuthSessionKey";
     [self performLoginWithEmailRequest];
 }
 
+- (void)pressedLoginWithPasskey {
+
+    [self clearAuthenticationError];
+
+    if (![self validateSignInWithPasskey]) {
+        return;
+    }
+
+    //TODO: Login with passkey
+    NSLog(@"# Logging in with passkeys!!");
+}
+
 - (void)pressedSignUp {
     [SPTracker trackUserSignedUp];
     [self clearAuthenticationError];
@@ -290,6 +302,11 @@ static NSString *SPAuthSessionKey = @"SPAuthSessionKey";
 }
 
 - (BOOL)validateSignInWithMagicLink {
+    return [self validateConnection] &&
+           [self validateUsername];
+}
+
+- (BOOL)validateSignInWithPasskey {
     return [self validateConnection] &&
            [self validateUsername];
 }

--- a/Simplenote/AuthenticationMode.swift
+++ b/Simplenote/AuthenticationMode.swift
@@ -107,6 +107,23 @@ extension AuthenticationMode {
                            isWordPressVisible: true)
     }
 
+    /// Auth Mode: Login is handled via Passkeys!
+    ///
+    @objc
+    static var loginWithPasskeys: AuthenticationMode {
+        AuthenticationMode(primaryActionText: PasskeyStrings.primaryAction,
+                           primaryActionAnimationText: PasskeyStrings.primaryAnimationText,
+                           primaryActionSelector: #selector(AuthViewController.pressedLoginWithPasskey),
+                           secondaryActionText: PasskeyStrings.secondaryAction,
+                           secondaryActionSelector: #selector(AuthViewController.switchToPasswordAuth),
+                           switchActionText: PasskeyStrings.switchAction,
+                           switchActionTip: PasskeyStrings.switchTip,
+                           switchTargetMode: { .signup },
+                           isPasswordVisible: false,
+                           isSecondaryActionVisible: true,
+                           isWordPressVisible: true)
+    }
+
     /// Auth Mode: SignUp
     ///
     @objc
@@ -118,7 +135,7 @@ extension AuthenticationMode {
                            secondaryActionSelector: nil,
                            switchActionText: SignupStrings.switchAction,
                            switchActionTip: SignupStrings.switchTip,
-                           switchTargetMode: { .loginWithMagicLink },
+                           switchTargetMode: { .loginWithPasskeys },
                            isPasswordVisible: false,
                            isSecondaryActionVisible: false,
                            isWordPressVisible: false)
@@ -149,4 +166,12 @@ private enum SignupStrings {
     static let primaryAnimationText = NSLocalizedString("Signing Up...", comment: "Title of button for logging in")
     static let switchAction         = NSLocalizedString("Log In", comment: "Title of button for logging in up")
     static let switchTip            = NSLocalizedString("Already have an account?", comment: "Link to sign in to an account")
+}
+
+private enum PasskeyStrings {
+    static let primaryAction        = NSLocalizedString("Log In With Passkeys", comment: "Login with Passkey action")
+    static let primaryAnimationText = NSLocalizedString("Requesting Passkey...", comment: "Title of button for logging in")
+    static let secondaryAction      = NSLocalizedString("Continue with Password", comment: "Continue with Password Action")
+    static let switchAction         = NSLocalizedString("Sign Up", comment: "Title of button for signing up")
+    static let switchTip            = NSLocalizedString("Need an account?", comment: "Link to create an account")
 }

--- a/Simplenote/Data+Simplenote.swift
+++ b/Simplenote/Data+Simplenote.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+extension Data {
+    /// Certain base 64 data values are encoded to be url safe.  For the webauthn authentication we will need to decode the url safe data so that we can read it locally.
+    ///
+    static func decodeUrlSafeBase64(_ value: String) throws -> Data {
+        var stringtoDecode: String = value.replacingOccurrences(of: "-", with: "+")
+        stringtoDecode = stringtoDecode.replacingOccurrences(of: "_", with: "/")
+        switch stringtoDecode.utf8.count % 4 {
+            case 2:
+                stringtoDecode += "=="
+            case 3:
+                stringtoDecode += "="
+            default:
+                break
+        }
+        guard let data = Data(base64Encoded: stringtoDecode, options: [.ignoreUnknownCharacters]) else {
+            throw NSError(domain: "decodeUrlSafeBase64", code: 1,
+                        userInfo: [NSLocalizedDescriptionKey: "Can't decode base64 string"])
+        }
+        return data
+    }
+}

--- a/Simplenote/PasskeyAuthChallenge.swift
+++ b/Simplenote/PasskeyAuthChallenge.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+struct PasskeyAuthChallenge: Decodable {
+    let relayingParty: String
+    let challenge: String
+
+    enum CodingKeys: String, CodingKey {
+        case relayingParty = "rpId"
+        case challenge
+    }
+}

--- a/Simplenote/PasskeyAuthResponse.swift
+++ b/Simplenote/PasskeyAuthResponse.swift
@@ -1,0 +1,22 @@
+import Foundation
+import AuthenticationServices
+
+struct PasskeyAuthResponse: Codable {
+    let id: String
+    let rawId: String
+    let response: Response
+    var type: String = "public-key"
+
+    init(from credential: ASAuthorizationPlatformPublicKeyCredentialAssertion) {
+        self.id = credential.credentialID.base64EncodedString().toBase64url()
+        self.rawId = credential.credentialID.base64EncodedString().toBase64url()
+        self.response = PasskeyAuthResponse.Response(clientDataJSON: credential.rawClientDataJSON.base64EncodedString(), authenticatorData: credential.rawAuthenticatorData.base64EncodedString(), signature: credential.signature.base64EncodedString(), userHandle: credential.userID.base64EncodedString())
+    }
+
+    struct Response: Codable {
+        let clientDataJSON: String
+        let authenticatorData: String
+        let signature: String
+        let userHandle: String
+    }
+}

--- a/Simplenote/PasskeyAuthenticator.swift
+++ b/Simplenote/PasskeyAuthenticator.swift
@@ -1,0 +1,77 @@
+import Foundation
+import AuthenticationServices
+
+class PasskeyAuthControllerDelegate: NSObject, ASAuthorizationControllerDelegate {
+
+    var onCompletion: ((Result<PasskeyAuthResponse, Error>) -> Void)?
+
+    public func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: any Error) {
+        onCompletion?(.failure(error))
+    }
+
+    public func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
+        guard let credential = authorization.credential as? ASAuthorizationPlatformPublicKeyCredentialAssertion else {
+            onCompletion?(.failure(PasskeyError.authFailed))
+            return
+        }
+
+        let response = PasskeyAuthResponse(from: credential)
+        onCompletion?(.success(response))
+    }
+}
+
+class PasskeyAuthenticator: NSObject {
+    private let passkeyRemote: PasskeyRemote
+    private let internalAuthControllerDelegate: PasskeyAuthControllerDelegate
+
+    init(passkeyRemote: PasskeyRemote = PasskeyRemote(), authControllerDelegate: PasskeyAuthControllerDelegate = .init()) {
+        self.passkeyRemote = passkeyRemote
+        self.internalAuthControllerDelegate = authControllerDelegate
+    }
+
+    func attemptPasskeyAuth(for email: String, in presentationContext: PresentationContext) async throws -> PasskeyVerifyResponse {
+        let challenge = try await passkeyRemote.passkeyAuthChallenge(for: email)
+
+        let challengeData = try Data.decodeUrlSafeBase64(challenge.challenge)
+        let provider = ASAuthorizationPlatformPublicKeyCredentialProvider(relyingPartyIdentifier: challenge.relayingParty)
+        let request = provider.createCredentialAssertionRequest(challenge: challengeData)
+
+        let controller = ASAuthorizationController(authorizationRequests: [request])
+        controller.delegate = internalAuthControllerDelegate
+        controller.presentationContextProvider = presentationContext
+
+        return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<PasskeyVerifyResponse, any Error>) in
+            internalAuthControllerDelegate.onCompletion = { [weak self] result in
+                guard let self else {
+                    continuation.resume(throwing: PasskeyError.authFailed)
+                    return
+                }
+
+                switch result {
+                case .success(let response):
+                    Task {
+                        do {
+                            let verify = try await self.performPasskeyAuthentication(with: response)
+                            continuation.resume(returning: verify)
+                        } catch {
+                            continuation.resume(throwing: error)
+                        }
+                    }
+
+                case .failure(let error):
+                    continuation.resume(throwing: error)
+                }
+            }
+
+            controller.performRequests()
+        }
+    }
+
+    private func performPasskeyAuthentication(with response: PasskeyAuthResponse) async throws -> PasskeyVerifyResponse {
+        guard let response = try? await passkeyRemote.verifyPasskeyLogin(with: response) else {
+            throw PasskeyError.authFailed
+        }
+
+        return response
+    }
+}

--- a/Simplenote/PasskeyTypeAliases.swift
+++ b/Simplenote/PasskeyTypeAliases.swift
@@ -2,3 +2,4 @@ import AuthenticationServices
 
 typealias PresentationContext = ASAuthorizationControllerPresentationContextProviding
 typealias PublicKeyCredentialRegistration = ASAuthorizationPlatformPublicKeyCredentialRegistration
+typealias PublicKeyCredentialAssertion = ASAuthorizationPlatformPublicKeyCredentialAssertion

--- a/Simplenote/PasskeyVerifyResponse.swift
+++ b/Simplenote/PasskeyVerifyResponse.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+struct PasskeyVerifyResponse: Decodable {
+    let username: String
+    let accessToken: String
+    let verified: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case username
+        case accessToken = "access_token"
+        case verified
+    }
+}

--- a/Simplenote/SimplenoteConstants.swift
+++ b/Simplenote/SimplenoteConstants.swift
@@ -43,4 +43,6 @@ class SimplenoteConstants: NSObject {
     static let currentPasskeyBaseURL = URL(string: "https://passkey-dev-dot-simple-note-hrd.appspot.com")!
     static let passkeyCredentialCreationURL = currentPasskeyBaseURL.appendingPathComponent("/api2/login")
     static let passkeyRegistrationURL = currentPasskeyBaseURL.appendingPathComponent("/auth/add-credential")
+    static let passkeyAuthChallengeURL = currentPasskeyBaseURL.appendingPathComponent("/auth/prepare-auth-challenge")
+    static let verifyPasskeyAuthChallengeURL = currentPasskeyBaseURL.appendingPathComponent("/auth/verify-login-credential")
 }

--- a/SimplenoteTests/PasskeyRemote.swift
+++ b/SimplenoteTests/PasskeyRemote.swift
@@ -56,4 +56,46 @@ class PasskeyRemote: Remote {
         let request = requestForPasskeyCredentialRegistration(withData: data)
         try await _ = performDataTask(with: request)
     }
+
+    private func passkeyAuthChallengeRequest(forEmail email: String) -> URLRequest {
+        var urlRequest = URLRequest(url: SimplenoteConstants.passkeyAuthChallengeURL)
+        urlRequest.httpMethod = RemoteConstants.Method.POST
+        urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        let body = [
+            "email": email.lowercased()
+        ]
+        let json = try? JSONEncoder().encode(body)
+
+        urlRequest.httpBody = json
+
+        return urlRequest
+    }
+
+    func passkeyAuthChallenge(for email: String) async throws -> PasskeyAuthChallenge {
+        let request = passkeyAuthChallengeRequest(forEmail: email)
+        let data = try await performDataTask(with: request)
+
+        return try JSONDecoder().decode(PasskeyAuthChallenge.self, from: data)
+    }
+
+    private func verifyPassKeyRequest(with data: Data) -> URLRequest {
+        var urlRequest = URLRequest(url: SimplenoteConstants.verifyPasskeyAuthChallengeURL)
+        urlRequest.httpMethod = RemoteConstants.Method.POST
+        urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        urlRequest.httpBody = data
+
+        return urlRequest
+    }
+
+    func verifyPasskeyLogin(with response: PasskeyAuthResponse) async throws -> PasskeyVerifyResponse {
+        guard let data = try? JSONEncoder().encode(response) else {
+            throw PasskeyError.authFailed
+        }
+
+        let request = verifyPassKeyRequest(with: data)
+        let verify = try await performDataTask(with: request)
+
+        return try JSONDecoder().decode(PasskeyVerifyResponse.self, from: verify)
+    }
 }


### PR DESCRIPTION
### Fix
So the next step in setting up passkeys on SN is authenticating with passkeys on Mac.  So in this PR I have done that.

Note that because we are reworking the auth UI, I have decided to take over the UI for `login with email` that was recently added and reuse it for my purposes.  That is a temporary change since we are using a feature branch and it should be redone to work in the new UI before merging into trunk.

### Test
***(Required)*** List the steps to test the behavior.  For example:
1. Clean install Simplenote.  Click on Log in, enter your email and tap on Log in With Passkeys.  Confirm animations appear and the ui is blocked
2. If there are passkeys on your device for that email you should see apples auth ui.  Dismiss this without authenticating.  Confirm you see an alert modal saying auth failed (if you don't have a passkey for that account you will need to log in and create one, see PR #1190 for details)
3. Attempt the login again, this time verify the apple authentication when prompted.  Confirm the UI unlocks and that you are logged into your SN account.

### Review
***(Required)*** Add instructions for reviewers.  For example:
> Only one developer is required to review these changes, but anyone can perform the review.

### Release
***(Required)*** Add a concise statement to `RELEASE-NOTES.txt` if the changes should be included in release notes. Include details about updating the notes in this section. For example:

> These changes do not require release notes.
