### PR TITLE
Magic Links: Add SPNavigationController

### DIFF
--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -341,6 +341,7 @@
 		BAF1B0C32BC9B1C500B55F73 /* NoteWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAF1B0C12BC9B1C500B55F73 /* NoteWindow.swift */; };
 		BAF1B0C92BCEDFD400B55F73 /* NoteWindowControllersManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAF1B0C72BCDDA9600B55F73 /* NoteWindowControllersManager.swift */; };
 		BAF4E5DE2C49C08A009B891F /* SPNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAF4E5DD2C49C08A009B891F /* SPNavigationController.swift */; };
+		BAF4E5E02C49C17A009B891F /* NSViewController+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAF4E5DF2C49C17A009B891F /* NSViewController+Simplenote.swift */; };
 		BAFB545126CCA7F1006E037C /* NSProgressIndicator+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAFB544F26CCA7F1006E037C /* NSProgressIndicator+Simplenote.swift */; };
 		CD6BC8FB4B8661C30318208C /* Pods_Automattic_SimplenoteTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 22D95A169BF4BF7DEABC4021 /* Pods_Automattic_SimplenoteTests.framework */; };
 		F998F3EC22853C49008C2B59 /* CrashLogging.swift in Sources */ = {isa = PBXBuildFile; fileRef = F998F3EA22853C29008C2B59 /* CrashLogging.swift */; };
@@ -809,6 +810,7 @@
 		BAF1B0C12BC9B1C500B55F73 /* NoteWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteWindow.swift; sourceTree = "<group>"; };
 		BAF1B0C72BCDDA9600B55F73 /* NoteWindowControllersManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteWindowControllersManager.swift; sourceTree = "<group>"; };
 		BAF4E5DD2C49C08A009B891F /* SPNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPNavigationController.swift; sourceTree = "<group>"; };
+		BAF4E5DF2C49C17A009B891F /* NSViewController+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSViewController+Simplenote.swift"; sourceTree = "<group>"; };
 		BAF8D5DB26AE3BE800CA9383 /* markdown-light.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; path = "markdown-light.css"; sourceTree = "<group>"; };
 		BAFB544F26CCA7F1006E037C /* NSProgressIndicator+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSProgressIndicator+Simplenote.swift"; sourceTree = "<group>"; };
 		F998F3EA22853C29008C2B59 /* CrashLogging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashLogging.swift; sourceTree = "<group>"; };
@@ -1241,6 +1243,7 @@
 				BAFB544F26CCA7F1006E037C /* NSProgressIndicator+Simplenote.swift */,
 				BA2C65CA26FE996100FA84E1 /* NSButton+Extensions.swift */,
 				BA52005C2BC88397003F1B75 /* NSManagedObjectContext+Simplenote.swift */,
+				BAF4E5DF2C49C17A009B891F /* NSViewController+Simplenote.swift */,
 			);
 			name = Extensions;
 			sourceTree = "<group>";
@@ -2082,6 +2085,7 @@
 				B5E086292448B57200DEF476 /* HeaderTableCellView.swift in Sources */,
 				375D294721E033D1007AB25A /* version.c in Sources */,
 				466FFEA917CC10A800399652 /* SimplenoteAppDelegate.m in Sources */,
+				BAF4E5E02C49C17A009B891F /* NSViewController+Simplenote.swift in Sources */,
 				B5D3FCCD201F906E00A813B7 /* StatusChecker.m in Sources */,
 				B52EE32825927D5100347F2B /* NoteListViewController.swift in Sources */,
 				B542FE4B25D42E7B00A3582D /* NoteContentHelper.swift in Sources */,

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -340,6 +340,7 @@
 		BAE66CAA26AF647500398FF3 /* Remote.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA938CEB26ACFF4A00BE5A1D /* Remote.swift */; };
 		BAF1B0C32BC9B1C500B55F73 /* NoteWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAF1B0C12BC9B1C500B55F73 /* NoteWindow.swift */; };
 		BAF1B0C92BCEDFD400B55F73 /* NoteWindowControllersManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAF1B0C72BCDDA9600B55F73 /* NoteWindowControllersManager.swift */; };
+		BAF4E5DE2C49C08A009B891F /* SPNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAF4E5DD2C49C08A009B891F /* SPNavigationController.swift */; };
 		BAFB545126CCA7F1006E037C /* NSProgressIndicator+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAFB544F26CCA7F1006E037C /* NSProgressIndicator+Simplenote.swift */; };
 		CD6BC8FB4B8661C30318208C /* Pods_Automattic_SimplenoteTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 22D95A169BF4BF7DEABC4021 /* Pods_Automattic_SimplenoteTests.framework */; };
 		F998F3EC22853C49008C2B59 /* CrashLogging.swift in Sources */ = {isa = PBXBuildFile; fileRef = F998F3EA22853C29008C2B59 /* CrashLogging.swift */; };
@@ -807,6 +808,7 @@
 		BACA687A2C0A7634005409C1 /* KeychainPasswordItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainPasswordItem.swift; sourceTree = "<group>"; };
 		BAF1B0C12BC9B1C500B55F73 /* NoteWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteWindow.swift; sourceTree = "<group>"; };
 		BAF1B0C72BCDDA9600B55F73 /* NoteWindowControllersManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteWindowControllersManager.swift; sourceTree = "<group>"; };
+		BAF4E5DD2C49C08A009B891F /* SPNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPNavigationController.swift; sourceTree = "<group>"; };
 		BAF8D5DB26AE3BE800CA9383 /* markdown-light.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; path = "markdown-light.css"; sourceTree = "<group>"; };
 		BAFB544F26CCA7F1006E037C /* NSProgressIndicator+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSProgressIndicator+Simplenote.swift"; sourceTree = "<group>"; };
 		F998F3EA22853C29008C2B59 /* CrashLogging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashLogging.swift; sourceTree = "<group>"; };
@@ -1578,6 +1580,7 @@
 				B5C7DD42243E4A8E00BEE354 /* CollaborateViewController.xib */,
 				B5C7DD45243E51E200BEE354 /* PublishViewController.swift */,
 				B5C7DD48243E524000BEE354 /* PublishViewController.xib */,
+				BAF4E5DD2C49C08A009B891F /* SPNavigationController.swift */,
 			);
 			name = ViewControllers;
 			sourceTree = "<group>";
@@ -2237,6 +2240,7 @@
 				B5F5415525F0137100CAF52C /* MagicLinkAuthenticator.swift in Sources */,
 				B58A71BF258422CC00601641 /* NSBezierPath+Simplenote.swift in Sources */,
 				B587D7EE2C2217B1006645CF /* LoginRemoteProtocol.swift in Sources */,
+				BAF4E5DE2C49C08A009B891F /* SPNavigationController.swift in Sources */,
 				B5DD0F922476309000C8DD41 /* NoteTableCellView.swift in Sources */,
 				B503FF4924848D0B00066059 /* TagAttachmentCell.swift in Sources */,
 				466FFED417CC10A800399652 /* SPTableView.m in Sources */,

--- a/Simplenote/AuthViewController+Swift.swift
+++ b/Simplenote/AuthViewController+Swift.swift
@@ -164,6 +164,20 @@ extension AuthViewController {
         
         performSelector(onMainThread: secondaryActionSelector, with: nil, waitUntilDone: false)
     }
+
+    @IBAction
+    func switchAuthenticationMode(_ sender: Any) {
+        containingNavigationController?.push(nextViewController())
+    }
+
+    private func nextViewController() -> AuthViewController {
+        let nextMode = mode.nextMode()
+
+        let nextVC = AuthViewController()
+        nextVC.mode = nextMode
+
+        return nextVC
+    }
 }
 
 

--- a/Simplenote/AuthViewController+Swift.swift
+++ b/Simplenote/AuthViewController+Swift.swift
@@ -176,6 +176,7 @@ extension AuthViewController {
         let nextMode = mode.nextMode()
 
         let nextVC = AuthViewController()
+        nextVC.authenticator = authenticator
         nextVC.mode = nextMode
 
         return nextVC

--- a/Simplenote/AuthViewController+Swift.swift
+++ b/Simplenote/AuthViewController+Swift.swift
@@ -101,6 +101,8 @@ extension AuthViewController {
         passwordField.alphaValue                = mode.passwordFieldAlpha
         secondaryActionButton.alphaValue        = mode.secondaryActionFieldAlpha
         wordPressSSOButton.alphaValue           = mode.wordPressSSOFieldAlpha
+
+        switchAuthenticationView.isHidden                 = !mode.isSwitchVisible
     }
 
     /// Animates Visible / Invisible components, based on the specified state

--- a/Simplenote/AuthViewController.h
+++ b/Simplenote/AuthViewController.h
@@ -21,6 +21,7 @@
 @property (nonatomic, strong) IBOutlet NSButton                     *switchActionButton;
 @property (nonatomic, strong) IBOutlet NSView                       *wordPressSSOContainerView;
 @property (nonatomic, strong) IBOutlet NSButton                     *wordPressSSOButton;
+@property (weak) IBOutlet NSView *switchAuthenticationView;
 
 @property (nonatomic, strong) IBOutlet NSLayoutConstraint           *passwordFieldHeightConstraint;
 @property (nonatomic, strong) IBOutlet NSLayoutConstraint           *secondaryActionHeightConstraint;

--- a/Simplenote/AuthViewController.m
+++ b/Simplenote/AuthViewController.m
@@ -65,10 +65,6 @@ static NSString *SPAuthSessionKey = @"SPAuthSessionKey";
     [[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString:forgotPasswordURL]];
 }
 
-- (IBAction)switchAuthenticationMode:(id)sender {
-    self.mode = [self.mode nextMode];
-}
-
 
 #pragma mark - Dynamic Properties
 

--- a/Simplenote/AuthViewController.xib
+++ b/Simplenote/AuthViewController.xib
@@ -136,7 +136,7 @@
                                         <constraint firstAttribute="height" constant="20" id="3pI-cn-CI2"/>
                                     </constraints>
                                     <connections>
-                                        <action selector="switchAuthenticationMode:" target="-2" id="5M2-AR-yd6"/>
+                                        <action selector="switchAuthenticationMode:" target="-2" id="RHe-NY-xff"/>
                                     </connections>
                                 </button>
                             </subviews>

--- a/Simplenote/AuthViewController.xib
+++ b/Simplenote/AuthViewController.xib
@@ -18,6 +18,7 @@
                 <outlet property="secondaryActionHeightConstraint" destination="HrL-ss-QSd" id="Vg3-A9-yCH"/>
                 <outlet property="stackView" destination="PWa-EY-51O" id="jUJ-sH-HgC"/>
                 <outlet property="switchActionButton" destination="5np-Xn-oop" id="KYi-sy-yoJ"/>
+                <outlet property="switchAuthenticationView" destination="mRM-75-7tv" id="Yij-Ld-A8r"/>
                 <outlet property="switchTipField" destination="0yP-IQ-Unz" id="jvk-lr-cHO"/>
                 <outlet property="usernameField" destination="Fco-3r-2Ys" id="qFA-HM-uFa"/>
                 <outlet property="view" destination="kU7-kg-wG3" id="WH8-Qa-i4c"/>

--- a/Simplenote/AuthWindowController.swift
+++ b/Simplenote/AuthWindowController.swift
@@ -9,7 +9,7 @@ class AuthWindowController: NSWindowController, SPAuthenticationInterface {
 
     /// Starting Point!
     ///
-    let authViewController = AuthViewController()
+    let authViewController: AuthViewController
 
     /// Simperium's Authenticator Instance
     ///
@@ -26,7 +26,9 @@ class AuthWindowController: NSWindowController, SPAuthenticationInterface {
     }
 
     init() {
-        let window = NSWindow(contentViewController: authViewController)
+        self.authViewController = AuthViewController()
+        let navigationController = SPNavigationController(initialViewController: authViewController)
+        let window = NSWindow(contentViewController: navigationController)
         window.styleMask = [.borderless, .closable, .titled, .fullSizeContentView]
         window.appearance = NSAppearance(named: .aqua)
         window.titleVisibility = .hidden

--- a/Simplenote/AuthenticationMode.swift
+++ b/Simplenote/AuthenticationMode.swift
@@ -18,8 +18,9 @@ class AuthenticationMode: NSObject {
     let isPasswordVisible: Bool
     let isSecondaryActionVisible: Bool
     let isWordPressVisible: Bool
-    
-    init(primaryActionText: String, primaryActionAnimationText: String, primaryActionSelector: Selector, secondaryActionText: String?, secondaryActionSelector: Selector?, switchActionText: String, switchActionTip: String, switchTargetMode: @escaping () -> AuthenticationMode, isPasswordVisible: Bool, isSecondaryActionVisible: Bool, isWordPressVisible: Bool) {
+    let isSwitchVisible: Bool
+
+    init(primaryActionText: String, primaryActionAnimationText: String, primaryActionSelector: Selector, secondaryActionText: String?, secondaryActionSelector: Selector?, switchActionText: String, switchActionTip: String, switchTargetMode: @escaping () -> AuthenticationMode, isPasswordVisible: Bool, isSecondaryActionVisible: Bool, isWordPressVisible: Bool, isSwitchVisible: Bool) {
         self.primaryActionText = primaryActionText
         self.primaryActionAnimationText =  primaryActionAnimationText
         self.primaryActionSelector = primaryActionSelector
@@ -31,6 +32,7 @@ class AuthenticationMode: NSObject {
         self.isPasswordVisible = isPasswordVisible
         self.isSecondaryActionVisible = isSecondaryActionVisible
         self.isWordPressVisible = isWordPressVisible
+        self.isSwitchVisible = isSwitchVisible
     }
 }
 
@@ -87,7 +89,8 @@ extension AuthenticationMode {
                            switchTargetMode: { .signup },
                            isPasswordVisible: true,
                            isSecondaryActionVisible: true,
-                           isWordPressVisible: true)
+                           isWordPressVisible: true,
+                           isSwitchVisible: false)
     }
 
     /// Auth Mode: Login is handled via Magic Links!
@@ -104,7 +107,8 @@ extension AuthenticationMode {
                            switchTargetMode: { .signup },
                            isPasswordVisible: false,
                            isSecondaryActionVisible: true,
-                           isWordPressVisible: true)
+                           isWordPressVisible: true,
+                           isSwitchVisible: false)
     }
 
     /// Auth Mode: SignUp
@@ -121,7 +125,8 @@ extension AuthenticationMode {
                            switchTargetMode: { .loginWithMagicLink },
                            isPasswordVisible: false,
                            isSecondaryActionVisible: false,
-                           isWordPressVisible: false)
+                           isWordPressVisible: false,
+                           isSwitchVisible: true)
     }
 }
 

--- a/Simplenote/NSView+Simplenote.swift
+++ b/Simplenote/NSView+Simplenote.swift
@@ -19,4 +19,10 @@ extension NSView {
         let effectiveResponder = fieldEditor?.delegate as? NSControl
         return effectiveResponder == self
     }
+
+    /// Returns first layout constraint found for attribute type
+    ///
+    func firstContraint(firstView: NSView, firstAttribute: NSLayoutConstraint.Attribute) -> NSLayoutConstraint? {
+        constraints.first(where: { $0.firstItem as? NSView == firstView && $0.firstAttribute == firstAttribute })
+    }
 }

--- a/Simplenote/NSViewController+Simplenote.swift
+++ b/Simplenote/NSViewController+Simplenote.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+extension NSViewController {
+    var containingNavigationController: SPNavigationController? {
+        parent as? SPNavigationController
+    }
+}

--- a/Simplenote/SPNavigationController.swift
+++ b/Simplenote/SPNavigationController.swift
@@ -3,7 +3,7 @@ import Foundation
 class SPNavigationController: NSViewController {
     private var viewStack: [NSViewController] = []
 
-    private var backButton: NSButton = NSButton(title: String(), image: NSImage(named: NSImage.goBackTemplateName)!, target: nil, action: #selector(backWasPressed))
+    private var backButton: NSButton!
 
     var initialViewController: NSViewController {
         guard let first = viewStack.first else {
@@ -34,17 +34,18 @@ class SPNavigationController: NSViewController {
     override func loadView() {
         view = NSView()
         let initialView = initialViewController.view
-
         let spacerView = NSView(frame: NSRect(x: 0, y: 0, width: 100, height: 30))
-        spacerView.translatesAutoresizingMaskIntoConstraints = false
 
-        backButton.contentTintColor = .blue
-        backButton.setTitleColor(.blue)
-        backButton.bezelStyle = .accessoryBar
-        backButton.translatesAutoresizingMaskIntoConstraints = false
-        backButton.isHidden = hideBackButton
+        let buttonImage = NSImage(named: NSImage.goBackTemplateName)!
+        let button = NSButton(title: String(), image: NSImage(named: NSImage.goBackTemplateName)!, target: nil, action: #selector(backWasPressed))
+        button.bezelStyle = .accessoryBarAction
 
         view.translatesAutoresizingMaskIntoConstraints = false
+        spacerView.translatesAutoresizingMaskIntoConstraints = false
+        button.translatesAutoresizingMaskIntoConstraints = false
+
+        backButton = button
+        backButton.isHidden = hideBackButton
 
         view.addSubview(spacerView)
         NSLayoutConstraint.activate([
@@ -56,8 +57,9 @@ class SPNavigationController: NSViewController {
 
         view.addSubview(backButton)
         NSLayoutConstraint.activate([
-            backButton.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            backButton.topAnchor.constraint(equalTo: spacerView.bottomAnchor)
+            backButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 10),
+            backButton.topAnchor.constraint(equalTo: spacerView.bottomAnchor),
+            backButton.widthAnchor.constraint(equalToConstant: 50)
         ])
 
         show(initialView)

--- a/Simplenote/SPNavigationController.swift
+++ b/Simplenote/SPNavigationController.swift
@@ -23,8 +23,36 @@ class SPNavigationController: NSViewController {
 
     init(initialViewController: NSViewController) {
         super.init(nibName: nil, bundle: nil)
+
+//        let viewController = NSViewController()
+//        let view = NSView(frame: NSRect(x: 0, y: 0, width: 300, height: 300))
+//        viewController.view = view
+//        view.wantsLayer = true
+//        view.layer?.backgroundColor = NSColor.green.cgColor
+//
+//        let button = NSButton(frame: NSRect(x: 20, y: 20, width: 20, height: 20))
+//        button.action = #selector(animateNewView)
+//
+//        view.addSubview(button)
+//        addChild(viewController)
+//        viewStack.append(viewController)
         viewStack.append(initialViewController)
         addChild(initialViewController)
+    }
+
+    @objc
+    func animateNewView() {
+        let newView = NSView(frame: NSRect(x: 300, y: 0, width: 300, height: 300))
+        newView.wantsLayer = true
+        newView.layer?.backgroundColor = NSColor.red.cgColor
+
+        view.addSubview(newView)
+
+        NSAnimationContext.runAnimationGroup { context in
+            context.duration = 0.5
+            currentView?.animator().frame.origin.x -= 300
+            newView.animator().frame.origin.x -= 300
+        }
     }
 
     required init?(coder: NSCoder) {
@@ -32,20 +60,21 @@ class SPNavigationController: NSViewController {
     }
 
     override func loadView() {
-        view = NSView()
         let initialView = initialViewController.view
         let spacerView = NSView(frame: NSRect(x: 0, y: 0, width: 100, height: 30))
-
-        let buttonImage = NSImage(named: NSImage.goBackTemplateName)!
         let button = NSButton(title: String(), image: NSImage(named: NSImage.goBackTemplateName)!, target: nil, action: #selector(backWasPressed))
-        button.bezelStyle = .accessoryBarAction
+        view = NSView()
+
+        view.frame = NSRect(x: 0, y: 0, width: initialView.frame.width, height: initialView.frame.height)
 
         view.translatesAutoresizingMaskIntoConstraints = false
+        initialView.translatesAutoresizingMaskIntoConstraints = false
         spacerView.translatesAutoresizingMaskIntoConstraints = false
         button.translatesAutoresizingMaskIntoConstraints = false
 
         backButton = button
         backButton.isHidden = hideBackButton
+        button.bezelStyle = .accessoryBarAction
 
         view.addSubview(spacerView)
         NSLayoutConstraint.activate([
@@ -62,29 +91,48 @@ class SPNavigationController: NSViewController {
             backButton.widthAnchor.constraint(equalToConstant: 50)
         ])
 
-        show(initialView)
+        view.addSubview(initialView)
     }
 
     private func show(_ newView: NSView) {
         view.addSubview(newView)
-        NSLayoutConstraint.activate([
-            newView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            newView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            newView.topAnchor.constraint(equalTo: backButton.bottomAnchor),
-            newView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
-        ])
+//        NSLayoutConstraint.activate([
+//            newView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+//            newView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+//            newView.topAnchor.constraint(equalTo: backButton.bottomAnchor),
+//            newView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+//        ])
     }
 
     func push(_ viewController: NSViewController) {
 
-        currentView?.removeFromSuperview()
+//        currentView?.removeFromSuperview()
+//
+//        let newView = viewController.view
+//        viewStack.append(viewController)
+//        addChild(viewController)
+//
+//        show(newView)
+//        refreshView()
 
-        let newView = viewController.view
-        viewStack.append(viewController)
+        guard let currentView else {
+            return
+        }
+
+        currentView.removeConstraints(currentView.constraints)
+
         addChild(viewController)
+        let newView = viewController.view
 
-        show(newView)
-        refreshView()
+        newView.frame.origin.x += currentView.frame.width
+        view.addSubview(newView)
+
+        NSAnimationContext.runAnimationGroup { context in
+            context.duration = 0.75
+
+            currentView.animator().frame.origin.x -= currentView.frame.width
+            newView.animator().frame.origin.x -= currentView.frame.width
+        }
     }
 
     func popViewController() {

--- a/Simplenote/SPNavigationController.swift
+++ b/Simplenote/SPNavigationController.swift
@@ -78,11 +78,12 @@ class SPNavigationController: NSViewController {
     // MARK: - Add a View to the stack
     //
     func push(_ viewController: NSViewController, animated: Bool = true) {
-        guard let currentView = topViewController?.view else {
-            return
-        }
+        let currentView = topViewController?.view
+
         attach(child: viewController)
-        currentView.removeConstraints(currentView.constraints)
+        if let currentView {
+            currentView.removeConstraints(currentView.constraints)
+        }
 
         guard let (leadingAnchor, trailingAnchor) = attachView(subview: viewController.view) else {
             return
@@ -96,7 +97,7 @@ class SPNavigationController: NSViewController {
         trailingAnchor.constant = view.frame.width
 
         animateTransition(slidingView: viewController.view, fadingView: currentView, direction: .trailingToLeading) {
-            currentView.removeFromSuperview()
+            currentView?.removeFromSuperview()
         }
     }
 
@@ -159,7 +160,7 @@ class SPNavigationController: NSViewController {
         case trailingToLeading
     }
 
-    private func animateTransition(slidingView: NSView, fadingView: NSView, direction: AnimationDirection, onCompletion: @escaping () -> Void) {
+    private func animateTransition(slidingView: NSView, fadingView: NSView?, direction: AnimationDirection, onCompletion: @escaping () -> Void) {
         guard let leadingConstraint = view.constraints.first(where: { $0.firstItem as? NSView == slidingView && $0.firstAttribute == .leading }),
               let trailingConstraint = view.constraints.first(where: { $0.firstItem as? NSView == slidingView && $0.firstAttribute == .trailing }) else {
             return
@@ -172,7 +173,7 @@ class SPNavigationController: NSViewController {
             context.duration = 0.4
             context.timingFunction = .init(name: .easeInEaseOut)
 
-            fadingView.animator().alphaValue = alpha
+            fadingView?.animator().alphaValue = alpha
             leadingConstraint.animator().constant += view.frame.width * multiplier
             trailingConstraint.animator().constant += view.frame.width * multiplier
             backButtonHeightConstraint.animator().constant = hideBackButton ? 0 : 30

--- a/Simplenote/SPNavigationController.swift
+++ b/Simplenote/SPNavigationController.swift
@@ -143,9 +143,7 @@ class SPNavigationController: NSViewController {
             return
         }
 
-        guard let (leadingAnchor, trailingAnchor) = self.attachView(subview: nextViewController.view, behindCurrent: true) else {
-            return
-        }
+        self.attachView(subview: nextViewController.view, behindCurrent: true)
 
         animateTransition(slidingView: currentViewController.view, fadingView: nextViewController.view, direction: .leadingToTrailing) {
             self.dettach(child: currentViewController)

--- a/Simplenote/SPNavigationController.swift
+++ b/Simplenote/SPNavigationController.swift
@@ -7,6 +7,8 @@ class SPNavigationController: NSViewController {
     private var viewStack: [NSViewController] = []
     private var backButton: NSButton!
 
+    private var backButtonHeightConstraint: NSLayoutConstraint!
+
     var hideBackButton: Bool {
         viewStack.count < 2
     }
@@ -53,10 +55,12 @@ class SPNavigationController: NSViewController {
         ])
 
         view.addSubview(backButton)
+        backButtonHeightConstraint = backButton.heightAnchor.constraint(equalToConstant: 0)
         NSLayoutConstraint.activate([
             backButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 10),
             backButton.topAnchor.constraint(equalTo: spacerView.bottomAnchor),
-            backButton.widthAnchor.constraint(equalToConstant: 50)
+            backButton.widthAnchor.constraint(equalToConstant: 50),
+            backButtonHeightConstraint
         ])
 
         view.addSubview(initialView)
@@ -176,6 +180,7 @@ class SPNavigationController: NSViewController {
             fadingView.animator().alphaValue = alpha
             leadingConstraint.animator().constant += view.frame.width * multiplier
             trailingConstraint.animator().constant += view.frame.width * multiplier
+            backButtonHeightConstraint.animator().constant = hideBackButton ? 0 : 30
             backButton.animator().isHidden = hideBackButton
         } completionHandler: {
             onCompletion()

--- a/Simplenote/SPNavigationController.swift
+++ b/Simplenote/SPNavigationController.swift
@@ -98,16 +98,6 @@ class SPNavigationController: NSViewController {
         refreshView()
     }
 
-    func popToInitialViewController() {
-        guard viewStack.count > 1 else {
-            return
-        }
-
-        while viewStack.count > 1 {
-            popViewController()
-        }
-    }
-
     @objc
     func backWasPressed() {
         popViewController()

--- a/Simplenote/SPNavigationController.swift
+++ b/Simplenote/SPNavigationController.swift
@@ -1,0 +1,120 @@
+import Foundation
+
+class SPNavigationController: NSViewController {
+    private var viewStack: [NSViewController] = []
+
+    private var backButton: NSButton = NSButton(title: String(), image: NSImage(named: NSImage.goBackTemplateName)!, target: nil, action: #selector(backWasPressed))
+
+    var initialViewController: NSViewController {
+        guard let first = viewStack.first else {
+            fatalError()
+        }
+
+        return first
+    }
+
+    var currentView: NSView? {
+        viewStack.last?.view
+    }
+
+    var hideBackButton: Bool {
+        viewStack.count < 2
+    }
+
+    init(initialViewController: NSViewController) {
+        super.init(nibName: nil, bundle: nil)
+        viewStack.append(initialViewController)
+        addChild(initialViewController)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func loadView() {
+        view = NSView()
+        let initialView = initialViewController.view
+
+        let spacerView = NSView(frame: NSRect(x: 0, y: 0, width: 100, height: 30))
+        spacerView.translatesAutoresizingMaskIntoConstraints = false
+
+        backButton.contentTintColor = .blue
+        backButton.setTitleColor(.blue)
+        backButton.bezelStyle = .accessoryBar
+        backButton.translatesAutoresizingMaskIntoConstraints = false
+        backButton.isHidden = hideBackButton
+
+        view.translatesAutoresizingMaskIntoConstraints = false
+
+        view.addSubview(spacerView)
+        NSLayoutConstraint.activate([
+            spacerView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            spacerView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            spacerView.heightAnchor.constraint(equalToConstant: 30),
+            spacerView.topAnchor.constraint(equalTo: view.topAnchor)
+        ])
+
+        view.addSubview(backButton)
+        NSLayoutConstraint.activate([
+            backButton.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            backButton.topAnchor.constraint(equalTo: spacerView.bottomAnchor)
+        ])
+
+        show(initialView)
+    }
+
+    private func show(_ newView: NSView) {
+        view.addSubview(newView)
+        NSLayoutConstraint.activate([
+            newView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            newView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            newView.topAnchor.constraint(equalTo: backButton.bottomAnchor),
+            newView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+    }
+
+    func push(_ viewController: NSViewController) {
+
+        currentView?.removeFromSuperview()
+
+        let newView = viewController.view
+        viewStack.append(viewController)
+        addChild(viewController)
+
+        show(newView)
+        refreshView()
+    }
+
+    func popViewController() {
+        guard viewStack.count > 1 else {
+            return
+        }
+
+        let viewControllerToPop = viewStack.removeLast()
+        viewControllerToPop.view.removeFromSuperview()
+        viewControllerToPop.removeFromParent()
+
+        show(currentView!)
+        refreshView()
+    }
+
+    func popToInitialViewController() {
+        guard viewStack.count > 1 else {
+            return
+        }
+
+        while viewStack.count > 1 {
+            popViewController()
+        }
+    }
+
+    @objc
+    func backWasPressed() {
+        popViewController()
+    }
+
+    private func refreshView() {
+        backButton.isHidden = hideBackButton
+        view.window?.layoutIfNeeded()
+    }
+}

--- a/Simplenote/SPNavigationController.swift
+++ b/Simplenote/SPNavigationController.swift
@@ -85,7 +85,7 @@ class SPNavigationController: NSViewController {
             currentView.removeConstraints(currentView.constraints)
         }
 
-        guard let (leadingAnchor, trailingAnchor) = attachView(subview: viewController.view) else {
+        guard let (leadingAnchor, trailingAnchor) = attachView(subview: viewController.view, currentView: currentView) else {
             return
         }
 
@@ -107,9 +107,8 @@ class SPNavigationController: NSViewController {
     }
 
     @discardableResult
-    private func attachView(subview: NSView, behindCurrent: Bool = false) -> (leading: NSLayoutConstraint, trailing: NSLayoutConstraint)? {
-        if let currentView = topViewController?.view,
-           behindCurrent {
+    private func attachView(subview: NSView, currentView: NSView?, behindCurrent: Bool = false) -> (leading: NSLayoutConstraint, trailing: NSLayoutConstraint)? {
+        if behindCurrent {
             view.addSubview(subview, positioned: .below, relativeTo: currentView)
         } else {
             view.addSubview(subview)
@@ -141,7 +140,7 @@ class SPNavigationController: NSViewController {
             return
         }
 
-        self.attachView(subview: nextViewController.view, behindCurrent: true)
+        attachView(subview: nextViewController.view, currentView: currentViewController.view, behindCurrent: true)
 
         animateTransition(slidingView: currentViewController.view, fadingView: nextViewController.view, direction: .leadingToTrailing) {
             self.dettach(child: currentViewController)

--- a/Simplenote/SPNavigationController.swift
+++ b/Simplenote/SPNavigationController.swift
@@ -160,8 +160,8 @@ class SPNavigationController: NSViewController {
     }
 
     private func animateTransition(slidingView: NSView, fadingView: NSView?, direction: AnimationDirection, onCompletion: @escaping () -> Void) {
-        guard let leadingConstraint = view.constraints.first(where: { $0.firstItem as? NSView == slidingView && $0.firstAttribute == .leading }),
-              let trailingConstraint = view.constraints.first(where: { $0.firstItem as? NSView == slidingView && $0.firstAttribute == .trailing }) else {
+        guard let leadingConstraint = view.firstContraint(firstView: slidingView, firstAttribute: .leading),
+              let trailingConstraint = view.firstContraint(firstView: slidingView, firstAttribute: .trailing) else {
             return
         }
 

--- a/Simplenote/SPNavigationController.swift
+++ b/Simplenote/SPNavigationController.swift
@@ -32,36 +32,12 @@ class SPNavigationController: NSViewController {
             fatalError()
         }
 
-        let initialView = initialViewController.view
-        let spacerView = NSView(frame: .zero)
-        let button = NSButton(title: String(), image: NSImage(named: NSImage.goBackTemplateName)!, target: nil, action: #selector(backWasPressed))
         view = NSView()
+        let initialView = initialViewController.view
+        backButton = insertBackButton()
 
         view.translatesAutoresizingMaskIntoConstraints = false
         initialView.translatesAutoresizingMaskIntoConstraints = false
-        spacerView.translatesAutoresizingMaskIntoConstraints = false
-        button.translatesAutoresizingMaskIntoConstraints = false
-
-        backButton = button
-        backButton.isHidden = hideBackButton
-        button.bezelStyle = .accessoryBarAction
-
-        view.addSubview(spacerView)
-        NSLayoutConstraint.activate([
-            spacerView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            spacerView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            spacerView.heightAnchor.constraint(equalToConstant: 30),
-            spacerView.topAnchor.constraint(equalTo: view.topAnchor)
-        ])
-
-        view.addSubview(backButton)
-        backButtonHeightConstraint = backButton.heightAnchor.constraint(equalToConstant: 0)
-        NSLayoutConstraint.activate([
-            backButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 10),
-            backButton.topAnchor.constraint(equalTo: spacerView.bottomAnchor),
-            backButton.widthAnchor.constraint(equalToConstant: 50),
-            backButtonHeightConstraint
-        ])
 
         view.addSubview(initialView)
 
@@ -71,6 +47,27 @@ class SPNavigationController: NSViewController {
             initialView.topAnchor.constraint(equalTo: backButton.bottomAnchor),
             initialView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
         ])
+    }
+
+    private func insertBackButton() -> NSButton {
+        let button = NSButton(title: String(), image: NSImage(named: NSImage.goBackTemplateName)!, target: nil, action: #selector(backWasPressed))
+
+        button.translatesAutoresizingMaskIntoConstraints = false
+
+        backButton = button
+        backButton.isHidden = hideBackButton
+        button.bezelStyle = .accessoryBarAction
+
+        view.addSubview(backButton)
+        backButtonHeightConstraint = backButton.heightAnchor.constraint(equalToConstant: 0)
+        NSLayoutConstraint.activate([
+            backButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 10),
+            backButton.topAnchor.constraint(equalTo: view.topAnchor, constant: 30),
+            backButton.widthAnchor.constraint(equalToConstant: 50),
+            backButtonHeightConstraint
+        ])
+
+        return button
     }
 
     @objc


### PR DESCRIPTION
### Fix
For the magic links setup to work we need to reshape how the auth view looks.  Right now it is a single screen to sign in or an email me a link screen which has a button on it for showing the password field.  This is fine for now, but doesn't really work with the new layout designs that we are putting into the other apps which has a series of screens depending on how the user wants to login and where they are in the process.

To be able to manage the transition from one screen to another we need some sort of view management system.  Natively MacOS doesn't support this, so in this PR I have created a new view controller that can act similar to an iOS navigation controller.  This will permit us to travel through a stack of views and return back to them if need be.

In this PR I have not made any changes to how the ui currently works except that we are pushing to the email view from sign up instead of cross fading.

Note that the sizes between the sign up and login views are a little off so the animation is a bit wonky, but that is a problem for a future PR this is just about getting the views transitioning.

Open to suggestions and feedback on how the animation works.  Currently for a push the new view slides in and the old view fades out.  For a pop the current view slides out and the next view fades in.

### Test
***(Required)*** List the steps to test the behavior.  For example:
1. Launch SNMac, log out if you are logged in. 
2. From the sign up screen tap on the Login button.
- [ ] Confirm that the email auth view slides 
- [ ] Confirm that a back button appears
- [ ] confirm that the signup view fades away
- [ ] Tap the back button and confirm the animation happens in reverse and you are left with the sign up view

### Review
***(Required)*** Add instructions for reviewers.  For example:
> Only one developer is required to review these changes, but anyone can perform the review.

### Release
***(Required)*** Add a concise statement to `RELEASE-NOTES.txt` if the changes should be included in release notes. Include details about updating the notes in this section. For example:
> These changes do not require release notes.
