### PR TITLE
Magic Links: UI Updates Mk1

### DIFF
--- a/Simplenote/AuthViewController+Swift.swift
+++ b/Simplenote/AuthViewController+Swift.swift
@@ -30,6 +30,17 @@ extension AuthViewController {
         wordPressSSOButton.image = NSImage(named: .wordPressLogo)?.tinted(with: .simplenoteBrandColor)
         wordPressSSOButton.title = Localization.dotcomSSOAction
         wordPressSSOButton.contentTintColor = .simplenoteTertiaryTextColor
+
+        setupActionsSeparatorView()
+    }
+
+    private func setupActionsSeparatorView() {
+        leadingSeparatorView.wantsLayer = true
+        leadingSeparatorView.layer?.backgroundColor = NSColor.lightGray.cgColor
+        trailingSeparatorView.wantsLayer = true
+        trailingSeparatorView.layer?.backgroundColor = NSColor.lightGray.cgColor
+
+        separatorLabel.textColor = .lightGray
     }
 }
 
@@ -103,6 +114,7 @@ extension AuthViewController {
         wordPressSSOButton.alphaValue           = mode.wordPressSSOFieldAlpha
 
         switchAuthenticationView.isHidden                 = !mode.isSwitchVisible
+        actionsSeparatorView.isHidden = !mode.showActionSeparator
     }
 
     /// Animates Visible / Invisible components, based on the specified state
@@ -180,6 +192,11 @@ extension AuthViewController {
         nextVC.mode = nextMode
 
         return nextVC
+    }
+
+    @objc
+    func pushEmailLoginView() {
+        containingNavigationController?.push(nextViewController())
     }
 }
 

--- a/Simplenote/AuthViewController+Swift.swift
+++ b/Simplenote/AuthViewController+Swift.swift
@@ -21,9 +21,11 @@ extension AuthViewController {
         secondaryActionButton.contentTintColor = .simplenoteBrandColor
 
         // WordPress SSO
-        wordPressSSOButton.image = NSImage(named: .wordPressLogo)?.tinted(with: .simplenoteBrandColor)
         wordPressSSOButton.title = Localization.dotcomSSOAction
-        wordPressSSOButton.contentTintColor = .simplenoteTertiaryTextColor
+        wordPressSSOButton.contentTintColor = .white
+        wordPressSSOContainerView.wantsLayer = true
+        wordPressSSOContainerView.layer?.backgroundColor = NSColor.simplenoteWPBlue50Color.cgColor
+        wordPressSSOContainerView.layer?.cornerRadius = 5
 
         setupActionsSeparatorView()
     }

--- a/Simplenote/AuthViewController+Swift.swift
+++ b/Simplenote/AuthViewController+Swift.swift
@@ -20,12 +20,6 @@ extension AuthViewController {
         // Secondary Action
         secondaryActionButton.contentTintColor = .simplenoteBrandColor
 
-        // Toggle Signup: Tip
-        switchTipField.textColor = .simplenoteTertiaryTextColor
-
-        // Toggle Signup: Action
-        switchActionButton.contentTintColor = .simplenoteBrandColor
-
         // WordPress SSO
         wordPressSSOButton.image = NSImage(named: .wordPressLogo)?.tinted(with: .simplenoteBrandColor)
         wordPressSSOButton.title = Localization.dotcomSSOAction
@@ -78,8 +72,6 @@ extension AuthViewController {
     func refreshButtonTitles() {
         actionButton.title          = mode.primaryActionText
         secondaryActionButton.title = mode.secondaryActionText?.uppercased() ?? ""
-        switchTipField.stringValue  = mode.switchActionTip.uppercased()
-        switchActionButton.title    = mode.switchActionText.uppercased()
     }
 
     /// Makes sure unused components (in the current mode) are effectively disabled
@@ -113,7 +105,6 @@ extension AuthViewController {
         secondaryActionButton.alphaValue        = mode.secondaryActionFieldAlpha
         wordPressSSOButton.alphaValue           = mode.wordPressSSOFieldAlpha
 
-        switchAuthenticationView.isHidden                 = !mode.isSwitchVisible
         actionsSeparatorView.isHidden = !mode.showActionSeparator
     }
 
@@ -177,11 +168,6 @@ extension AuthViewController {
         }
         
         performSelector(onMainThread: secondaryActionSelector, with: nil, waitUntilDone: false)
-    }
-
-    @IBAction
-    func switchAuthenticationMode(_ sender: Any) {
-        containingNavigationController?.push(nextViewController())
     }
 
     private func nextViewController() -> AuthViewController {

--- a/Simplenote/AuthViewController.h
+++ b/Simplenote/AuthViewController.h
@@ -22,6 +22,10 @@
 @property (nonatomic, strong) IBOutlet NSView                       *wordPressSSOContainerView;
 @property (nonatomic, strong) IBOutlet NSButton                     *wordPressSSOButton;
 @property (weak) IBOutlet NSView *switchAuthenticationView;
+@property (weak) IBOutlet NSView *actionsSeparatorView;
+@property (weak) IBOutlet NSView *leadingSeparatorView;
+@property (weak) IBOutlet NSTextField *separatorLabel;
+@property (weak) IBOutlet NSView *trailingSeparatorView;
 
 @property (nonatomic, strong) IBOutlet NSLayoutConstraint           *passwordFieldHeightConstraint;
 @property (nonatomic, strong) IBOutlet NSLayoutConstraint           *secondaryActionHeightConstraint;

--- a/Simplenote/AuthViewController.h
+++ b/Simplenote/AuthViewController.h
@@ -17,11 +17,8 @@
 @property (nonatomic, strong) IBOutlet NSButton                     *actionButton;
 @property (nonatomic, strong) IBOutlet NSProgressIndicator          *actionProgress;
 @property (nonatomic, strong) IBOutlet NSButton                     *secondaryActionButton;
-@property (nonatomic, strong) IBOutlet NSTextField                  *switchTipField;
-@property (nonatomic, strong) IBOutlet NSButton                     *switchActionButton;
 @property (nonatomic, strong) IBOutlet NSView                       *wordPressSSOContainerView;
 @property (nonatomic, strong) IBOutlet NSButton                     *wordPressSSOButton;
-@property (weak) IBOutlet NSView *switchAuthenticationView;
 @property (weak) IBOutlet NSView *actionsSeparatorView;
 @property (weak) IBOutlet NSView *leadingSeparatorView;
 @property (weak) IBOutlet NSTextField *separatorLabel;

--- a/Simplenote/AuthViewController.m
+++ b/Simplenote/AuthViewController.m
@@ -81,7 +81,6 @@ static NSString *SPAuthSessionKey = @"SPAuthSessionKey";
     [self.passwordField setEnabled:enabled];
     [self.actionButton setEnabled:enabled];
     [self.secondaryActionButton setEnabled:enabled];
-    [self.switchActionButton setEnabled:enabled];
     [self.wordPressSSOButton setEnabled:enabled];
 }
 

--- a/Simplenote/AuthViewController.xib
+++ b/Simplenote/AuthViewController.xib
@@ -20,9 +20,6 @@
                 <outlet property="secondaryActionHeightConstraint" destination="HrL-ss-QSd" id="Vg3-A9-yCH"/>
                 <outlet property="separatorLabel" destination="xI6-bI-NiW" id="PA7-tE-0Od"/>
                 <outlet property="stackView" destination="PWa-EY-51O" id="jUJ-sH-HgC"/>
-                <outlet property="switchActionButton" destination="5np-Xn-oop" id="KYi-sy-yoJ"/>
-                <outlet property="switchAuthenticationView" destination="mRM-75-7tv" id="Yij-Ld-A8r"/>
-                <outlet property="switchTipField" destination="0yP-IQ-Unz" id="jvk-lr-cHO"/>
                 <outlet property="trailingSeparatorView" destination="Uej-dg-hz2" id="UUI-he-9Xh"/>
                 <outlet property="usernameField" destination="Fco-3r-2Ys" id="qFA-HM-uFa"/>
                 <outlet property="view" destination="kU7-kg-wG3" id="WH8-Qa-i4c"/>
@@ -34,13 +31,13 @@
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <view wantsLayer="YES" appearanceType="aqua" translatesAutoresizingMaskIntoConstraints="NO" id="kU7-kg-wG3" customClass="SPAuthenticationView">
-            <rect key="frame" x="0.0" y="0.0" width="380" height="638"/>
+            <rect key="frame" x="0.0" y="0.0" width="380" height="568"/>
             <subviews>
                 <stackView distribution="fill" orientation="vertical" alignment="centerX" spacing="12" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="PWa-EY-51O">
-                    <rect key="frame" x="30" y="45" width="320" height="548"/>
+                    <rect key="frame" x="30" y="45" width="320" height="478"/>
                     <subviews>
                         <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="W9h-HS-WbG">
-                            <rect key="frame" x="112" y="452" width="96" height="96"/>
+                            <rect key="frame" x="112" y="382" width="96" height="96"/>
                             <constraints>
                                 <constraint firstAttribute="width" constant="96" id="Sys-NN-iWa"/>
                                 <constraint firstAttribute="height" constant="96" id="mq9-yP-8Tc"/>
@@ -48,7 +45,7 @@
                             <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="icon_simplenote_login" id="2Fh-2C-hTH"/>
                         </imageView>
                         <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="lwM-mh-i3o">
-                            <rect key="frame" x="-2" y="424" width="324" height="16"/>
+                            <rect key="frame" x="-2" y="354" width="324" height="16"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="16" id="Pcu-pb-Ma8"/>
                             </constraints>
@@ -59,13 +56,13 @@
                             </textFieldCell>
                         </textField>
                         <customView translatesAutoresizingMaskIntoConstraints="NO" id="Fco-3r-2Ys" userLabel="Username TextField" customClass="SPAuthenticationTextField">
-                            <rect key="frame" x="0.0" y="372" width="320" height="40"/>
+                            <rect key="frame" x="0.0" y="302" width="320" height="40"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="40" id="ZyF-TN-zXQ"/>
                             </constraints>
                         </customView>
                         <customView wantsLayer="YES" translatesAutoresizingMaskIntoConstraints="NO" id="2bk-bk-VfG" userLabel="Password TextField" customClass="SPAuthenticationTextField">
-                            <rect key="frame" x="0.0" y="320" width="320" height="40"/>
+                            <rect key="frame" x="0.0" y="250" width="320" height="40"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="40" id="Cah-V8-aCS"/>
                             </constraints>
@@ -74,7 +71,7 @@
                             </userDefinedRuntimeAttributes>
                         </customView>
                         <customView translatesAutoresizingMaskIntoConstraints="NO" id="Epn-oY-sfo" userLabel="Action View">
-                            <rect key="frame" x="0.0" y="242" width="320" height="66"/>
+                            <rect key="frame" x="0.0" y="172" width="320" height="66"/>
                             <subviews>
                                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Lid-6Q-zHR" userLabel="Main Action Button" customClass="SPAuthenticationButton">
                                     <rect key="frame" x="0.0" y="0.0" width="320" height="40"/>
@@ -103,7 +100,7 @@
                             </constraints>
                         </customView>
                         <button wantsLayer="YES" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="y1M-Np-v9m" userLabel="Secondary Action Button">
-                            <rect key="frame" x="0.0" y="210" width="320" height="20"/>
+                            <rect key="frame" x="0.0" y="140" width="320" height="20"/>
                             <buttonCell key="cell" type="bevel" title="[Secondary Action]" bezelStyle="rounded" alignment="center" imageScaling="proportionallyDown" inset="2" id="zjo-dD-vux" userLabel="[Secondary Action]">
                                 <behavior key="behavior" lightByContents="YES"/>
                                 <font key="font" metaFont="systemMedium" size="13"/>
@@ -116,7 +113,7 @@
                             </connections>
                         </button>
                         <customView appearanceType="darkAqua" translatesAutoresizingMaskIntoConstraints="NO" id="WI9-SH-Yrp" userLabel="Actions Separator View">
-                            <rect key="frame" x="0.0" y="154" width="320" height="44"/>
+                            <rect key="frame" x="0.0" y="84" width="320" height="44"/>
                             <subviews>
                                 <customView translatesAutoresizingMaskIntoConstraints="NO" id="4nP-3I-NOF" userLabel="Leading Line">
                                     <rect key="frame" x="0.0" y="22" width="145" height="1"/>
@@ -149,46 +146,6 @@
                                 <constraint firstAttribute="trailing" secondItem="Uej-dg-hz2" secondAttribute="trailing" id="chk-5V-L7P"/>
                                 <constraint firstItem="Uej-dg-hz2" firstAttribute="centerY" secondItem="WI9-SH-Yrp" secondAttribute="centerY" id="rUr-aw-HHD"/>
                                 <constraint firstItem="xI6-bI-NiW" firstAttribute="centerX" secondItem="WI9-SH-Yrp" secondAttribute="centerX" id="tJX-vD-jHm"/>
-                            </constraints>
-                        </customView>
-                        <customView translatesAutoresizingMaskIntoConstraints="NO" id="mRM-75-7tv" userLabel="Switch View">
-                            <rect key="frame" x="0.0" y="84" width="320" height="58"/>
-                            <subviews>
-                                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0yP-IQ-Unz" userLabel="Switch Tip">
-                                    <rect key="frame" x="-2" y="20" width="324" height="20"/>
-                                    <constraints>
-                                        <constraint firstAttribute="height" constant="20" id="5GW-OX-wF2"/>
-                                        <constraint firstAttribute="width" constant="320" id="Ice-bc-Xa9"/>
-                                    </constraints>
-                                    <textFieldCell key="cell" lineBreakMode="clipping" allowsUndo="NO" alignment="center" title="[Switch Tip]" id="lWM-Lh-rKn">
-                                        <font key="font" metaFont="systemSemibold" size="13"/>
-                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                    </textFieldCell>
-                                </textField>
-                                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="5np-Xn-oop" userLabel="Switch Button">
-                                    <rect key="frame" x="0.0" y="0.0" width="320" height="20"/>
-                                    <buttonCell key="cell" type="bevel" title="[Switch Action]" bezelStyle="rounded" alignment="center" imageScaling="proportionallyDown" inset="2" id="nb6-bt-sFC">
-                                        <behavior key="behavior" lightByContents="YES"/>
-                                        <font key="font" metaFont="systemSemibold" size="13"/>
-                                    </buttonCell>
-                                    <constraints>
-                                        <constraint firstAttribute="width" constant="320" id="3N3-wW-P6F"/>
-                                        <constraint firstAttribute="height" constant="20" id="3pI-cn-CI2"/>
-                                    </constraints>
-                                    <connections>
-                                        <action selector="switchAuthenticationMode:" target="-2" id="RHe-NY-xff"/>
-                                    </connections>
-                                </button>
-                            </subviews>
-                            <constraints>
-                                <constraint firstItem="0yP-IQ-Unz" firstAttribute="leading" secondItem="mRM-75-7tv" secondAttribute="leading" id="3oG-BE-MuY"/>
-                                <constraint firstAttribute="trailing" secondItem="0yP-IQ-Unz" secondAttribute="trailing" id="41V-Lw-UEz"/>
-                                <constraint firstItem="5np-Xn-oop" firstAttribute="leading" secondItem="mRM-75-7tv" secondAttribute="leading" id="Tlj-YL-2ZG"/>
-                                <constraint firstItem="5np-Xn-oop" firstAttribute="top" secondItem="0yP-IQ-Unz" secondAttribute="bottom" id="e9q-W5-TqD"/>
-                                <constraint firstItem="0yP-IQ-Unz" firstAttribute="top" secondItem="mRM-75-7tv" secondAttribute="top" constant="18" id="iL2-kb-zDB"/>
-                                <constraint firstAttribute="trailing" secondItem="5np-Xn-oop" secondAttribute="trailing" id="nsv-X2-CkQ"/>
-                                <constraint firstAttribute="bottom" secondItem="5np-Xn-oop" secondAttribute="bottom" id="zC9-oc-1g2"/>
                             </constraints>
                         </customView>
                         <customView wantsLayer="YES" translatesAutoresizingMaskIntoConstraints="NO" id="3tE-Zi-edS" userLabel="WordPress SSO View">
@@ -243,10 +200,8 @@
                         <integer value="1000"/>
                         <integer value="1000"/>
                         <integer value="1000"/>
-                        <integer value="1000"/>
                     </visibilityPriorities>
                     <customSpacing>
-                        <real value="3.4028234663852886e+38"/>
                         <real value="3.4028234663852886e+38"/>
                         <real value="3.4028234663852886e+38"/>
                         <real value="3.4028234663852886e+38"/>

--- a/Simplenote/AuthViewController.xib
+++ b/Simplenote/AuthViewController.xib
@@ -10,16 +10,20 @@
             <connections>
                 <outlet property="actionButton" destination="Lid-6Q-zHR" id="k1R-7A-0Fc"/>
                 <outlet property="actionProgress" destination="GMB-3v-AEQ" id="Qv3-0X-3xO"/>
+                <outlet property="actionsSeparatorView" destination="WI9-SH-Yrp" id="SJl-TQ-htb"/>
                 <outlet property="errorField" destination="lwM-mh-i3o" id="hCf-XY-GKI"/>
+                <outlet property="leadingSeparatorView" destination="4nP-3I-NOF" id="mKf-M6-kx7"/>
                 <outlet property="logoImageView" destination="W9h-HS-WbG" id="GV7-vy-NaT"/>
                 <outlet property="passwordField" destination="2bk-bk-VfG" id="JQn-Xi-XNs"/>
                 <outlet property="passwordFieldHeightConstraint" destination="Cah-V8-aCS" id="saQ-Mz-zu6"/>
                 <outlet property="secondaryActionButton" destination="y1M-Np-v9m" id="z7i-Qa-Tye"/>
                 <outlet property="secondaryActionHeightConstraint" destination="HrL-ss-QSd" id="Vg3-A9-yCH"/>
+                <outlet property="separatorLabel" destination="xI6-bI-NiW" id="PA7-tE-0Od"/>
                 <outlet property="stackView" destination="PWa-EY-51O" id="jUJ-sH-HgC"/>
                 <outlet property="switchActionButton" destination="5np-Xn-oop" id="KYi-sy-yoJ"/>
                 <outlet property="switchAuthenticationView" destination="mRM-75-7tv" id="Yij-Ld-A8r"/>
                 <outlet property="switchTipField" destination="0yP-IQ-Unz" id="jvk-lr-cHO"/>
+                <outlet property="trailingSeparatorView" destination="Uej-dg-hz2" id="UUI-he-9Xh"/>
                 <outlet property="usernameField" destination="Fco-3r-2Ys" id="qFA-HM-uFa"/>
                 <outlet property="view" destination="kU7-kg-wG3" id="WH8-Qa-i4c"/>
                 <outlet property="wordPressSSOButton" destination="sc9-DH-ug9" id="bjJ-cB-cCj"/>
@@ -30,13 +34,13 @@
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <view wantsLayer="YES" appearanceType="aqua" translatesAutoresizingMaskIntoConstraints="NO" id="kU7-kg-wG3" customClass="SPAuthenticationView">
-            <rect key="frame" x="0.0" y="0.0" width="380" height="582"/>
+            <rect key="frame" x="0.0" y="0.0" width="380" height="638"/>
             <subviews>
                 <stackView distribution="fill" orientation="vertical" alignment="centerX" spacing="12" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="PWa-EY-51O">
-                    <rect key="frame" x="30" y="45" width="320" height="492"/>
+                    <rect key="frame" x="30" y="45" width="320" height="548"/>
                     <subviews>
                         <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="W9h-HS-WbG">
-                            <rect key="frame" x="112" y="396" width="96" height="96"/>
+                            <rect key="frame" x="112" y="452" width="96" height="96"/>
                             <constraints>
                                 <constraint firstAttribute="width" constant="96" id="Sys-NN-iWa"/>
                                 <constraint firstAttribute="height" constant="96" id="mq9-yP-8Tc"/>
@@ -44,7 +48,7 @@
                             <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="icon_simplenote_login" id="2Fh-2C-hTH"/>
                         </imageView>
                         <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="lwM-mh-i3o">
-                            <rect key="frame" x="-2" y="368" width="324" height="16"/>
+                            <rect key="frame" x="-2" y="424" width="324" height="16"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="16" id="Pcu-pb-Ma8"/>
                             </constraints>
@@ -55,13 +59,13 @@
                             </textFieldCell>
                         </textField>
                         <customView translatesAutoresizingMaskIntoConstraints="NO" id="Fco-3r-2Ys" userLabel="Username TextField" customClass="SPAuthenticationTextField">
-                            <rect key="frame" x="0.0" y="316" width="320" height="40"/>
+                            <rect key="frame" x="0.0" y="372" width="320" height="40"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="40" id="ZyF-TN-zXQ"/>
                             </constraints>
                         </customView>
                         <customView wantsLayer="YES" translatesAutoresizingMaskIntoConstraints="NO" id="2bk-bk-VfG" userLabel="Password TextField" customClass="SPAuthenticationTextField">
-                            <rect key="frame" x="0.0" y="264" width="320" height="40"/>
+                            <rect key="frame" x="0.0" y="320" width="320" height="40"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="40" id="Cah-V8-aCS"/>
                             </constraints>
@@ -70,7 +74,7 @@
                             </userDefinedRuntimeAttributes>
                         </customView>
                         <customView translatesAutoresizingMaskIntoConstraints="NO" id="Epn-oY-sfo" userLabel="Action View">
-                            <rect key="frame" x="0.0" y="186" width="320" height="66"/>
+                            <rect key="frame" x="0.0" y="242" width="320" height="66"/>
                             <subviews>
                                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Lid-6Q-zHR" userLabel="Main Action Button" customClass="SPAuthenticationButton">
                                     <rect key="frame" x="0.0" y="0.0" width="320" height="40"/>
@@ -99,7 +103,7 @@
                             </constraints>
                         </customView>
                         <button wantsLayer="YES" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="y1M-Np-v9m" userLabel="Secondary Action Button">
-                            <rect key="frame" x="0.0" y="154" width="320" height="20"/>
+                            <rect key="frame" x="0.0" y="210" width="320" height="20"/>
                             <buttonCell key="cell" type="bevel" title="[Secondary Action]" bezelStyle="rounded" alignment="center" imageScaling="proportionallyDown" inset="2" id="zjo-dD-vux" userLabel="[Secondary Action]">
                                 <behavior key="behavior" lightByContents="YES"/>
                                 <font key="font" metaFont="systemMedium" size="13"/>
@@ -111,6 +115,42 @@
                                 <action selector="performSecondaryAction:" target="-2" id="hjL-sS-hbT"/>
                             </connections>
                         </button>
+                        <customView appearanceType="darkAqua" translatesAutoresizingMaskIntoConstraints="NO" id="WI9-SH-Yrp" userLabel="Actions Separator View">
+                            <rect key="frame" x="0.0" y="154" width="320" height="44"/>
+                            <subviews>
+                                <customView translatesAutoresizingMaskIntoConstraints="NO" id="4nP-3I-NOF" userLabel="Leading Line">
+                                    <rect key="frame" x="0.0" y="22" width="145" height="1"/>
+                                    <constraints>
+                                        <constraint firstAttribute="height" constant="1" id="0F2-TL-h1F"/>
+                                    </constraints>
+                                </customView>
+                                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="xI6-bI-NiW" userLabel="Or">
+                                    <rect key="frame" x="151" y="15" width="19" height="15"/>
+                                    <textFieldCell key="cell" lineBreakMode="clipping" title="Or" id="V5x-vC-IGm">
+                                        <font key="font" size="13" name="SFPro-RegularItalic"/>
+                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                    </textFieldCell>
+                                </textField>
+                                <customView translatesAutoresizingMaskIntoConstraints="NO" id="Uej-dg-hz2" userLabel="Trailing Line">
+                                    <rect key="frame" x="176" y="22" width="144" height="1"/>
+                                    <constraints>
+                                        <constraint firstAttribute="height" constant="1" id="Qig-LY-zAH"/>
+                                    </constraints>
+                                </customView>
+                            </subviews>
+                            <constraints>
+                                <constraint firstItem="Uej-dg-hz2" firstAttribute="leading" secondItem="xI6-bI-NiW" secondAttribute="trailing" constant="8" id="36u-lv-wOT"/>
+                                <constraint firstAttribute="height" constant="44" id="FJn-bq-bEy"/>
+                                <constraint firstItem="4nP-3I-NOF" firstAttribute="centerY" secondItem="WI9-SH-Yrp" secondAttribute="centerY" id="IdE-dj-SwX"/>
+                                <constraint firstItem="4nP-3I-NOF" firstAttribute="leading" secondItem="WI9-SH-Yrp" secondAttribute="leading" id="SbL-Zj-SbQ"/>
+                                <constraint firstItem="4nP-3I-NOF" firstAttribute="trailing" secondItem="xI6-bI-NiW" secondAttribute="leading" constant="-8" id="Z4v-qb-RdQ"/>
+                                <constraint firstItem="xI6-bI-NiW" firstAttribute="centerY" secondItem="WI9-SH-Yrp" secondAttribute="centerY" id="cdG-ci-RvD"/>
+                                <constraint firstAttribute="trailing" secondItem="Uej-dg-hz2" secondAttribute="trailing" id="chk-5V-L7P"/>
+                                <constraint firstItem="Uej-dg-hz2" firstAttribute="centerY" secondItem="WI9-SH-Yrp" secondAttribute="centerY" id="rUr-aw-HHD"/>
+                                <constraint firstItem="xI6-bI-NiW" firstAttribute="centerX" secondItem="WI9-SH-Yrp" secondAttribute="centerX" id="tJX-vD-jHm"/>
+                            </constraints>
+                        </customView>
                         <customView translatesAutoresizingMaskIntoConstraints="NO" id="mRM-75-7tv" userLabel="Switch View">
                             <rect key="frame" x="0.0" y="84" width="320" height="58"/>
                             <subviews>
@@ -184,12 +224,15 @@
                         <constraint firstItem="3tE-Zi-edS" firstAttribute="leading" secondItem="PWa-EY-51O" secondAttribute="leading" id="8t5-zc-I3D"/>
                         <constraint firstItem="2bk-bk-VfG" firstAttribute="leading" secondItem="PWa-EY-51O" secondAttribute="leading" id="GPa-uH-nyA"/>
                         <constraint firstItem="y1M-Np-v9m" firstAttribute="leading" secondItem="PWa-EY-51O" secondAttribute="leading" id="GWL-9k-A81"/>
+                        <constraint firstAttribute="width" constant="320" id="Ifa-qD-b3e"/>
                         <constraint firstAttribute="trailing" secondItem="y1M-Np-v9m" secondAttribute="trailing" id="Zys-3I-SBQ"/>
                         <constraint firstAttribute="trailing" secondItem="Epn-oY-sfo" secondAttribute="trailing" id="eWd-kZ-fSY"/>
                         <constraint firstAttribute="trailing" secondItem="Fco-3r-2Ys" secondAttribute="trailing" id="gTV-rG-Rz6"/>
                         <constraint firstItem="Fco-3r-2Ys" firstAttribute="leading" secondItem="PWa-EY-51O" secondAttribute="leading" id="lFa-dR-M3o"/>
                         <constraint firstAttribute="trailing" secondItem="3tE-Zi-edS" secondAttribute="trailing" id="oW8-45-PLX"/>
                         <constraint firstItem="lwM-mh-i3o" firstAttribute="leading" secondItem="PWa-EY-51O" secondAttribute="leading" id="pMz-cI-3Ed"/>
+                        <constraint firstAttribute="trailing" secondItem="WI9-SH-Yrp" secondAttribute="trailing" id="sUi-JY-GKT"/>
+                        <constraint firstItem="WI9-SH-Yrp" firstAttribute="leading" secondItem="PWa-EY-51O" secondAttribute="leading" id="ufX-by-B5G"/>
                     </constraints>
                     <visibilityPriorities>
                         <integer value="1000"/>
@@ -200,8 +243,10 @@
                         <integer value="1000"/>
                         <integer value="1000"/>
                         <integer value="1000"/>
+                        <integer value="1000"/>
                     </visibilityPriorities>
                     <customSpacing>
+                        <real value="3.4028234663852886e+38"/>
                         <real value="3.4028234663852886e+38"/>
                         <real value="3.4028234663852886e+38"/>
                         <real value="3.4028234663852886e+38"/>

--- a/Simplenote/AuthViewController.xib
+++ b/Simplenote/AuthViewController.xib
@@ -31,13 +31,13 @@
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <view wantsLayer="YES" appearanceType="aqua" translatesAutoresizingMaskIntoConstraints="NO" id="kU7-kg-wG3" customClass="SPAuthenticationView">
-            <rect key="frame" x="0.0" y="0.0" width="380" height="568"/>
+            <rect key="frame" x="0.0" y="0.0" width="380" height="536"/>
             <subviews>
                 <stackView distribution="fill" orientation="vertical" alignment="centerX" spacing="12" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="PWa-EY-51O">
-                    <rect key="frame" x="30" y="45" width="320" height="478"/>
+                    <rect key="frame" x="30" y="45" width="320" height="446"/>
                     <subviews>
                         <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="W9h-HS-WbG">
-                            <rect key="frame" x="112" y="382" width="96" height="96"/>
+                            <rect key="frame" x="112" y="350" width="96" height="96"/>
                             <constraints>
                                 <constraint firstAttribute="width" constant="96" id="Sys-NN-iWa"/>
                                 <constraint firstAttribute="height" constant="96" id="mq9-yP-8Tc"/>
@@ -45,7 +45,7 @@
                             <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="icon_simplenote_login" id="2Fh-2C-hTH"/>
                         </imageView>
                         <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="lwM-mh-i3o">
-                            <rect key="frame" x="-2" y="354" width="324" height="16"/>
+                            <rect key="frame" x="-2" y="322" width="324" height="16"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="16" id="Pcu-pb-Ma8"/>
                             </constraints>
@@ -56,13 +56,13 @@
                             </textFieldCell>
                         </textField>
                         <customView translatesAutoresizingMaskIntoConstraints="NO" id="Fco-3r-2Ys" userLabel="Username TextField" customClass="SPAuthenticationTextField">
-                            <rect key="frame" x="0.0" y="302" width="320" height="40"/>
+                            <rect key="frame" x="0.0" y="270" width="320" height="40"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="40" id="ZyF-TN-zXQ"/>
                             </constraints>
                         </customView>
                         <customView wantsLayer="YES" translatesAutoresizingMaskIntoConstraints="NO" id="2bk-bk-VfG" userLabel="Password TextField" customClass="SPAuthenticationTextField">
-                            <rect key="frame" x="0.0" y="250" width="320" height="40"/>
+                            <rect key="frame" x="0.0" y="218" width="320" height="40"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="40" id="Cah-V8-aCS"/>
                             </constraints>
@@ -71,7 +71,7 @@
                             </userDefinedRuntimeAttributes>
                         </customView>
                         <customView translatesAutoresizingMaskIntoConstraints="NO" id="Epn-oY-sfo" userLabel="Action View">
-                            <rect key="frame" x="0.0" y="172" width="320" height="66"/>
+                            <rect key="frame" x="0.0" y="140" width="320" height="66"/>
                             <subviews>
                                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Lid-6Q-zHR" userLabel="Main Action Button" customClass="SPAuthenticationButton">
                                     <rect key="frame" x="0.0" y="0.0" width="320" height="40"/>
@@ -100,7 +100,7 @@
                             </constraints>
                         </customView>
                         <button wantsLayer="YES" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="y1M-Np-v9m" userLabel="Secondary Action Button">
-                            <rect key="frame" x="0.0" y="140" width="320" height="20"/>
+                            <rect key="frame" x="0.0" y="108" width="320" height="20"/>
                             <buttonCell key="cell" type="bevel" title="[Secondary Action]" bezelStyle="rounded" alignment="center" imageScaling="proportionallyDown" inset="2" id="zjo-dD-vux" userLabel="[Secondary Action]">
                                 <behavior key="behavior" lightByContents="YES"/>
                                 <font key="font" metaFont="systemMedium" size="13"/>
@@ -113,7 +113,7 @@
                             </connections>
                         </button>
                         <customView appearanceType="darkAqua" translatesAutoresizingMaskIntoConstraints="NO" id="WI9-SH-Yrp" userLabel="Actions Separator View">
-                            <rect key="frame" x="0.0" y="84" width="320" height="44"/>
+                            <rect key="frame" x="0.0" y="52" width="320" height="44"/>
                             <subviews>
                                 <customView translatesAutoresizingMaskIntoConstraints="NO" id="4nP-3I-NOF" userLabel="Leading Line">
                                     <rect key="frame" x="0.0" y="22" width="145" height="1"/>
@@ -149,11 +149,11 @@
                             </constraints>
                         </customView>
                         <customView wantsLayer="YES" translatesAutoresizingMaskIntoConstraints="NO" id="3tE-Zi-edS" userLabel="WordPress SSO View">
-                            <rect key="frame" x="0.0" y="0.0" width="320" height="72"/>
+                            <rect key="frame" x="0.0" y="0.0" width="320" height="40"/>
                             <subviews>
                                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="sc9-DH-ug9" userLabel="WordPress SSO Button">
                                     <rect key="frame" x="0.0" y="0.0" width="320" height="40"/>
-                                    <buttonCell key="cell" type="bevel" title="[WordPress SSO]" bezelStyle="rounded" image="icon_wp" imagePosition="left" alignment="center" imageScaling="proportionallyDown" inset="2" id="Mzh-LI-XpK">
+                                    <buttonCell key="cell" type="bevel" title="[WordPress SSO]" bezelStyle="rounded" imagePosition="left" alignment="center" imageScaling="proportionallyDown" inset="2" id="Mzh-LI-XpK">
                                         <behavior key="behavior" lightByContents="YES"/>
                                         <font key="font" metaFont="system" size="16"/>
                                     </buttonCell>
@@ -167,10 +167,10 @@
                             </subviews>
                             <constraints>
                                 <constraint firstAttribute="trailing" secondItem="sc9-DH-ug9" secondAttribute="trailing" id="8Jl-X1-wpa"/>
-                                <constraint firstAttribute="height" constant="72" id="IW2-ZK-7lM"/>
+                                <constraint firstAttribute="height" constant="40" id="IW2-ZK-7lM"/>
                                 <constraint firstAttribute="bottom" secondItem="sc9-DH-ug9" secondAttribute="bottom" id="OYw-Do-eII"/>
                                 <constraint firstItem="sc9-DH-ug9" firstAttribute="leading" secondItem="3tE-Zi-edS" secondAttribute="leading" id="Q4j-qA-c63"/>
-                                <constraint firstItem="sc9-DH-ug9" firstAttribute="top" secondItem="3tE-Zi-edS" secondAttribute="top" priority="999" constant="32" id="k9B-l0-1OW"/>
+                                <constraint firstItem="sc9-DH-ug9" firstAttribute="top" secondItem="3tE-Zi-edS" secondAttribute="top" priority="999" id="k9B-l0-1OW"/>
                             </constraints>
                         </customView>
                     </subviews>
@@ -224,6 +224,5 @@
     </objects>
     <resources>
         <image name="icon_simplenote_login" width="96" height="96"/>
-        <image name="icon_wp" width="32" height="32"/>
     </resources>
 </document>

--- a/Simplenote/AuthenticationMode.swift
+++ b/Simplenote/AuthenticationMode.swift
@@ -11,29 +11,32 @@ class AuthenticationMode: NSObject {
     let secondaryActionText: String?
     let secondaryActionSelector: Selector?
 
-    let switchActionText: String
-    let switchActionTip: String
     let switchTargetMode: () -> AuthenticationMode
     
     let isPasswordVisible: Bool
     let isSecondaryActionVisible: Bool
     let isWordPressVisible: Bool
-    let isSwitchVisible: Bool
     let showActionSeparator: Bool
 
-    init(primaryActionText: String, primaryActionAnimationText: String, primaryActionSelector: Selector, secondaryActionText: String?, secondaryActionSelector: Selector?, switchActionText: String, switchActionTip: String, switchTargetMode: @escaping () -> AuthenticationMode, isPasswordVisible: Bool, isSecondaryActionVisible: Bool, isWordPressVisible: Bool, isSwitchVisible: Bool, showActionSeparator: Bool) {
+    init(primaryActionText: String, 
+         primaryActionAnimationText: String,
+         primaryActionSelector: Selector,
+         secondaryActionText: String?,
+         secondaryActionSelector: Selector?,
+         switchTargetMode: @escaping () -> AuthenticationMode,
+         isPasswordVisible: Bool,
+         isSecondaryActionVisible: Bool,
+         isWordPressVisible: Bool,
+         showActionSeparator: Bool) {
         self.primaryActionText = primaryActionText
         self.primaryActionAnimationText =  primaryActionAnimationText
         self.primaryActionSelector = primaryActionSelector
         self.secondaryActionText = secondaryActionText
         self.secondaryActionSelector = secondaryActionSelector
-        self.switchActionText = switchActionText
-        self.switchActionTip = switchActionTip
         self.switchTargetMode = switchTargetMode
         self.isPasswordVisible = isPasswordVisible
         self.isSecondaryActionVisible = isSecondaryActionVisible
         self.isWordPressVisible = isWordPressVisible
-        self.isSwitchVisible = isSwitchVisible
         self.showActionSeparator = showActionSeparator
     }
 }
@@ -86,13 +89,10 @@ extension AuthenticationMode {
                            primaryActionSelector: #selector(AuthViewController.pressedLogInWithPassword),
                            secondaryActionText: LoginStrings.secondaryAction,
                            secondaryActionSelector: #selector(AuthViewController.openForgotPasswordURL),
-                           switchActionText: LoginStrings.switchAction,
-                           switchActionTip: LoginStrings.switchTip,
                            switchTargetMode: { .signup },
                            isPasswordVisible: true,
                            isSecondaryActionVisible: true,
                            isWordPressVisible: true,
-                           isSwitchVisible: false,
                            showActionSeparator: true)
     }
 
@@ -105,13 +105,10 @@ extension AuthenticationMode {
                            primaryActionSelector: #selector(AuthViewController.pressedLoginWithMagicLink),
                            secondaryActionText: MagicLinkStrings.secondaryAction,
                            secondaryActionSelector: #selector(AuthViewController.switchToPasswordAuth),
-                           switchActionText: MagicLinkStrings.switchAction,
-                           switchActionTip: MagicLinkStrings.switchTip,
                            switchTargetMode: { .signup },
                            isPasswordVisible: false,
                            isSecondaryActionVisible: true,
                            isWordPressVisible: true,
-                           isSwitchVisible: false,
                            showActionSeparator: true)
     }
 
@@ -124,13 +121,10 @@ extension AuthenticationMode {
                            primaryActionSelector: #selector(AuthViewController.pressedSignUp),
                            secondaryActionText: SignupStrings.switchAction,
                            secondaryActionSelector: #selector(AuthViewController.pushEmailLoginView),
-                           switchActionText: SignupStrings.switchAction,
-                           switchActionTip: SignupStrings.switchTip,
                            switchTargetMode: { .loginWithMagicLink },
                            isPasswordVisible: false,
                            isSecondaryActionVisible: true,
                            isWordPressVisible: false,
-                           isSwitchVisible: false,
                            showActionSeparator: false)
     }
 }

--- a/Simplenote/AuthenticationMode.swift
+++ b/Simplenote/AuthenticationMode.swift
@@ -19,8 +19,9 @@ class AuthenticationMode: NSObject {
     let isSecondaryActionVisible: Bool
     let isWordPressVisible: Bool
     let isSwitchVisible: Bool
+    let showActionSeparator: Bool
 
-    init(primaryActionText: String, primaryActionAnimationText: String, primaryActionSelector: Selector, secondaryActionText: String?, secondaryActionSelector: Selector?, switchActionText: String, switchActionTip: String, switchTargetMode: @escaping () -> AuthenticationMode, isPasswordVisible: Bool, isSecondaryActionVisible: Bool, isWordPressVisible: Bool, isSwitchVisible: Bool) {
+    init(primaryActionText: String, primaryActionAnimationText: String, primaryActionSelector: Selector, secondaryActionText: String?, secondaryActionSelector: Selector?, switchActionText: String, switchActionTip: String, switchTargetMode: @escaping () -> AuthenticationMode, isPasswordVisible: Bool, isSecondaryActionVisible: Bool, isWordPressVisible: Bool, isSwitchVisible: Bool, showActionSeparator: Bool) {
         self.primaryActionText = primaryActionText
         self.primaryActionAnimationText =  primaryActionAnimationText
         self.primaryActionSelector = primaryActionSelector
@@ -33,6 +34,7 @@ class AuthenticationMode: NSObject {
         self.isSecondaryActionVisible = isSecondaryActionVisible
         self.isWordPressVisible = isWordPressVisible
         self.isSwitchVisible = isSwitchVisible
+        self.showActionSeparator = showActionSeparator
     }
 }
 
@@ -90,7 +92,8 @@ extension AuthenticationMode {
                            isPasswordVisible: true,
                            isSecondaryActionVisible: true,
                            isWordPressVisible: true,
-                           isSwitchVisible: false)
+                           isSwitchVisible: false,
+                           showActionSeparator: true)
     }
 
     /// Auth Mode: Login is handled via Magic Links!
@@ -108,7 +111,8 @@ extension AuthenticationMode {
                            isPasswordVisible: false,
                            isSecondaryActionVisible: true,
                            isWordPressVisible: true,
-                           isSwitchVisible: false)
+                           isSwitchVisible: false,
+                           showActionSeparator: true)
     }
 
     /// Auth Mode: SignUp
@@ -118,15 +122,16 @@ extension AuthenticationMode {
         AuthenticationMode(primaryActionText: SignupStrings.primaryAction,
                            primaryActionAnimationText: SignupStrings.primaryAnimationText,
                            primaryActionSelector: #selector(AuthViewController.pressedSignUp),
-                           secondaryActionText: nil,
-                           secondaryActionSelector: nil,
+                           secondaryActionText: SignupStrings.switchAction,
+                           secondaryActionSelector: #selector(AuthViewController.pushEmailLoginView),
                            switchActionText: SignupStrings.switchAction,
                            switchActionTip: SignupStrings.switchTip,
                            switchTargetMode: { .loginWithMagicLink },
                            isPasswordVisible: false,
-                           isSecondaryActionVisible: false,
+                           isSecondaryActionVisible: true,
                            isWordPressVisible: false,
-                           isSwitchVisible: true)
+                           isSwitchVisible: false,
+                           showActionSeparator: false)
     }
 }
 

--- a/Simplenote/AuthenticationMode.swift
+++ b/Simplenote/AuthenticationMode.swift
@@ -59,7 +59,7 @@ extension AuthenticationMode {
     }
     
     var wordPressSSOFieldHeight: CGFloat {
-        isWordPressVisible ? CGFloat(72) : .zero
+        isWordPressVisible ? CGFloat(40) : .zero
     }
     
     var passwordFieldAlpha: CGFloat {

--- a/Simplenote/NSColor+Theme.swift
+++ b/Simplenote/NSColor+Theme.swift
@@ -237,6 +237,10 @@ extension NSColor {
     static var simplenotePreferencesDividerColor: NSColor {
         dynamicColor(lightStudio: .black, darkStudio: .white, lightColorAlpha: AppKitConstants.alpha0_1, darkColorAlpha: AppKitConstants.alpha0_1)
     }
+
+    static var simplenoteWPBlue50Color: NSColor {
+        NSColor(studioColor: .wpBlue50)
+    }
 }
 
 // MARK: - Internal Colors


### PR DESCRIPTION
### Fix
This is the first step in reshaping the SNMac authentication to meet the new designs using magic links as the primary mode of authentication.  

| signup view | login with email |
|--------|--------|
| <img src="https://cdn-std.droplr.net/files/acc_593859/6DyFm0"/> | <img src="https://cdn-std.droplr.net/files/acc_593859/yZj3qF" /> | 

In this PR I have done the following:
- Removed the switch mode button/view/actions
- changed the Sign in view -> login view button to use the secondary button as it's trigger
- refactored the ui for the sign in with WP button to match the design on iOS

What is not done here:
- solve the sizing problem when hitting the back button on the navigation controller
- Adding the next view where you can code auth or password auth
- refactor authentication mode to be more generic
These changes will be coming in the next PR

### Test
1. Launch SNMac, tap on the Login button and confirm the login with email view appears
2. click on the login with Wordpress button and confirm that still works
3. tap on the continue with password button and confirm the password appears
4. Attempt login with email, confirm that works
5.  attempt login with password, confirm that works

### Review
***(Required)*** Add instructions for reviewers.  For example:
> Only one developer is required to review these changes, but anyone can perform the review.

### Release
***(Required)*** Add a concise statement to `RELEASE-NOTES.txt` if the changes should be included in release notes. Include details about updating the notes in this section. For example:
> These changes do not require release notes.
