### PR TITLE
Magic Links: Refactor Authentication Mode to handle auth view definitions

### DIFF
--- a/Simplenote/AuthViewController+Swift.swift
+++ b/Simplenote/AuthViewController+Swift.swift
@@ -275,7 +275,7 @@ extension AuthViewController {
         //TODO: Set the constant somewhere else
         UserDefaults.standard.set(sessionsState, forKey: "SPAuthSessionKey")
 
-        let requestURL = NSString(format: SPWPSignInAuthURL as NSString, SPCredentials.wpcomClientID, SPCredentials.wpcomRedirectURL)
+        let requestURL = String(format: SPWPSignInAuthURL, SPCredentials.wpcomClientID, SPCredentials.wpcomRedirectURL, sessionsState)
         let encodedURL = requestURL.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)
         NSWorkspace.shared.open(URL(string: encodedURL!)!)
 

--- a/Simplenote/AuthViewController+Swift.swift
+++ b/Simplenote/AuthViewController+Swift.swift
@@ -137,7 +137,6 @@ extension AuthViewController {
 
         passwordField.alphaValue                = mode.passwordFieldAlpha
 
-        actionsSeparatorView.isHidden = !mode.showActionSeparator
         simplenoteTitleView.isHidden = !mode.isIntroView
         simplenoteSubTitleView.isHidden = !mode.isIntroView
 

--- a/Simplenote/AuthViewController+Swift.swift
+++ b/Simplenote/AuthViewController+Swift.swift
@@ -196,16 +196,6 @@ extension AuthViewController {
         return vc
     }
 
-    private func nextViewController() -> AuthViewController {
-        let nextMode = mode.nextMode()
-
-        let nextVC = AuthViewController()
-        nextVC.authenticator = authenticator
-        nextVC.mode = nextMode
-
-        return nextVC
-    }
-
     @objc
     func pushEmailLoginView() {
         containingNavigationController?.push(authViewController(with: .requestLoginCode))

--- a/Simplenote/AuthViewController+Swift.swift
+++ b/Simplenote/AuthViewController+Swift.swift
@@ -76,7 +76,7 @@ extension AuthViewController {
     func refreshInterface(animated: Bool) {
         clearAuthenticationError()
         refreshActionViews()
-        refreshEnabledComponents()
+        refreshInputViews()
         refreshVisibleComponents(animated: animated)
     }
 
@@ -99,20 +99,23 @@ extension AuthViewController {
             }
 
             if let title = descriptor.text {
-                let modifiedTitle = descriptor.name == .secondary ? title.uppercased() : title
-                actionView.title = modifiedTitle
+                actionView.title = title
             }
 
             actionView.action = descriptor.selector
+            actionView.target = self
             actionView.isHidden = false
             actionView.isEnabled = true
         }
     }
 
-    /// Makes sure unused components (in the current mode) are effectively disabled
-    ///
-    func refreshEnabledComponents() {
-        passwordField.isEnabled         = mode.isPasswordVisible
+    private func refreshInputViews() {
+        let inputElements = mode.inputElements
+
+        usernameField.isHidden          = !inputElements.contains(.username)
+        passwordField.isHidden          = !inputElements.contains(.password)
+        actionsSeparatorView.isHidden   = !inputElements.contains(.actionSeparator)
+
     }
 
     /// Shows / Hides relevant components, based on the specified state

--- a/Simplenote/AuthViewController+Swift.swift
+++ b/Simplenote/AuthViewController+Swift.swift
@@ -148,10 +148,8 @@ extension AuthViewController {
             context.duration = AppKitConstants.duration0_2
 
             passwordFieldHeightConstraint.animator().constant   = mode.passwordFieldHeight
-//            wordPressSSOHeightConstraint.animator().constant    = mode.wordPressSSOFieldHeight
 
             passwordField.alphaValue            = mode.passwordFieldAlpha
-//            wordPressSSOButton.alphaValue       = mode.wordPressSSOFieldAlpha
             
             view.layoutSubtreeIfNeeded()
         }

--- a/Simplenote/AuthViewController+Swift.swift
+++ b/Simplenote/AuthViewController+Swift.swift
@@ -24,11 +24,11 @@ extension AuthViewController {
         secondaryActionButton.contentTintColor = .simplenoteBrandColor
 
         // WordPress SSO
-        wordPressSSOButton.title = Localization.dotcomSSOAction
-        wordPressSSOButton.contentTintColor = .white
-        wordPressSSOContainerView.wantsLayer = true
-        wordPressSSOContainerView.layer?.backgroundColor = NSColor.simplenoteWPBlue50Color.cgColor
-        wordPressSSOContainerView.layer?.cornerRadius = 5
+
+        tertiaryButton.contentTintColor = .white
+        tertiaryButton.wantsLayer = true
+        tertiaryButton.layer?.backgroundColor = NSColor.simplenoteWPBlue50Color.cgColor
+        tertiaryButton.layer?.cornerRadius = 5
 
         setupActionsSeparatorView()
     }
@@ -64,7 +64,7 @@ extension AuthViewController {
     /// # All of the Action Views
     ///
     private var allActionViews: [NSButton] {
-        [actionButton, secondaryActionButton]
+        [actionButton, secondaryActionButton, tertiaryButton]
     }
 }
 
@@ -83,7 +83,8 @@ extension AuthViewController {
     private func refreshActionViews() {
         let viewMap: [AuthenticationActionName: NSButton] = [
             .primary: actionButton,
-            .secondary: secondaryActionButton
+            .secondary: secondaryActionButton,
+            .tertiary: tertiaryButton
         ]
 
         allActionViews.forEach({
@@ -112,7 +113,6 @@ extension AuthViewController {
     ///
     func refreshEnabledComponents() {
         passwordField.isEnabled         = mode.isPasswordVisible
-        wordPressSSOButton.isEnabled    = mode.isWordPressVisible
     }
 
     /// Shows / Hides relevant components, based on the specified state
@@ -131,10 +131,8 @@ extension AuthViewController {
     ///
     func refreshVisibleComponentsWithoutAnimation() {
         passwordFieldHeightConstraint.constant  = mode.passwordFieldHeight
-        wordPressSSOHeightConstraint.constant   = mode.wordPressSSOFieldHeight
 
         passwordField.alphaValue                = mode.passwordFieldAlpha
-        wordPressSSOButton.alphaValue           = mode.wordPressSSOFieldAlpha
 
         actionsSeparatorView.isHidden = !mode.showActionSeparator
         simplenoteTitleView.isHidden = !mode.isIntroView
@@ -150,10 +148,10 @@ extension AuthViewController {
             context.duration = AppKitConstants.duration0_2
 
             passwordFieldHeightConstraint.animator().constant   = mode.passwordFieldHeight
-            wordPressSSOHeightConstraint.animator().constant    = mode.wordPressSSOFieldHeight
+//            wordPressSSOHeightConstraint.animator().constant    = mode.wordPressSSOFieldHeight
 
             passwordField.alphaValue            = mode.passwordFieldAlpha
-            wordPressSSOButton.alphaValue       = mode.wordPressSSOFieldAlpha
+//            wordPressSSOButton.alphaValue       = mode.wordPressSSOFieldAlpha
             
             view.layoutSubtreeIfNeeded()
         }
@@ -280,7 +278,20 @@ extension AuthViewController {
             self.showAuthenticationError(forCode: statusCode, responseString: nil)
         }
     }
-    
+
+    @objc
+    func wordpressSSOAction() {
+        let sessionsState = "app-\(UUID().uuidString)"
+        //TODO: Set the constant somewhere else
+        UserDefaults.standard.set(sessionsState, forKey: "SPAuthSessionKey")
+
+        let requestURL = NSString(format: SPWPSignInAuthURL as NSString, SPCredentials.wpcomClientID, SPCredentials.wpcomRedirectURL)
+        let encodedURL = requestURL.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)
+        NSWorkspace.shared.open(URL(string: encodedURL!)!)
+
+        SPTracker.trackWPCCButtonPressed()
+    }
+
     @IBAction
     func handleNewlineInField(_ field: NSControl) {
         if field.isEqual(passwordField.textField) {
@@ -386,7 +397,6 @@ extension AuthViewController {
 private enum Localization {
     static let emailPlaceholder = NSLocalizedString("Email", comment: "Placeholder text for login field")
     static let passwordPlaceholder = NSLocalizedString("Password", comment: "Placeholder text for password field")
-    static let dotcomSSOAction = NSLocalizedString("Log in with WordPress.com", comment: "button title for wp.com sign in button")
     static let compromisedPasswordAlert = NSLocalizedString("Compromised Password", comment: "Compromised passsword alert title")
     static let compromisedPasswordMessage = NSLocalizedString("This password has appeared in a data breach, which puts your account at high risk of compromise. To protect your data, you'll need to update your password before being able to log in again.", comment: "Compromised password alert message")
     static let changePasswordAction = NSLocalizedString("Change Password", comment: "Change password action")

--- a/Simplenote/AuthViewController+Swift.swift
+++ b/Simplenote/AuthViewController+Swift.swift
@@ -272,8 +272,7 @@ extension AuthViewController {
     @objc
     func wordpressSSOAction() {
         let sessionsState = "app-\(UUID().uuidString)"
-        //TODO: Set the constant somewhere else
-        UserDefaults.standard.set(sessionsState, forKey: "SPAuthSessionKey")
+        UserDefaults.standard.set(sessionsState, forKey: .SPAuthSessionKey)
 
         let requestURL = String(format: SPWPSignInAuthURL, SPCredentials.wpcomClientID, SPCredentials.wpcomRedirectURL, sessionsState)
         let encodedURL = requestURL.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)

--- a/Simplenote/AuthViewController+Swift.swift
+++ b/Simplenote/AuthViewController+Swift.swift
@@ -86,7 +86,10 @@ extension AuthViewController {
             .secondary: secondaryActionButton
         ]
 
-        allActionViews.forEach({ $0.isHidden = true })
+        allActionViews.forEach({
+            $0.isHidden = true
+            $0.isEnabled = false
+        })
 
         for descriptor in mode.actions {
             guard let actionView = viewMap[descriptor.name] else {
@@ -101,6 +104,7 @@ extension AuthViewController {
 
             actionView.action = descriptor.selector
             actionView.isHidden = false
+            actionView.isEnabled = true
         }
     }
 
@@ -108,7 +112,6 @@ extension AuthViewController {
     ///
     func refreshEnabledComponents() {
         passwordField.isEnabled         = mode.isPasswordVisible
-        secondaryActionButton.isEnabled = mode.isSecondaryActionVisible
         wordPressSSOButton.isEnabled    = mode.isWordPressVisible
     }
 
@@ -128,11 +131,9 @@ extension AuthViewController {
     ///
     func refreshVisibleComponentsWithoutAnimation() {
         passwordFieldHeightConstraint.constant  = mode.passwordFieldHeight
-        secondaryActionHeightConstraint.constant = mode.secondaryActionFieldHeight
         wordPressSSOHeightConstraint.constant   = mode.wordPressSSOFieldHeight
 
         passwordField.alphaValue                = mode.passwordFieldAlpha
-        secondaryActionButton.alphaValue        = mode.secondaryActionFieldAlpha
         wordPressSSOButton.alphaValue           = mode.wordPressSSOFieldAlpha
 
         actionsSeparatorView.isHidden = !mode.showActionSeparator
@@ -149,11 +150,9 @@ extension AuthViewController {
             context.duration = AppKitConstants.duration0_2
 
             passwordFieldHeightConstraint.animator().constant   = mode.passwordFieldHeight
-            secondaryActionHeightConstraint.animator().constant = mode.secondaryActionFieldHeight
             wordPressSSOHeightConstraint.animator().constant    = mode.wordPressSSOFieldHeight
 
             passwordField.alphaValue            = mode.passwordFieldAlpha
-            secondaryActionButton.alphaValue    = mode.secondaryActionFieldAlpha
             wordPressSSOButton.alphaValue       = mode.wordPressSSOFieldAlpha
             
             view.layoutSubtreeIfNeeded()

--- a/Simplenote/AuthViewController+Swift.swift
+++ b/Simplenote/AuthViewController+Swift.swift
@@ -6,6 +6,9 @@ extension AuthViewController {
 
     @objc
     func setupInterface() {
+        simplenoteTitleView.stringValue = "Simplenote"
+        simplenoteSubTitleView.textColor = .simplenoteGray50Color
+        simplenoteSubTitleView.stringValue = NSLocalizedString("The simplest way to keep notes.", comment: "Simplenote subtitle")
         // Error Label
         errorField.stringValue = ""
         errorField.textColor = .red
@@ -108,6 +111,10 @@ extension AuthViewController {
         wordPressSSOButton.alphaValue           = mode.wordPressSSOFieldAlpha
 
         actionsSeparatorView.isHidden = !mode.showActionSeparator
+        simplenoteTitleView.isHidden = !mode.isIntroView
+        simplenoteSubTitleView.isHidden = !mode.isIntroView
+
+        headerLabel.isHidden = mode.header == nil
     }
 
     /// Animates Visible / Invisible components, based on the specified state
@@ -172,6 +179,14 @@ extension AuthViewController {
         performSelector(onMainThread: secondaryActionSelector, with: nil, waitUntilDone: false)
     }
 
+    private func authViewController(with mode: AuthenticationMode) -> AuthViewController {
+        let vc = AuthViewController()
+        vc.authenticator = authenticator
+        vc.mode = mode
+
+        return vc
+    }
+
     private func nextViewController() -> AuthViewController {
         let nextMode = mode.nextMode()
 
@@ -184,7 +199,12 @@ extension AuthViewController {
 
     @objc
     func pushEmailLoginView() {
-        containingNavigationController?.push(nextViewController())
+        containingNavigationController?.push(authViewController(with: .requestLoginCode))
+    }
+
+    @objc
+    func pushSignupView() {
+        containingNavigationController?.push(authViewController(with: .signup))
     }
 }
 
@@ -195,7 +215,7 @@ extension AuthViewController {
 
     @IBAction
     func switchToPasswordAuth(_ sender: Any) {
-        mode = .loginWithPassword
+        mode = AuthenticationMode.loginWithPassword(header: nil)
     }
     
     @objc

--- a/Simplenote/AuthViewController.h
+++ b/Simplenote/AuthViewController.h
@@ -20,8 +20,8 @@
 @property (nonatomic, strong) IBOutlet NSButton                     *actionButton;
 @property (nonatomic, strong) IBOutlet NSProgressIndicator          *actionProgress;
 @property (nonatomic, strong) IBOutlet NSButton                     *secondaryActionButton;
-@property (nonatomic, strong) IBOutlet NSView                       *wordPressSSOContainerView;
-@property (nonatomic, strong) IBOutlet NSButton                     *wordPressSSOButton;
+@property (nonatomic, strong) IBOutlet NSView                       *tertiaryButtonContainerView;
+@property (nonatomic, strong) IBOutlet NSButton                     *tertiaryButton;
 @property (weak) IBOutlet NSView *actionsSeparatorView;
 @property (weak) IBOutlet NSView *leadingSeparatorView;
 @property (weak) IBOutlet NSTextField *separatorLabel;

--- a/Simplenote/AuthViewController.h
+++ b/Simplenote/AuthViewController.h
@@ -11,6 +11,9 @@
 
 @property (nonatomic, strong) IBOutlet NSStackView                  *stackView;
 @property (nonatomic, strong) IBOutlet NSImageView                  *logoImageView;
+@property (nonatomic, strong) IBOutlet NSTextField *simplenoteTitleView;
+@property (nonatomic, strong) IBOutlet NSTextField *simplenoteSubTitleView;
+@property (nonatomic, strong) IBOutlet NSTextField *headerLabel;
 @property (nonatomic, strong) IBOutlet NSTextField                  *errorField;
 @property (nonatomic, strong) IBOutlet SPAuthenticationTextField    *usernameField;
 @property (nonatomic, strong) IBOutlet SPAuthenticationTextField    *passwordField;

--- a/Simplenote/AuthViewController.m
+++ b/Simplenote/AuthViewController.m
@@ -6,8 +6,6 @@
 
 #pragma mark - Constants
 
-static NSString *SPAuthSessionKey = @"SPAuthSessionKey";
-
 
 #pragma mark - Private
 

--- a/Simplenote/AuthViewController.m
+++ b/Simplenote/AuthViewController.m
@@ -81,24 +81,11 @@ static NSString *SPAuthSessionKey = @"SPAuthSessionKey";
     [self.passwordField setEnabled:enabled];
     [self.actionButton setEnabled:enabled];
     [self.secondaryActionButton setEnabled:enabled];
-    [self.wordPressSSOButton setEnabled:enabled];
+    [self.tertiaryButton setEnabled:enabled];
 }
 
 
 #pragma mark - WordPress SSO
-
-- (IBAction)wpccSignInAction:(id)sender
-{
-    NSString *sessionState = [[NSUUID UUID] UUIDString];
-    sessionState = [@"app-" stringByAppendingString:sessionState];
-    [[NSUserDefaults standardUserDefaults] setObject:sessionState forKey:SPAuthSessionKey];
-
-    NSString *requestUrl = [NSString stringWithFormat:SPWPSignInAuthURL, SPCredentials.wpcomClientID, SPCredentials.wpcomRedirectURL, sessionState];
-    NSString *encodedUrl = [requestUrl stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]];
-    [[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString:encodedUrl]];
-
-    [SPTracker trackWPCCButtonPressed];
-}
 
 - (IBAction)signInErrorAction:(NSNotification *)notification
 {

--- a/Simplenote/AuthViewController.m
+++ b/Simplenote/AuthViewController.m
@@ -29,7 +29,7 @@ static NSString *SPAuthSessionKey = @"SPAuthSessionKey";
 {
     if (self = [super init]) {
         self.validator = [SPAuthenticationValidator new];
-        self.mode = [AuthenticationMode signup];
+        self.mode = [AuthenticationMode onboarding];
     }
 
     return self;

--- a/Simplenote/AuthViewController.xib
+++ b/Simplenote/AuthViewController.xib
@@ -12,6 +12,7 @@
                 <outlet property="actionProgress" destination="GMB-3v-AEQ" id="Qv3-0X-3xO"/>
                 <outlet property="actionsSeparatorView" destination="WI9-SH-Yrp" id="SJl-TQ-htb"/>
                 <outlet property="errorField" destination="lwM-mh-i3o" id="hCf-XY-GKI"/>
+                <outlet property="headerLabel" destination="xA2-cU-2CM" id="fvc-Az-Hc1"/>
                 <outlet property="leadingSeparatorView" destination="4nP-3I-NOF" id="mKf-M6-kx7"/>
                 <outlet property="logoImageView" destination="W9h-HS-WbG" id="GV7-vy-NaT"/>
                 <outlet property="passwordField" destination="2bk-bk-VfG" id="JQn-Xi-XNs"/>
@@ -19,6 +20,8 @@
                 <outlet property="secondaryActionButton" destination="y1M-Np-v9m" id="z7i-Qa-Tye"/>
                 <outlet property="secondaryActionHeightConstraint" destination="HrL-ss-QSd" id="Vg3-A9-yCH"/>
                 <outlet property="separatorLabel" destination="xI6-bI-NiW" id="PA7-tE-0Od"/>
+                <outlet property="simplenoteSubTitleView" destination="OWk-yc-eau" id="fbz-WL-DUq"/>
+                <outlet property="simplenoteTitleView" destination="QdZ-0O-kg0" id="nKL-R9-joW"/>
                 <outlet property="stackView" destination="PWa-EY-51O" id="jUJ-sH-HgC"/>
                 <outlet property="trailingSeparatorView" destination="Uej-dg-hz2" id="UUI-he-9Xh"/>
                 <outlet property="usernameField" destination="Fco-3r-2Ys" id="qFA-HM-uFa"/>
@@ -31,19 +34,43 @@
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <view wantsLayer="YES" appearanceType="aqua" translatesAutoresizingMaskIntoConstraints="NO" id="kU7-kg-wG3" customClass="SPAuthenticationView">
-            <rect key="frame" x="0.0" y="0.0" width="380" height="536"/>
+            <rect key="frame" x="0.0" y="0.0" width="380" height="645"/>
             <subviews>
                 <stackView distribution="fill" orientation="vertical" alignment="centerX" spacing="12" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="PWa-EY-51O">
-                    <rect key="frame" x="30" y="45" width="320" height="446"/>
+                    <rect key="frame" x="30" y="45" width="320" height="555"/>
                     <subviews>
                         <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="W9h-HS-WbG">
-                            <rect key="frame" x="112" y="350" width="96" height="96"/>
+                            <rect key="frame" x="112" y="459" width="96" height="96"/>
                             <constraints>
                                 <constraint firstAttribute="width" constant="96" id="Sys-NN-iWa"/>
                                 <constraint firstAttribute="height" constant="96" id="mq9-yP-8Tc"/>
                             </constraints>
                             <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="icon_simplenote_login" id="2Fh-2C-hTH"/>
                         </imageView>
+                        <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="QdZ-0O-kg0" userLabel="simplenoteTitleLabel">
+                            <rect key="frame" x="129" y="409" width="62" height="38"/>
+                            <textFieldCell key="cell" lineBreakMode="clipping" alignment="center" title="title" id="qpG-DI-lUy">
+                                <font key="font" metaFont="systemMedium" size="32"/>
+                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                            </textFieldCell>
+                        </textField>
+                        <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="OWk-yc-eau" userLabel="simplenoteSubTitleLabel">
+                            <rect key="frame" x="129" y="378" width="62" height="19"/>
+                            <textFieldCell key="cell" lineBreakMode="clipping" alignment="center" title="subtitle" id="biC-yR-Nb8">
+                                <font key="font" metaFont="system" size="16"/>
+                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                            </textFieldCell>
+                        </textField>
+                        <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="xA2-cU-2CM" userLabel="headerLabel">
+                            <rect key="frame" x="134" y="350" width="53" height="16"/>
+                            <textFieldCell key="cell" lineBreakMode="clipping" alignment="center" title="Header" id="pyn-HV-JBL">
+                                <font key="font" metaFont="system"/>
+                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                            </textFieldCell>
+                        </textField>
                         <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="lwM-mh-i3o">
                             <rect key="frame" x="-2" y="322" width="324" height="16"/>
                             <constraints>
@@ -200,8 +227,14 @@
                         <integer value="1000"/>
                         <integer value="1000"/>
                         <integer value="1000"/>
+                        <integer value="1000"/>
+                        <integer value="1000"/>
+                        <integer value="1000"/>
                     </visibilityPriorities>
                     <customSpacing>
+                        <real value="3.4028234663852886e+38"/>
+                        <real value="3.4028234663852886e+38"/>
+                        <real value="3.4028234663852886e+38"/>
                         <real value="3.4028234663852886e+38"/>
                         <real value="3.4028234663852886e+38"/>
                         <real value="3.4028234663852886e+38"/>

--- a/Simplenote/AuthViewController.xib
+++ b/Simplenote/AuthViewController.xib
@@ -23,11 +23,11 @@
                 <outlet property="simplenoteSubTitleView" destination="OWk-yc-eau" id="fbz-WL-DUq"/>
                 <outlet property="simplenoteTitleView" destination="QdZ-0O-kg0" id="nKL-R9-joW"/>
                 <outlet property="stackView" destination="PWa-EY-51O" id="jUJ-sH-HgC"/>
+                <outlet property="tertiaryButton" destination="sc9-DH-ug9" id="gLe-Cv-8dc"/>
+                <outlet property="tertiaryButtonContainerView" destination="3tE-Zi-edS" id="TCK-Oi-0EO"/>
                 <outlet property="trailingSeparatorView" destination="Uej-dg-hz2" id="UUI-he-9Xh"/>
                 <outlet property="usernameField" destination="Fco-3r-2Ys" id="qFA-HM-uFa"/>
                 <outlet property="view" destination="kU7-kg-wG3" id="WH8-Qa-i4c"/>
-                <outlet property="wordPressSSOButton" destination="sc9-DH-ug9" id="bjJ-cB-cCj"/>
-                <outlet property="wordPressSSOContainerView" destination="3tE-Zi-edS" id="Nhq-OA-Rqf"/>
                 <outlet property="wordPressSSOHeightConstraint" destination="IW2-ZK-7lM" id="NWD-Sk-CYO"/>
             </connections>
         </customObject>
@@ -169,21 +169,18 @@
                                 <constraint firstItem="xI6-bI-NiW" firstAttribute="centerX" secondItem="WI9-SH-Yrp" secondAttribute="centerX" id="tJX-vD-jHm"/>
                             </constraints>
                         </customView>
-                        <customView wantsLayer="YES" translatesAutoresizingMaskIntoConstraints="NO" id="3tE-Zi-edS" userLabel="WordPress SSO View">
+                        <customView wantsLayer="YES" translatesAutoresizingMaskIntoConstraints="NO" id="3tE-Zi-edS" userLabel="Tertiary Button View">
                             <rect key="frame" x="0.0" y="0.0" width="320" height="40"/>
                             <subviews>
-                                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="sc9-DH-ug9" userLabel="WordPress SSO Button">
+                                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="sc9-DH-ug9" userLabel="Tertiary Button">
                                     <rect key="frame" x="0.0" y="0.0" width="320" height="40"/>
-                                    <buttonCell key="cell" type="bevel" title="[WordPress SSO]" bezelStyle="rounded" imagePosition="left" alignment="center" imageScaling="proportionallyDown" inset="2" id="Mzh-LI-XpK">
+                                    <buttonCell key="cell" type="bevel" title="Tertiary" bezelStyle="rounded" imagePosition="left" alignment="center" imageScaling="proportionallyDown" inset="2" id="Mzh-LI-XpK">
                                         <behavior key="behavior" lightByContents="YES"/>
                                         <font key="font" metaFont="system" size="16"/>
                                     </buttonCell>
                                     <constraints>
                                         <constraint firstAttribute="height" priority="999" constant="40" id="ynU-1V-xiN"/>
                                     </constraints>
-                                    <connections>
-                                        <action selector="wpccSignInAction:" target="-2" id="XuG-cb-poD"/>
-                                    </connections>
                                 </button>
                             </subviews>
                             <constraints>

--- a/Simplenote/AuthViewController.xib
+++ b/Simplenote/AuthViewController.xib
@@ -109,9 +109,6 @@
                                     <constraints>
                                         <constraint firstAttribute="height" constant="40" id="UVW-gz-8cN"/>
                                     </constraints>
-                                    <connections>
-                                        <action selector="performMainAction:" target="-2" id="t7F-Eu-cMm"/>
-                                    </connections>
                                 </button>
                                 <progressIndicator maxValue="100" displayedWhenStopped="NO" indeterminate="YES" controlSize="small" style="spinning" translatesAutoresizingMaskIntoConstraints="NO" id="GMB-3v-AEQ" userLabel="Main Action Progress Indicator">
                                     <rect key="frame" x="289" y="12" width="16" height="16"/>
@@ -135,9 +132,6 @@
                             <constraints>
                                 <constraint firstAttribute="height" constant="20" id="HrL-ss-QSd"/>
                             </constraints>
-                            <connections>
-                                <action selector="performSecondaryAction:" target="-2" id="hjL-sS-hbT"/>
-                            </connections>
                         </button>
                         <customView appearanceType="darkAqua" translatesAutoresizingMaskIntoConstraints="NO" id="WI9-SH-Yrp" userLabel="Actions Separator View">
                             <rect key="frame" x="0.0" y="52" width="320" height="44"/>

--- a/Simplenote/AuthenticationMode.swift
+++ b/Simplenote/AuthenticationMode.swift
@@ -1,18 +1,36 @@
 import Foundation
 
+// MARK: - Authentication Actions
+//
+enum AuthenticationActionName {
+    case primary
+    case secondary
+    case tertiary
+    case quaternary
+}
+
+struct AuthenticationActionDescriptor {
+    let name: AuthenticationActionName
+    let selector: Selector
+    let text: String?
+    let attributedText: NSAttributedString?
+
+    init(name: AuthenticationActionName, selector: Selector, text: String?, attributedText: NSAttributedString? = nil) {
+        self.name = name
+        self.selector = selector
+        self.text = text
+        self.attributedText = attributedText
+    }
+}
 
 // MARK: - AuthenticationMode
 //
 class AuthenticationMode: NSObject {
     let title: String
     let header: String?
+    let actions: [AuthenticationActionDescriptor]
 
-    let primaryActionText: String
     let primaryActionAnimationText: String
-    let primaryActionSelector: Selector
-    
-    let secondaryActionText: String?
-    let secondaryActionSelector: Selector?
 
     let switchTargetMode: () -> AuthenticationMode
     
@@ -24,11 +42,8 @@ class AuthenticationMode: NSObject {
 
     init(title: String,
          header: String? = nil,
-         primaryActionText: String,
+         actions: [AuthenticationActionDescriptor],
          primaryActionAnimationText: String,
-         primaryActionSelector: Selector,
-         secondaryActionText: String?,
-         secondaryActionSelector: Selector?,
          switchTargetMode: @escaping () -> AuthenticationMode,
          isPasswordVisible: Bool,
          isSecondaryActionVisible: Bool,
@@ -37,11 +52,8 @@ class AuthenticationMode: NSObject {
          isIntroView: Bool = false) {
         self.title = title
         self.header = header
-        self.primaryActionText = primaryActionText
+        self.actions = actions
         self.primaryActionAnimationText =  primaryActionAnimationText
-        self.primaryActionSelector = primaryActionSelector
-        self.secondaryActionText = secondaryActionText
-        self.secondaryActionSelector = secondaryActionSelector
         self.switchTargetMode = switchTargetMode
         self.isPasswordVisible = isPasswordVisible
         self.isSecondaryActionVisible = isSecondaryActionVisible
@@ -92,12 +104,16 @@ extension AuthenticationMode {
     @objc
     static var onboarding: AuthenticationMode {
         return AuthenticationMode(title: "Onboarding",
-                           header: nil,
-                           primaryActionText: SignupStrings.primaryAction,
+                                  header: nil,
+                                  actions: [
+                                    AuthenticationActionDescriptor(name: .primary,
+                                                                   selector: #selector(AuthViewController.pushSignupView),
+                                                                   text: SignupStrings.primaryAction),
+                                    AuthenticationActionDescriptor(name: .secondary,
+                                                                   selector: #selector(AuthViewController.pushEmailLoginView),
+                                                                   text: LoginStrings.primaryAction)
+                                  ],
                            primaryActionAnimationText: SignupStrings.primaryAnimationText,
-                           primaryActionSelector: #selector(AuthViewController.pushSignupView),
-                           secondaryActionText: LoginStrings.primaryAction,
-                           secondaryActionSelector: #selector(AuthViewController.pushEmailLoginView),
                            switchTargetMode: { .requestLoginCode }, isPasswordVisible: false,
                            isSecondaryActionVisible: true,
                            isWordPressVisible: false,
@@ -110,11 +126,15 @@ extension AuthenticationMode {
     static func loginWithPassword(header: String? = nil) -> AuthenticationMode {
         AuthenticationMode(title: NSLocalizedString("Log In with Password", comment: "LogIn Interface Title"),
                            header: header,
-                           primaryActionText: LoginStrings.primaryAction,
+                           actions: [
+                            AuthenticationActionDescriptor(name: .primary,
+                                                           selector: #selector(AuthViewController.pressedLogInWithPassword),
+                                                           text: LoginStrings.primaryAction),
+                            AuthenticationActionDescriptor(name: .secondary,
+                                                           selector: #selector(AuthViewController.openForgotPasswordURL),
+                                                           text: LoginStrings.secondaryAction)
+                           ],
                            primaryActionAnimationText: LoginStrings.primaryAnimationText,
-                           primaryActionSelector: #selector(AuthViewController.pressedLogInWithPassword),
-                           secondaryActionText: LoginStrings.secondaryAction,
-                           secondaryActionSelector: #selector(AuthViewController.openForgotPasswordURL),
                            switchTargetMode: { .signup },
                            isPasswordVisible: true,
                            isSecondaryActionVisible: true,
@@ -128,11 +148,15 @@ extension AuthenticationMode {
     @objc
     static var requestLoginCode: AuthenticationMode {
         AuthenticationMode(title: NSLocalizedString("Log In", comment: "LogIn Interface Title"),
-                           primaryActionText: MagicLinkStrings.primaryAction,
+                           actions: [
+                            AuthenticationActionDescriptor(name: .primary, 
+                                                           selector: #selector(AuthViewController.pressedLoginWithMagicLink),
+                                                           text: MagicLinkStrings.primaryAction),
+                            AuthenticationActionDescriptor(name: .secondary,
+                                                           selector: #selector(AuthViewController.switchToPasswordAuth),
+                                                           text: MagicLinkStrings.secondaryAction)
+                           ],
                            primaryActionAnimationText: MagicLinkStrings.primaryAnimationText,
-                           primaryActionSelector: #selector(AuthViewController.pressedLoginWithMagicLink),
-                           secondaryActionText: MagicLinkStrings.secondaryAction,
-                           secondaryActionSelector: #selector(AuthViewController.switchToPasswordAuth),
                            switchTargetMode: { .signup },
                            isPasswordVisible: false,
                            isSecondaryActionVisible: true,
@@ -145,11 +169,12 @@ extension AuthenticationMode {
     @objc
     static var signup: AuthenticationMode {
         AuthenticationMode(title: NSLocalizedString("Sign Up", comment: "SignUp Interface Title"),
-                           primaryActionText: SignupStrings.primaryAction,
+                           actions: [
+                            AuthenticationActionDescriptor(name: .primary,
+                                                           selector: #selector(AuthViewController.pressedSignUp),
+                                                           text: SignupStrings.primaryAction)
+                           ],
                            primaryActionAnimationText: SignupStrings.primaryAnimationText,
-                           primaryActionSelector: #selector(AuthViewController.pressedSignUp),
-                           secondaryActionText: SignupStrings.switchAction,
-                           secondaryActionSelector: #selector(AuthViewController.pushEmailLoginView),
                            switchTargetMode: { .requestLoginCode },
                            isPasswordVisible: false,
                            isSecondaryActionVisible: true,

--- a/Simplenote/AuthenticationMode.swift
+++ b/Simplenote/AuthenticationMode.swift
@@ -45,7 +45,6 @@ class AuthenticationMode: NSObject {
     let primaryActionAnimationText: String
     
     let isPasswordVisible: Bool
-    let showActionSeparator: Bool
     let isIntroView: Bool
 
     init(title: String,
@@ -54,7 +53,6 @@ class AuthenticationMode: NSObject {
          actions: [AuthenticationActionDescriptor],
          primaryActionAnimationText: String,
          isPasswordVisible: Bool,
-         showActionSeparator: Bool,
          isIntroView: Bool = false) {
         self.title = title
         self.header = header
@@ -62,7 +60,6 @@ class AuthenticationMode: NSObject {
         self.actions = actions
         self.primaryActionAnimationText =  primaryActionAnimationText
         self.isPasswordVisible = isPasswordVisible
-        self.showActionSeparator = showActionSeparator
         self.isIntroView = isIntroView
     }
 }
@@ -99,7 +96,6 @@ extension AuthenticationMode {
                                   ],
                                   primaryActionAnimationText: SignupStrings.primaryAnimationText,
                                   isPasswordVisible: false,
-                                  showActionSeparator: false,
                                   isIntroView: true)
     }
 
@@ -118,8 +114,7 @@ extension AuthenticationMode {
                                                            text: LoginStrings.secondaryAction)
                            ],
                            primaryActionAnimationText: LoginStrings.primaryAnimationText,
-                           isPasswordVisible: true,
-                           showActionSeparator: true)
+                           isPasswordVisible: true)
     }
 
     /// Auth Mode: Login is handled via Magic Links!
@@ -128,7 +123,7 @@ extension AuthenticationMode {
     @objc
     static var requestLoginCode: AuthenticationMode {
         AuthenticationMode(title: NSLocalizedString("Log In", comment: "LogIn Interface Title"),
-                           inputElements: [.username],
+                           inputElements: [.username, .actionSeparator],
                            actions: [
                             AuthenticationActionDescriptor(name: .primary, 
                                                            selector: #selector(AuthViewController.pressedLoginWithMagicLink),
@@ -140,8 +135,7 @@ extension AuthenticationMode {
                                                            selector: #selector(AuthViewController.wordpressSSOAction), text: LoginStrings.wordpressAction)
                            ],
                            primaryActionAnimationText: MagicLinkStrings.primaryAnimationText,
-                           isPasswordVisible: false,
-                           showActionSeparator: true)
+                           isPasswordVisible: false)
     }
 
     /// Auth Mode: SignUp
@@ -156,8 +150,7 @@ extension AuthenticationMode {
                                                            text: SignupStrings.primaryAction)
                            ],
                            primaryActionAnimationText: SignupStrings.primaryAnimationText,
-                           isPasswordVisible: false,
-                           showActionSeparator: false)
+                           isPasswordVisible: false)
     }
 }
 

--- a/Simplenote/AuthenticationMode.swift
+++ b/Simplenote/AuthenticationMode.swift
@@ -142,7 +142,9 @@ extension AuthenticationMode {
                                                            text: MagicLinkStrings.primaryAction),
                             AuthenticationActionDescriptor(name: .secondary,
                                                            selector: #selector(AuthViewController.switchToPasswordAuth),
-                                                           text: MagicLinkStrings.secondaryAction)
+                                                           text: MagicLinkStrings.secondaryAction),
+                            AuthenticationActionDescriptor(name: .tertiary,
+                                                           selector: #selector(AuthViewController.wordpressSSOAction), text: LoginStrings.wordpressAction)
                            ],
                            primaryActionAnimationText: MagicLinkStrings.primaryAnimationText,
                            switchTargetMode: { .signup },
@@ -178,6 +180,7 @@ private enum LoginStrings {
     static let secondaryAction      = NSLocalizedString("Forgot your Password?", comment: "Forgot Password Button")
     static let switchAction         = NSLocalizedString("Sign Up", comment: "Title of button for signing up")
     static let switchTip            = NSLocalizedString("Need an account?", comment: "Link to create an account")
+    static let wordpressAction      = NSLocalizedString("Log in with WordPress.com", comment: "Title to use wordpress login instead of email")
 }
 
 private enum MagicLinkStrings {

--- a/Simplenote/AuthenticationMode.swift
+++ b/Simplenote/AuthenticationMode.swift
@@ -43,8 +43,6 @@ class AuthenticationMode: NSObject {
     let actions: [AuthenticationActionDescriptor]
 
     let primaryActionAnimationText: String
-
-    let switchTargetMode: () -> AuthenticationMode
     
     let isPasswordVisible: Bool
     let isWordPressVisible: Bool
@@ -56,7 +54,6 @@ class AuthenticationMode: NSObject {
          inputElements: AuthenticationInputElements,
          actions: [AuthenticationActionDescriptor],
          primaryActionAnimationText: String,
-         switchTargetMode: @escaping () -> AuthenticationMode,
          isPasswordVisible: Bool,
          isWordPressVisible: Bool,
          showActionSeparator: Bool,
@@ -66,7 +63,6 @@ class AuthenticationMode: NSObject {
         self.inputElements = inputElements
         self.actions = actions
         self.primaryActionAnimationText =  primaryActionAnimationText
-        self.switchTargetMode = switchTargetMode
         self.isPasswordVisible = isPasswordVisible
         self.isWordPressVisible = isWordPressVisible
         self.showActionSeparator = showActionSeparator
@@ -77,11 +73,6 @@ class AuthenticationMode: NSObject {
 // MARK: - Dynamic Properties
 //
 extension AuthenticationMode {
-    
-    @objc
-    func nextMode() -> AuthenticationMode {
-        switchTargetMode()
-    }
     
     var passwordFieldHeight: CGFloat {
         isPasswordVisible ? CGFloat(40) : .zero
@@ -117,11 +108,10 @@ extension AuthenticationMode {
                                                                    selector: #selector(AuthViewController.pushEmailLoginView),
                                                                    text: LoginStrings.primaryAction.uppercased())
                                   ],
-
-                           primaryActionAnimationText: SignupStrings.primaryAnimationText,
-                           switchTargetMode: { .requestLoginCode }, isPasswordVisible: false,
-                           isWordPressVisible: false,
-                           showActionSeparator: false,
+                                  primaryActionAnimationText: SignupStrings.primaryAnimationText,
+                                  isPasswordVisible: false,
+                                  isWordPressVisible: false,
+                                  showActionSeparator: false,
                                   isIntroView: true)
     }
 
@@ -140,7 +130,6 @@ extension AuthenticationMode {
                                                            text: LoginStrings.secondaryAction)
                            ],
                            primaryActionAnimationText: LoginStrings.primaryAnimationText,
-                           switchTargetMode: { .signup },
                            isPasswordVisible: true,
                            isWordPressVisible: true,
                            showActionSeparator: true)
@@ -164,7 +153,6 @@ extension AuthenticationMode {
                                                            selector: #selector(AuthViewController.wordpressSSOAction), text: LoginStrings.wordpressAction)
                            ],
                            primaryActionAnimationText: MagicLinkStrings.primaryAnimationText,
-                           switchTargetMode: { .signup },
                            isPasswordVisible: false,
                            isWordPressVisible: true,
                            showActionSeparator: true)
@@ -182,7 +170,6 @@ extension AuthenticationMode {
                                                            text: SignupStrings.primaryAction)
                            ],
                            primaryActionAnimationText: SignupStrings.primaryAnimationText,
-                           switchTargetMode: { .requestLoginCode },
                            isPasswordVisible: false,
                            isWordPressVisible: false,
                            showActionSeparator: false)

--- a/Simplenote/AuthenticationMode.swift
+++ b/Simplenote/AuthenticationMode.swift
@@ -35,7 +35,6 @@ class AuthenticationMode: NSObject {
     let switchTargetMode: () -> AuthenticationMode
     
     let isPasswordVisible: Bool
-    let isSecondaryActionVisible: Bool
     let isWordPressVisible: Bool
     let showActionSeparator: Bool
     let isIntroView: Bool
@@ -46,7 +45,6 @@ class AuthenticationMode: NSObject {
          primaryActionAnimationText: String,
          switchTargetMode: @escaping () -> AuthenticationMode,
          isPasswordVisible: Bool,
-         isSecondaryActionVisible: Bool,
          isWordPressVisible: Bool,
          showActionSeparator: Bool,
          isIntroView: Bool = false) {
@@ -56,7 +54,6 @@ class AuthenticationMode: NSObject {
         self.primaryActionAnimationText =  primaryActionAnimationText
         self.switchTargetMode = switchTargetMode
         self.isPasswordVisible = isPasswordVisible
-        self.isSecondaryActionVisible = isSecondaryActionVisible
         self.isWordPressVisible = isWordPressVisible
         self.showActionSeparator = showActionSeparator
         self.isIntroView = isIntroView
@@ -76,10 +73,6 @@ extension AuthenticationMode {
         isPasswordVisible ? CGFloat(40) : .zero
     }
     
-    var secondaryActionFieldHeight: CGFloat {
-        isSecondaryActionVisible ? CGFloat(20) : .zero
-    }
-    
     var wordPressSSOFieldHeight: CGFloat {
         isWordPressVisible ? CGFloat(40) : .zero
     }
@@ -87,11 +80,7 @@ extension AuthenticationMode {
     var passwordFieldAlpha: CGFloat {
         isPasswordVisible ? AppKitConstants.alpha1_0 : AppKitConstants.alpha0_0
     }
-    
-    var secondaryActionFieldAlpha: CGFloat {
-        isSecondaryActionVisible ? AppKitConstants.alpha1_0 : AppKitConstants.alpha0_0
-    }
-    
+
     var wordPressSSOFieldAlpha: CGFloat {
         isWordPressVisible ? AppKitConstants.alpha1_0 : AppKitConstants.alpha0_0
     }
@@ -113,9 +102,9 @@ extension AuthenticationMode {
                                                                    selector: #selector(AuthViewController.pushEmailLoginView),
                                                                    text: LoginStrings.primaryAction)
                                   ],
+
                            primaryActionAnimationText: SignupStrings.primaryAnimationText,
                            switchTargetMode: { .requestLoginCode }, isPasswordVisible: false,
-                           isSecondaryActionVisible: true,
                            isWordPressVisible: false,
                            showActionSeparator: false,
                                   isIntroView: true)
@@ -137,7 +126,6 @@ extension AuthenticationMode {
                            primaryActionAnimationText: LoginStrings.primaryAnimationText,
                            switchTargetMode: { .signup },
                            isPasswordVisible: true,
-                           isSecondaryActionVisible: true,
                            isWordPressVisible: true,
                            showActionSeparator: true)
     }
@@ -159,7 +147,6 @@ extension AuthenticationMode {
                            primaryActionAnimationText: MagicLinkStrings.primaryAnimationText,
                            switchTargetMode: { .signup },
                            isPasswordVisible: false,
-                           isSecondaryActionVisible: true,
                            isWordPressVisible: true,
                            showActionSeparator: true)
     }
@@ -177,7 +164,6 @@ extension AuthenticationMode {
                            primaryActionAnimationText: SignupStrings.primaryAnimationText,
                            switchTargetMode: { .requestLoginCode },
                            isPasswordVisible: false,
-                           isSecondaryActionVisible: true,
                            isWordPressVisible: false,
                            showActionSeparator: false)
     }

--- a/Simplenote/AuthenticationMode.swift
+++ b/Simplenote/AuthenticationMode.swift
@@ -4,6 +4,9 @@ import Foundation
 // MARK: - AuthenticationMode
 //
 class AuthenticationMode: NSObject {
+    let title: String
+    let header: String?
+
     let primaryActionText: String
     let primaryActionAnimationText: String
     let primaryActionSelector: Selector
@@ -17,8 +20,11 @@ class AuthenticationMode: NSObject {
     let isSecondaryActionVisible: Bool
     let isWordPressVisible: Bool
     let showActionSeparator: Bool
+    let isIntroView: Bool
 
-    init(primaryActionText: String, 
+    init(title: String,
+         header: String? = nil,
+         primaryActionText: String,
          primaryActionAnimationText: String,
          primaryActionSelector: Selector,
          secondaryActionText: String?,
@@ -27,7 +33,10 @@ class AuthenticationMode: NSObject {
          isPasswordVisible: Bool,
          isSecondaryActionVisible: Bool,
          isWordPressVisible: Bool,
-         showActionSeparator: Bool) {
+         showActionSeparator: Bool,
+         isIntroView: Bool = false) {
+        self.title = title
+        self.header = header
         self.primaryActionText = primaryActionText
         self.primaryActionAnimationText =  primaryActionAnimationText
         self.primaryActionSelector = primaryActionSelector
@@ -38,6 +47,7 @@ class AuthenticationMode: NSObject {
         self.isSecondaryActionVisible = isSecondaryActionVisible
         self.isWordPressVisible = isWordPressVisible
         self.showActionSeparator = showActionSeparator
+        self.isIntroView = isIntroView
     }
 }
 
@@ -79,12 +89,28 @@ extension AuthenticationMode {
 // MARK: - Static Properties
 //
 extension AuthenticationMode {
-    
+    @objc
+    static var onboarding: AuthenticationMode {
+        return AuthenticationMode(title: "Onboarding",
+                           header: nil,
+                           primaryActionText: SignupStrings.primaryAction,
+                           primaryActionAnimationText: SignupStrings.primaryAnimationText,
+                           primaryActionSelector: #selector(AuthViewController.pushSignupView),
+                           secondaryActionText: LoginStrings.primaryAction,
+                           secondaryActionSelector: #selector(AuthViewController.pushEmailLoginView),
+                           switchTargetMode: { .requestLoginCode }, isPasswordVisible: false,
+                           isSecondaryActionVisible: true,
+                           isWordPressVisible: false,
+                           showActionSeparator: false,
+                                  isIntroView: true)
+    }
+
     /// Auth Mode: Login with Username + Password
     ///
-    @objc
-    static var loginWithPassword: AuthenticationMode {
-        AuthenticationMode(primaryActionText: LoginStrings.primaryAction,
+    static func loginWithPassword(header: String? = nil) -> AuthenticationMode {
+        AuthenticationMode(title: NSLocalizedString("Log In with Password", comment: "LogIn Interface Title"),
+                           header: header,
+                           primaryActionText: LoginStrings.primaryAction,
                            primaryActionAnimationText: LoginStrings.primaryAnimationText,
                            primaryActionSelector: #selector(AuthViewController.pressedLogInWithPassword),
                            secondaryActionText: LoginStrings.secondaryAction,
@@ -97,10 +123,12 @@ extension AuthenticationMode {
     }
 
     /// Auth Mode: Login is handled via Magic Links!
+    /// Requests a Login Code
     ///
     @objc
-    static var loginWithMagicLink: AuthenticationMode {
-        AuthenticationMode(primaryActionText: MagicLinkStrings.primaryAction,
+    static var requestLoginCode: AuthenticationMode {
+        AuthenticationMode(title: NSLocalizedString("Log In", comment: "LogIn Interface Title"),
+                           primaryActionText: MagicLinkStrings.primaryAction,
                            primaryActionAnimationText: MagicLinkStrings.primaryAnimationText,
                            primaryActionSelector: #selector(AuthViewController.pressedLoginWithMagicLink),
                            secondaryActionText: MagicLinkStrings.secondaryAction,
@@ -116,12 +144,13 @@ extension AuthenticationMode {
     ///
     @objc
     static var signup: AuthenticationMode {
-        AuthenticationMode(primaryActionText: SignupStrings.primaryAction,
+        AuthenticationMode(title: NSLocalizedString("Sign Up", comment: "SignUp Interface Title"),
+                           primaryActionText: SignupStrings.primaryAction,
                            primaryActionAnimationText: SignupStrings.primaryAnimationText,
                            primaryActionSelector: #selector(AuthViewController.pressedSignUp),
                            secondaryActionText: SignupStrings.switchAction,
                            secondaryActionSelector: #selector(AuthViewController.pushEmailLoginView),
-                           switchTargetMode: { .loginWithMagicLink },
+                           switchTargetMode: { .requestLoginCode },
                            isPasswordVisible: false,
                            isSecondaryActionVisible: true,
                            isWordPressVisible: false,

--- a/Simplenote/AuthenticationMode.swift
+++ b/Simplenote/AuthenticationMode.swift
@@ -1,5 +1,16 @@
 import Foundation
 
+// MARK: - Authentication Elements
+//
+struct AuthenticationInputElements: OptionSet, Hashable {
+    let rawValue: UInt
+
+    static let username         = AuthenticationInputElements(rawValue: 1 << 0)
+    static let password         = AuthenticationInputElements(rawValue: 1 << 1)
+    static let code             = AuthenticationInputElements(rawValue: 1 << 2)
+    static let actionSeparator  = AuthenticationInputElements(rawValue: 1 << 3)
+}
+
 // MARK: - Authentication Actions
 //
 enum AuthenticationActionName {
@@ -28,6 +39,7 @@ struct AuthenticationActionDescriptor {
 class AuthenticationMode: NSObject {
     let title: String
     let header: String?
+    let inputElements: AuthenticationInputElements
     let actions: [AuthenticationActionDescriptor]
 
     let primaryActionAnimationText: String
@@ -41,6 +53,7 @@ class AuthenticationMode: NSObject {
 
     init(title: String,
          header: String? = nil,
+         inputElements: AuthenticationInputElements,
          actions: [AuthenticationActionDescriptor],
          primaryActionAnimationText: String,
          switchTargetMode: @escaping () -> AuthenticationMode,
@@ -50,6 +63,7 @@ class AuthenticationMode: NSObject {
          isIntroView: Bool = false) {
         self.title = title
         self.header = header
+        self.inputElements = inputElements
         self.actions = actions
         self.primaryActionAnimationText =  primaryActionAnimationText
         self.switchTargetMode = switchTargetMode
@@ -94,13 +108,14 @@ extension AuthenticationMode {
     static var onboarding: AuthenticationMode {
         return AuthenticationMode(title: "Onboarding",
                                   header: nil,
+                                  inputElements: [],
                                   actions: [
                                     AuthenticationActionDescriptor(name: .primary,
                                                                    selector: #selector(AuthViewController.pushSignupView),
                                                                    text: SignupStrings.primaryAction),
                                     AuthenticationActionDescriptor(name: .secondary,
                                                                    selector: #selector(AuthViewController.pushEmailLoginView),
-                                                                   text: LoginStrings.primaryAction)
+                                                                   text: LoginStrings.primaryAction.uppercased())
                                   ],
 
                            primaryActionAnimationText: SignupStrings.primaryAnimationText,
@@ -115,6 +130,7 @@ extension AuthenticationMode {
     static func loginWithPassword(header: String? = nil) -> AuthenticationMode {
         AuthenticationMode(title: NSLocalizedString("Log In with Password", comment: "LogIn Interface Title"),
                            header: header,
+                           inputElements: [.username, .password],
                            actions: [
                             AuthenticationActionDescriptor(name: .primary,
                                                            selector: #selector(AuthViewController.pressedLogInWithPassword),
@@ -136,6 +152,7 @@ extension AuthenticationMode {
     @objc
     static var requestLoginCode: AuthenticationMode {
         AuthenticationMode(title: NSLocalizedString("Log In", comment: "LogIn Interface Title"),
+                           inputElements: [.username],
                            actions: [
                             AuthenticationActionDescriptor(name: .primary, 
                                                            selector: #selector(AuthViewController.pressedLoginWithMagicLink),
@@ -158,6 +175,7 @@ extension AuthenticationMode {
     @objc
     static var signup: AuthenticationMode {
         AuthenticationMode(title: NSLocalizedString("Sign Up", comment: "SignUp Interface Title"),
+                           inputElements: [.username],
                            actions: [
                             AuthenticationActionDescriptor(name: .primary,
                                                            selector: #selector(AuthViewController.pressedSignUp),

--- a/Simplenote/AuthenticationMode.swift
+++ b/Simplenote/AuthenticationMode.swift
@@ -45,7 +45,6 @@ class AuthenticationMode: NSObject {
     let primaryActionAnimationText: String
     
     let isPasswordVisible: Bool
-    let isWordPressVisible: Bool
     let showActionSeparator: Bool
     let isIntroView: Bool
 
@@ -55,7 +54,6 @@ class AuthenticationMode: NSObject {
          actions: [AuthenticationActionDescriptor],
          primaryActionAnimationText: String,
          isPasswordVisible: Bool,
-         isWordPressVisible: Bool,
          showActionSeparator: Bool,
          isIntroView: Bool = false) {
         self.title = title
@@ -64,7 +62,6 @@ class AuthenticationMode: NSObject {
         self.actions = actions
         self.primaryActionAnimationText =  primaryActionAnimationText
         self.isPasswordVisible = isPasswordVisible
-        self.isWordPressVisible = isWordPressVisible
         self.showActionSeparator = showActionSeparator
         self.isIntroView = isIntroView
     }
@@ -77,17 +74,9 @@ extension AuthenticationMode {
     var passwordFieldHeight: CGFloat {
         isPasswordVisible ? CGFloat(40) : .zero
     }
-    
-    var wordPressSSOFieldHeight: CGFloat {
-        isWordPressVisible ? CGFloat(40) : .zero
-    }
-    
+
     var passwordFieldAlpha: CGFloat {
         isPasswordVisible ? AppKitConstants.alpha1_0 : AppKitConstants.alpha0_0
-    }
-
-    var wordPressSSOFieldAlpha: CGFloat {
-        isWordPressVisible ? AppKitConstants.alpha1_0 : AppKitConstants.alpha0_0
     }
 }
 
@@ -110,7 +99,6 @@ extension AuthenticationMode {
                                   ],
                                   primaryActionAnimationText: SignupStrings.primaryAnimationText,
                                   isPasswordVisible: false,
-                                  isWordPressVisible: false,
                                   showActionSeparator: false,
                                   isIntroView: true)
     }
@@ -131,7 +119,6 @@ extension AuthenticationMode {
                            ],
                            primaryActionAnimationText: LoginStrings.primaryAnimationText,
                            isPasswordVisible: true,
-                           isWordPressVisible: true,
                            showActionSeparator: true)
     }
 
@@ -154,7 +141,6 @@ extension AuthenticationMode {
                            ],
                            primaryActionAnimationText: MagicLinkStrings.primaryAnimationText,
                            isPasswordVisible: false,
-                           isWordPressVisible: true,
                            showActionSeparator: true)
     }
 
@@ -171,7 +157,6 @@ extension AuthenticationMode {
                            ],
                            primaryActionAnimationText: SignupStrings.primaryAnimationText,
                            isPasswordVisible: false,
-                           isWordPressVisible: false,
                            showActionSeparator: false)
     }
 }

--- a/Simplenote/NSColor+Theme.swift
+++ b/Simplenote/NSColor+Theme.swift
@@ -241,6 +241,10 @@ extension NSColor {
     static var simplenoteWPBlue50Color: NSColor {
         NSColor(studioColor: .wpBlue50)
     }
+
+    static var simplenoteGray50Color: NSColor {
+        NSColor(studioColor: .gray50)
+    }
 }
 
 // MARK: - Internal Colors

--- a/Simplenote/UserDefaults+Simplenote.swift
+++ b/Simplenote/UserDefaults+Simplenote.swift
@@ -15,6 +15,7 @@ extension UserDefaults {
         case themeName = "VSThemeManagerThemePrefKey"
         case fontSize = "kFontSizePreferencesKey"
         case indexNotesForSpotlight
+        case SPAuthSessionKey
     }
 }
 


### PR DESCRIPTION
### Fix
Primarily this PR doesn't do much that is visible, but it is laying the ground work to continuing updating the auth views to the new designs and layouts, so we can add magic links.  

So in this PR I have:
- Added defining the buttons on different views using an action descriptor struct
- Updated the existing views to use the new action descriptor structs
- dropped existing primary/secondary/wordpress properties and definitions from Auth mode

This shouldn't look too much different from the current state of the auth views, but because so many things have moved around here we should confirm that it all still works.

### Test
1. Launch Simplenote Mac
2. Confirm that the launch screen now has no fields on it and looks more like the iOS launch screen
3. Tap on sign up and confirm that the screen that appears is for signup.  Test that you can create an account
4. Tap on login and confirm you are given the option to login with email.  Test that login still works
5. Confirm on the login screen that you can tap on the secondary button to reveal the password field.  Confirm you can login with a password
6. Confirm on the login screen that the Wordpress SSO button is there and that if you tap on it the Wordpress sign on appears in your browser

### Review
***(Required)*** Add instructions for reviewers.  For example:
> Only one developer is required to review these changes, but anyone can perform the review.

### Release
> These changes do not require release notes.
