### PR TITLE
Navigation Bar: Polishing Animation

### DIFF
--- a/Simplenote/SPNavigationController.swift
+++ b/Simplenote/SPNavigationController.swift
@@ -85,8 +85,12 @@ class SPNavigationController: NSViewController {
         let currentView = topViewController?.view
 
         attach(child: viewController)
-        if let currentView {
-            currentView.removeConstraints(currentView.constraints)
+        
+        /// Disable Bottom Constraint
+        /// This allows for the enclosing NSWindow to resize, just enough to fit the `nextViewController.view`
+        ///
+        if let currentView, let bottomConstraint = view.firstContraint(firstView: currentView, firstAttribute: .bottom) {
+            bottomConstraint.isActive = false
         }
 
         guard let (leadingAnchor, trailingAnchor) = attachView(subview: viewController.view, below: currentView) else {
@@ -138,6 +142,13 @@ class SPNavigationController: NSViewController {
     func popViewController() {
         guard viewStack.count > 1, let currentViewController = viewStack.popLast(), let nextViewController = viewStack.last else {
             return
+        }
+        
+        /// Disable Bottom Constraint
+        /// This allows for the enclosing NSWindow to resize, just enough to fit the `nextViewController.view`
+        ///
+        if let currentBottomConstraint = view.firstContraint(firstView: currentViewController.view, firstAttribute: .bottom) {
+            currentBottomConstraint.isActive = false
         }
   
         attachView(subview: nextViewController.view, below: currentViewController.view)

--- a/Simplenote/SPNavigationController.swift
+++ b/Simplenote/SPNavigationController.swift
@@ -38,12 +38,19 @@ class SPNavigationController: NSViewController {
         initialView.translatesAutoresizingMaskIntoConstraints = false
 
         view.addSubview(initialView)
+        
+        /// "Hint" we wanna occupy as little as possible. This constraint is meant to be broken, but the layout system will
+        /// attempt to reduce the Height, when possible
+        ///
+        let minimumHeightConstraint = view.heightAnchor.constraint(equalToConstant: .zero)
+        minimumHeightConstraint.priority = .init(1)
 
         NSLayoutConstraint.activate([
             initialView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             initialView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             initialView.topAnchor.constraint(equalTo: backButton.bottomAnchor),
-            initialView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+            initialView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            minimumHeightConstraint
         ])
     }
 

--- a/Simplenote/SPNavigationController.swift
+++ b/Simplenote/SPNavigationController.swift
@@ -7,8 +7,6 @@ class SPNavigationController: NSViewController {
     private var viewStack: [NSViewController] = []
     private var backButton: NSButton!
 
-    private var backButtonHeightConstraint: NSLayoutConstraint!
-
     var hideBackButton: Bool {
         viewStack.count < 2
     }
@@ -59,12 +57,11 @@ class SPNavigationController: NSViewController {
         button.bezelStyle = .accessoryBarAction
 
         view.addSubview(backButton)
-        backButtonHeightConstraint = backButton.heightAnchor.constraint(equalToConstant: 0)
         NSLayoutConstraint.activate([
             backButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 10),
             backButton.topAnchor.constraint(equalTo: view.topAnchor, constant: 30),
             backButton.widthAnchor.constraint(equalToConstant: 50),
-            backButtonHeightConstraint
+            backButton.heightAnchor.constraint(equalToConstant: 30)
         ])
 
         return button
@@ -175,7 +172,6 @@ class SPNavigationController: NSViewController {
             fadingView?.animator().alphaValue = alpha
             leadingConstraint.animator().constant += view.frame.width * multiplier
             trailingConstraint.animator().constant += view.frame.width * multiplier
-            backButtonHeightConstraint.animator().constant = hideBackButton ? 0 : 30
             backButton.animator().isHidden = hideBackButton
         } completionHandler: {
             onCompletion()

--- a/Simplenote/SPNavigationController.swift
+++ b/Simplenote/SPNavigationController.swift
@@ -82,7 +82,7 @@ class SPNavigationController: NSViewController {
             currentView.removeConstraints(currentView.constraints)
         }
 
-        guard let (leadingAnchor, trailingAnchor) = attachView(subview: viewController.view, currentView: currentView) else {
+        guard let (leadingAnchor, trailingAnchor) = attachView(subview: viewController.view, below: currentView) else {
             return
         }
 
@@ -104,12 +104,13 @@ class SPNavigationController: NSViewController {
     }
 
     @discardableResult
-    private func attachView(subview: NSView, currentView: NSView?, behindCurrent: Bool = false) -> (leading: NSLayoutConstraint, trailing: NSLayoutConstraint)? {
-        if behindCurrent {
-            view.addSubview(subview, positioned: .below, relativeTo: currentView)
+    private func attachView(subview: NSView, below siblingView: NSView?) -> (leading: NSLayoutConstraint, trailing: NSLayoutConstraint)? {
+        if let siblingView {
+            view.addSubview(subview, positioned: .below, relativeTo: siblingView)
         } else {
             view.addSubview(subview)
         }
+
         subview.translatesAutoresizingMaskIntoConstraints = false
 
         let leadingAnchor = subview.leadingAnchor.constraint(equalTo: view.leadingAnchor)
@@ -136,9 +137,9 @@ class SPNavigationController: NSViewController {
         guard let nextViewController = viewStack.last else {
             return
         }
-
-        attachView(subview: nextViewController.view, currentView: currentViewController.view, behindCurrent: true)
-
+  
+        attachView(subview: nextViewController.view, below: currentViewController.view)
+        
         animateTransition(slidingView: currentViewController.view, fadingView: nextViewController.view, direction: .leadingToTrailing) {
             self.dettach(child: currentViewController)
         }

--- a/Simplenote/SPNavigationController.swift
+++ b/Simplenote/SPNavigationController.swift
@@ -129,12 +129,7 @@ class SPNavigationController: NSViewController {
 
     // MARK: - Remove view from stack
     func popViewController() {
-        guard viewStack.count > 1 else {
-            return
-        }
-
-        let currentViewController = viewStack.removeLast()
-        guard let nextViewController = viewStack.last else {
+        guard viewStack.count > 1, let currentViewController = viewStack.popLast(), let nextViewController = viewStack.last else {
             return
         }
   


### PR DESCRIPTION
### Fix
In this PR we're polishing the Navigation Bar UX:

- `Back` will no longer shrink its height. This was resulting in a different top padding in the initial UI
- Polished the resize animation, when either increasing or reducing the height
- Simplified a tiny bit a couple API(s)

Ref. #1187 


### Test
1. Fresh install Simplenote macOS

- [x] Verify that if you click on `Log In`, the animation looks great
- [x] Verify that if you click on the `Back` button, there are no jumps, and the animation feels on spot
- [x] Verify that if you go back to `Log In` and click on `Continue with password`, everything looks good
- [x] Verify that if you click on `Back`, you end up in the initial UI

### Release
> These changes do not require release notes.
