### PR TITLE
Magic Links: Implement Code view and Password view

### DIFF
--- a/Simplenote/AuthViewController+Swift.swift
+++ b/Simplenote/AuthViewController+Swift.swift
@@ -299,6 +299,12 @@ extension AuthViewController {
             setInterfaceEnabled(true)
         }
 
+        clearAuthenticationError()
+
+        if !validateCode() {
+            return
+        }
+
         startActionAnimation()
         setInterfaceEnabled(false)
 

--- a/Simplenote/AuthViewController+Swift.swift
+++ b/Simplenote/AuthViewController+Swift.swift
@@ -311,7 +311,7 @@ extension AuthViewController {
 
     @IBAction
     func handleNewlineInField(_ field: NSControl) {
-        if field.isEqual(passwordField.textField) {
+        if shouldHandleNewLine(in: field) {
             guard let primaryActionDescriptor = mode.actions.first(where: { $0.name == .primary }) else {
                 assertionFailure()
                 return
@@ -320,6 +320,10 @@ extension AuthViewController {
             performSelector(onMainThread: primaryActionDescriptor.selector, with: nil, waitUntilDone: false)
             return
         }
+    }
+
+    func shouldHandleNewLine(in field: NSControl) -> Bool {
+        field.isEqual(usernameField.textField) || field.isEqual(passwordField.textField) || field.isEqual(codeTextField.textField)
     }
 
     @objc

--- a/Simplenote/AuthViewController+Swift.swift
+++ b/Simplenote/AuthViewController+Swift.swift
@@ -41,6 +41,7 @@ extension AuthViewController {
         quarternaryButtonView.layer?.borderWidth = 1
         quarternaryButtonView.layer?.borderColor = .black
         quarternaryButtonView.layer?.cornerRadius = 5
+        quarternaryButton.contentTintColor = .black
 
         actionProgress.set(tintColor: .white)
 

--- a/Simplenote/AuthViewController+Swift.swift
+++ b/Simplenote/AuthViewController+Swift.swift
@@ -283,9 +283,9 @@ extension AuthViewController {
 
 
         do {
-//            let email = usernameText
-//            let remote = LoginRemote()
-//            try await remote.requestLoginEmail(email: email)
+            let email = usernameText
+            let remote = LoginRemote()
+            try await remote.requestLoginEmail(email: email)
 
             pushCodeLoginView()
         } catch {

--- a/Simplenote/AuthViewController+Swift.swift
+++ b/Simplenote/AuthViewController+Swift.swift
@@ -42,6 +42,8 @@ extension AuthViewController {
         quarternaryButtonView.layer?.borderColor = .black
         quarternaryButtonView.layer?.cornerRadius = 5
 
+        actionProgress.set(tintColor: .white)
+
         setupActionsSeparatorView()
         setupAdditionalButtons()
         setupLabels()
@@ -275,15 +277,15 @@ extension AuthViewController {
             stopActionAnimation()
             setInterfaceEnabled(true)
         }
-        
+
         startActionAnimation()
         setInterfaceEnabled(false)
 
 
         do {
-            let email = usernameText
-            let remote = LoginRemote()
-            try await remote.requestLoginEmail(email: email)
+//            let email = usernameText
+//            let remote = LoginRemote()
+//            try await remote.requestLoginEmail(email: email)
 
             pushCodeLoginView()
         } catch {

--- a/Simplenote/AuthViewController+Swift.swift
+++ b/Simplenote/AuthViewController+Swift.swift
@@ -354,8 +354,7 @@ extension AuthViewController {
 
     @objc
     func stopActionAnimation() {
-        //TODO: Fix animating title changes
-//        actionButton.title = mode.primaryActionText
+        actionButton.title = mode.action(withName: .primary)?.text ?? String()
         actionProgress.stopAnimation(nil)
     }
 }

--- a/Simplenote/AuthViewController+Swift.swift
+++ b/Simplenote/AuthViewController+Swift.swift
@@ -230,7 +230,7 @@ extension AuthViewController {
 
     @objc
     func pushPasswordView() {
-        //TODO: Present password view
+        containingNavigationController?.push(authViewController(with: .loginWithPassword(), state: state))
     }
 
     func pushCodeLoginView() {
@@ -327,7 +327,7 @@ extension AuthViewController {
 
     @objc
     func performLogInWithCode() {
-
+        //TODO: Add login with code
     }
 
     @IBAction

--- a/Simplenote/AuthViewController+Swift.swift
+++ b/Simplenote/AuthViewController+Swift.swift
@@ -44,6 +44,7 @@ extension AuthViewController {
 
         setupActionsSeparatorView()
         setupAdditionalButtons()
+        setupLabels()
     }
 
     private func setupActionsSeparatorView() {
@@ -60,6 +61,13 @@ extension AuthViewController {
 
         tertiaryButtonContainerView.isHidden = !modeActions.contains(where: { $0.name == .tertiary })
         quarternaryButtonView.isHidden = !modeActions.contains(where: { $0.name == .quaternary })
+    }
+
+    private func setupLabels() {
+        simplenoteTitleView.isHidden = !mode.isIntroView
+        simplenoteSubTitleView.isHidden = !mode.isIntroView
+
+        headerLabel.isHidden = mode.header == nil
     }
 }
 
@@ -92,12 +100,11 @@ extension AuthViewController {
 //
 extension AuthViewController {
 
-    @objc(refreshInterfaceWithAnimation:)
-    func refreshInterface(animated: Bool) {
+    @objc(refreshInterface)
+    func refreshInterface() {
         clearAuthenticationError()
         refreshActionViews()
         refreshInputViews()
-        refreshVisibleComponents(animated: animated)
     }
 
     private func refreshActionViews() {
@@ -140,45 +147,6 @@ extension AuthViewController {
 
     }
 
-    /// Shows / Hides relevant components, based on the specified state
-    ///
-    func refreshVisibleComponents(animated: Bool) {
-        if animated {
-            refreshVisibleComponentsWithAnimation()
-        } else {
-            refreshVisibleComponentsWithoutAnimation()
-        }
-    }
-
-    /// Shows / Hides relevant components, based on the specified state
-    /// - Note: Trust me on this one. It's cleaner to have specific methods, rather than making a single one support the `animated` flag.
-    ///         Notice that AppKit requires us to go thru `animator()`.
-    ///
-    func refreshVisibleComponentsWithoutAnimation() {
-        passwordFieldHeightConstraint.constant  = mode.passwordFieldHeight
-
-        passwordField.alphaValue                = mode.passwordFieldAlpha
-
-        simplenoteTitleView.isHidden = !mode.isIntroView
-        simplenoteSubTitleView.isHidden = !mode.isIntroView
-
-        headerLabel.isHidden = mode.header == nil
-    }
-
-    /// Animates Visible / Invisible components, based on the specified state
-    ///
-    func refreshVisibleComponentsWithAnimation() {
-        NSAnimationContext.runAnimationGroup { context in
-            context.duration = AppKitConstants.duration0_2
-
-            passwordFieldHeightConstraint.animator().constant   = mode.passwordFieldHeight
-
-            passwordField.alphaValue            = mode.passwordFieldAlpha
-            
-            view.layoutSubtreeIfNeeded()
-        }
-    }
-
     /// Drops any Errors onscreen
     ///
     @objc
@@ -205,7 +173,7 @@ extension AuthViewController {
             return
         }
 
-        refreshInterface(animated: true)
+        refreshInterface()
         ensureUsernameIsFirstResponder()
     }
 

--- a/Simplenote/AuthViewController+Swift.swift
+++ b/Simplenote/AuthViewController+Swift.swift
@@ -302,7 +302,15 @@ extension AuthViewController {
     }
 
     @MainActor
-    func loginWithCode(username: String, code: String) async throws {
+    func loginWithCode(username: String, code: String) async {
+        defer {
+            stopActionAnimation()
+            setInterfaceEnabled(true)
+        }
+
+        startActionAnimation()
+        setInterfaceEnabled(false)
+
         let remote = LoginRemote()
 
         do {
@@ -327,7 +335,9 @@ extension AuthViewController {
 
     @objc
     func performLogInWithCode() {
-        //TODO: Add login with code
+        Task {
+            await loginWithCode(username: state.username, code: state.code)
+        }
     }
 
     @IBAction
@@ -356,7 +366,7 @@ extension AuthViewController {
         case passwordField:
             state.password = passwordField.stringValue
         case codeTextField:
-            state.code = passwordField.stringValue
+            state.code = codeTextField.stringValue
         default:
             return
         }

--- a/Simplenote/AuthViewController+Swift.swift
+++ b/Simplenote/AuthViewController+Swift.swift
@@ -38,7 +38,7 @@ extension AuthViewController {
 
         // quarternary button
         quarternaryButtonView.wantsLayer = true
-        quarternaryButtonView.layer?.borderWidth = 2
+        quarternaryButtonView.layer?.borderWidth = 1
         quarternaryButtonView.layer?.borderColor = .black
         quarternaryButtonView.layer?.cornerRadius = 5
 

--- a/Simplenote/AuthViewController+Swift.swift
+++ b/Simplenote/AuthViewController+Swift.swift
@@ -69,6 +69,10 @@ extension AuthViewController {
 
         headerLabel.isHidden = mode.header == nil
     }
+
+    open override func viewDidAppear() {
+        ensureFirstTextFieldIsFirstResponder()
+    }
 }
 
 // MARK: - Dynamic Properties
@@ -93,6 +97,14 @@ extension AuthViewController {
     ///
     private var allActionViews: [NSButton] {
         [actionButton, secondaryActionButton, tertiaryButton, quarternaryButton]
+    }
+
+    private var allInputViews: [SPAuthenticationTextField] {
+        [usernameField, passwordField, codeTextField]
+    }
+
+    private var firstVisibleTextField: SPAuthenticationTextField? {
+        allInputViews.first(where: { $0.isHidden == false })
     }
 }
 
@@ -157,8 +169,8 @@ extension AuthViewController {
     /// Marks the Username Field as the First Responder
     ///
     @objc
-    func ensureUsernameIsFirstResponder() {
-        usernameField?.textField.becomeFirstResponder()
+    func ensureFirstTextFieldIsFirstResponder() {
+        firstVisibleTextField?.textField.becomeFirstResponder()
         view.needsDisplay = true
     }
 }
@@ -174,7 +186,7 @@ extension AuthViewController {
         }
 
         refreshInterface()
-        ensureUsernameIsFirstResponder()
+        ensureFirstTextFieldIsFirstResponder()
     }
 
     private func authViewController(with mode: AuthenticationMode, state: AuthenticationState) -> AuthViewController {

--- a/Simplenote/AuthViewController+Swift.swift
+++ b/Simplenote/AuthViewController+Swift.swift
@@ -45,6 +45,7 @@ extension AuthViewController {
         setupActionsSeparatorView()
         setupAdditionalButtons()
         setupLabels()
+        setupHeaderView()
     }
 
     private func setupActionsSeparatorView() {
@@ -66,8 +67,16 @@ extension AuthViewController {
     private func setupLabels() {
         simplenoteTitleView.isHidden = !mode.isIntroView
         simplenoteSubTitleView.isHidden = !mode.isIntroView
+    }
 
-        headerLabel.isHidden = mode.header == nil
+    private func setupHeaderView() {
+        guard let headerText = mode.buildHeaderText(email: state.username) else {
+            headerLabel.isHidden = true
+            return
+        }
+
+        headerLabel.attributedStringValue = headerText
+        headerLabel.isHidden = false
     }
 
     open override func viewDidAppear() {

--- a/Simplenote/AuthViewController+Swift.swift
+++ b/Simplenote/AuthViewController+Swift.swift
@@ -285,7 +285,8 @@ extension AuthViewController {
             let confirmation = try await remote.requestLoginConfirmation(email: username, authCode: code.uppercased())
             authenticator.authenticate(withUsername: confirmation.username, token: confirmation.syncToken)
         } catch {
-            //TODO: Handle errors
+            let statusCode = (error as? RemoteError)?.statusCode ?? .zero
+            self.showAuthenticationError(forCode: statusCode, responseString: nil)
         }
     }
 

--- a/Simplenote/AuthViewController+Swift.swift
+++ b/Simplenote/AuthViewController+Swift.swift
@@ -71,6 +71,8 @@ extension AuthViewController {
     }
 
     open override func viewDidAppear() {
+        super.viewDidAppear()
+        
         ensureFirstTextFieldIsFirstResponder()
     }
 }

--- a/Simplenote/AuthViewController.h
+++ b/Simplenote/AuthViewController.h
@@ -3,6 +3,7 @@
 @import Simperium_OSX;
 
 @class AuthenticationMode;
+@class AuthenticationState;
 
 
 // MARK: - AuthViewController: Simperium's Authentication UI
@@ -27,6 +28,9 @@
 @property (nonatomic, strong) IBOutlet NSView                       *leadingSeparatorView;
 @property (nonatomic, strong) IBOutlet NSTextField                  *separatorLabel;
 @property (nonatomic, strong) IBOutlet NSView                       *trailingSeparatorView;
+@property (nonatomic, strong) IBOutlet NSView                       *quarternaryButtonView;
+@property (nonatomic, strong) IBOutlet NSButton                     *quarternaryButton;
+
 
 @property (nonatomic, strong) IBOutlet NSLayoutConstraint           *passwordFieldHeightConstraint;
 @property (nonatomic, strong) IBOutlet NSLayoutConstraint           *secondaryActionHeightConstraint;
@@ -34,6 +38,7 @@
 
 @property (nonatomic, strong) SPAuthenticator                       *authenticator;
 @property (nonatomic, strong) AuthenticationMode                    *mode;
+@property (nonatomic, strong) AuthenticationState                   *state;
 
 - (void)pressedLogInWithPassword;
 - (void)pressedLoginWithMagicLink;

--- a/Simplenote/AuthViewController.h
+++ b/Simplenote/AuthViewController.h
@@ -11,21 +11,22 @@
 
 @property (nonatomic, strong) IBOutlet NSStackView                  *stackView;
 @property (nonatomic, strong) IBOutlet NSImageView                  *logoImageView;
-@property (nonatomic, strong) IBOutlet NSTextField *simplenoteTitleView;
-@property (nonatomic, strong) IBOutlet NSTextField *simplenoteSubTitleView;
-@property (nonatomic, strong) IBOutlet NSTextField *headerLabel;
+@property (nonatomic, strong) IBOutlet NSTextField                  *simplenoteTitleView;
+@property (nonatomic, strong) IBOutlet NSTextField                  *simplenoteSubTitleView;
+@property (nonatomic, strong) IBOutlet NSTextField                  *headerLabel;
 @property (nonatomic, strong) IBOutlet NSTextField                  *errorField;
 @property (nonatomic, strong) IBOutlet SPAuthenticationTextField    *usernameField;
 @property (nonatomic, strong) IBOutlet SPAuthenticationTextField    *passwordField;
+@property (nonatomic, strong) IBOutlet SPAuthenticationTextField    *codeTextField;
 @property (nonatomic, strong) IBOutlet NSButton                     *actionButton;
 @property (nonatomic, strong) IBOutlet NSProgressIndicator          *actionProgress;
 @property (nonatomic, strong) IBOutlet NSButton                     *secondaryActionButton;
 @property (nonatomic, strong) IBOutlet NSView                       *tertiaryButtonContainerView;
 @property (nonatomic, strong) IBOutlet NSButton                     *tertiaryButton;
-@property (weak) IBOutlet NSView *actionsSeparatorView;
-@property (weak) IBOutlet NSView *leadingSeparatorView;
-@property (weak) IBOutlet NSTextField *separatorLabel;
-@property (weak) IBOutlet NSView *trailingSeparatorView;
+@property (nonatomic, strong) IBOutlet NSView                       *actionsSeparatorView;
+@property (nonatomic, strong) IBOutlet NSView                       *leadingSeparatorView;
+@property (nonatomic, strong) IBOutlet NSTextField                  *separatorLabel;
+@property (nonatomic, strong) IBOutlet NSView                       *trailingSeparatorView;
 
 @property (nonatomic, strong) IBOutlet NSLayoutConstraint           *passwordFieldHeightConstraint;
 @property (nonatomic, strong) IBOutlet NSLayoutConstraint           *secondaryActionHeightConstraint;

--- a/Simplenote/AuthViewController.h
+++ b/Simplenote/AuthViewController.h
@@ -44,6 +44,7 @@
 - (void)pressedLoginWithMagicLink;
 - (void)pressedSignUp;
 - (void)openForgotPasswordURL;
+- (BOOL)validateCode;
 
 - (void)setInterfaceEnabled:(BOOL)enabled;
 

--- a/Simplenote/AuthViewController.m
+++ b/Simplenote/AuthViewController.m
@@ -364,6 +364,8 @@
     if (currentEvent.type == NSEventTypeKeyDown && [currentEvent.charactersIgnoringModifiers isEqualToString:@"\r"]) {
         [self handleNewlineInField:obj.object];
     }
+
+    [self updateStateWith:obj.object];
 }
 
 @end

--- a/Simplenote/AuthViewController.m
+++ b/Simplenote/AuthViewController.m
@@ -38,7 +38,7 @@
     [super viewDidLoad];
 
     [self setupInterface];
-    [self refreshInterfaceWithAnimation:NO];
+    [self refreshInterface];
     [self startListeningToNotifications];
 }
 

--- a/Simplenote/AuthViewController.m
+++ b/Simplenote/AuthViewController.m
@@ -254,6 +254,15 @@
     return [self.validator mustPerformPasswordResetWithUsername:self.usernameText password:self.passwordText];
 }
 
+- (BOOL)validateCodeInput {
+    if (self.state.code.length >= 6) {
+        return YES;
+    }
+
+    [self showAuthenticationError:NSLocalizedString(@"Login Code is too short", comment: @"Message displayed when a login code is too short")];
+    return NO;
+}
+
 - (BOOL)validateSignIn {
     return [self validateConnection] &&
            [self validateUsername] &&
@@ -268,6 +277,11 @@
 - (BOOL)validateSignUp {
     return [self validateConnection] &&
            [self validateUsername];
+}
+
+- (BOOL)validateCode {
+    return [self validateConnection] &&
+    [self validateCodeInput];
 }
 
 - (void)showAuthenticationError:(NSString *)errorMessage {

--- a/Simplenote/AuthViewController.m
+++ b/Simplenote/AuthViewController.m
@@ -68,7 +68,6 @@
 
 - (void)setMode:(AuthenticationMode *)mode {
     _mode = mode;
-    [self didUpdateAuthenticationMode];
 }
 
 

--- a/Simplenote/AuthViewController.m
+++ b/Simplenote/AuthViewController.m
@@ -63,14 +63,6 @@
     [[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString:forgotPasswordURL]];
 }
 
-
-#pragma mark - Dynamic Properties
-
-- (void)setMode:(AuthenticationMode *)mode {
-    _mode = mode;
-}
-
-
 #pragma mark - Interface Helpers
 
 - (void)setInterfaceEnabled:(BOOL)enabled {

--- a/Simplenote/AuthViewController.m
+++ b/Simplenote/AuthViewController.m
@@ -168,7 +168,7 @@
     [self startActionAnimation];
     [self setInterfaceEnabled:NO];
 
-    [self.authenticator authenticateWithUsername:self.usernameText password:self.passwordText success:^{
+    [self.authenticator authenticateWithUsername:self.state.username password:self.state.password success:^{
         // NO-OP
     } failure:^(NSInteger responseCode, NSString *responseString, NSError *error) {
         [self showAuthenticationErrorForCode:responseCode responseString: responseString];
@@ -230,7 +230,7 @@
 
 - (BOOL)validateUsername {
     NSError *error = nil;
-    if ([self.validator validateUsername:self.usernameText error:&error]) {
+    if ([self.validator validateUsername:self.state.username error:&error]) {
         return YES;
     }
 
@@ -241,7 +241,7 @@
 
 - (BOOL)validatePasswordSecurity {
     NSError *error = nil;
-    if ([self.validator validatePasswordWithUsername:self.usernameText password:self.passwordText error:&error]) {
+    if ([self.validator validatePasswordWithUsername:self.state.username password:self.state.password error:&error]) {
         return YES;
     }
 

--- a/Simplenote/AuthViewController.xib
+++ b/Simplenote/AuthViewController.xib
@@ -68,7 +68,7 @@
                         </textField>
                         <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="xA2-cU-2CM" userLabel="headerLabel">
                             <rect key="frame" x="134" y="454" width="53" height="16"/>
-                            <textFieldCell key="cell" lineBreakMode="clipping" alignment="center" title="Header" id="pyn-HV-JBL">
+                            <textFieldCell key="cell" alignment="center" title="Header" id="pyn-HV-JBL">
                                 <font key="font" metaFont="system"/>
                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                 <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>

--- a/Simplenote/AuthViewController.xib
+++ b/Simplenote/AuthViewController.xib
@@ -18,6 +18,8 @@
                 <outlet property="logoImageView" destination="W9h-HS-WbG" id="GV7-vy-NaT"/>
                 <outlet property="passwordField" destination="2bk-bk-VfG" id="JQn-Xi-XNs"/>
                 <outlet property="passwordFieldHeightConstraint" destination="Cah-V8-aCS" id="saQ-Mz-zu6"/>
+                <outlet property="quarternaryButton" destination="PF9-wA-mIg" id="sQL-2W-kgK"/>
+                <outlet property="quarternaryButtonView" destination="Aiw-Qy-Zcs" id="iz2-AU-dmp"/>
                 <outlet property="secondaryActionButton" destination="y1M-Np-v9m" id="z7i-Qa-Tye"/>
                 <outlet property="secondaryActionHeightConstraint" destination="HrL-ss-QSd" id="Vg3-A9-yCH"/>
                 <outlet property="separatorLabel" destination="xI6-bI-NiW" id="PA7-tE-0Od"/>
@@ -35,13 +37,13 @@
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <view wantsLayer="YES" appearanceType="aqua" translatesAutoresizingMaskIntoConstraints="NO" id="kU7-kg-wG3" customClass="SPAuthenticationView">
-            <rect key="frame" x="0.0" y="0.0" width="380" height="697"/>
+            <rect key="frame" x="0.0" y="0.0" width="380" height="749"/>
             <subviews>
                 <stackView distribution="fill" orientation="vertical" alignment="centerX" spacing="12" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="PWa-EY-51O">
-                    <rect key="frame" x="30" y="45" width="320" height="607"/>
+                    <rect key="frame" x="30" y="45" width="320" height="659"/>
                     <subviews>
                         <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="W9h-HS-WbG">
-                            <rect key="frame" x="112" y="511" width="96" height="96"/>
+                            <rect key="frame" x="112" y="563" width="96" height="96"/>
                             <constraints>
                                 <constraint firstAttribute="width" constant="96" id="Sys-NN-iWa"/>
                                 <constraint firstAttribute="height" constant="96" id="mq9-yP-8Tc"/>
@@ -49,7 +51,7 @@
                             <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="icon_simplenote_login" id="2Fh-2C-hTH"/>
                         </imageView>
                         <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="QdZ-0O-kg0" userLabel="simplenoteTitleLabel">
-                            <rect key="frame" x="129" y="461" width="62" height="38"/>
+                            <rect key="frame" x="129" y="513" width="62" height="38"/>
                             <textFieldCell key="cell" lineBreakMode="clipping" alignment="center" title="title" id="qpG-DI-lUy">
                                 <font key="font" metaFont="systemMedium" size="32"/>
                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -57,7 +59,7 @@
                             </textFieldCell>
                         </textField>
                         <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="OWk-yc-eau" userLabel="simplenoteSubTitleLabel">
-                            <rect key="frame" x="129" y="430" width="62" height="19"/>
+                            <rect key="frame" x="129" y="482" width="62" height="19"/>
                             <textFieldCell key="cell" lineBreakMode="clipping" alignment="center" title="subtitle" id="biC-yR-Nb8">
                                 <font key="font" metaFont="system" size="16"/>
                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -65,7 +67,7 @@
                             </textFieldCell>
                         </textField>
                         <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="xA2-cU-2CM" userLabel="headerLabel">
-                            <rect key="frame" x="134" y="402" width="53" height="16"/>
+                            <rect key="frame" x="134" y="454" width="53" height="16"/>
                             <textFieldCell key="cell" lineBreakMode="clipping" alignment="center" title="Header" id="pyn-HV-JBL">
                                 <font key="font" metaFont="system"/>
                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -73,7 +75,7 @@
                             </textFieldCell>
                         </textField>
                         <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="lwM-mh-i3o">
-                            <rect key="frame" x="-2" y="374" width="324" height="16"/>
+                            <rect key="frame" x="-2" y="426" width="324" height="16"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="16" id="Pcu-pb-Ma8"/>
                             </constraints>
@@ -84,13 +86,13 @@
                             </textFieldCell>
                         </textField>
                         <customView translatesAutoresizingMaskIntoConstraints="NO" id="Fco-3r-2Ys" userLabel="Username TextField" customClass="SPAuthenticationTextField">
-                            <rect key="frame" x="0.0" y="322" width="320" height="40"/>
+                            <rect key="frame" x="0.0" y="374" width="320" height="40"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="40" id="ZyF-TN-zXQ"/>
                             </constraints>
                         </customView>
                         <customView wantsLayer="YES" translatesAutoresizingMaskIntoConstraints="NO" id="2bk-bk-VfG" userLabel="Password TextField" customClass="SPAuthenticationTextField">
-                            <rect key="frame" x="0.0" y="270" width="320" height="40"/>
+                            <rect key="frame" x="0.0" y="322" width="320" height="40"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="40" id="Cah-V8-aCS"/>
                             </constraints>
@@ -99,7 +101,7 @@
                             </userDefinedRuntimeAttributes>
                         </customView>
                         <customView wantsLayer="YES" translatesAutoresizingMaskIntoConstraints="NO" id="y3O-LQ-R2F" userLabel="CodeTextField" customClass="SPAuthenticationTextField">
-                            <rect key="frame" x="0.0" y="218" width="320" height="40"/>
+                            <rect key="frame" x="0.0" y="270" width="320" height="40"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="40" id="hpG-uZ-e1S"/>
                             </constraints>
@@ -108,7 +110,7 @@
                             </userDefinedRuntimeAttributes>
                         </customView>
                         <customView translatesAutoresizingMaskIntoConstraints="NO" id="Epn-oY-sfo" userLabel="Action View">
-                            <rect key="frame" x="0.0" y="140" width="320" height="66"/>
+                            <rect key="frame" x="0.0" y="192" width="320" height="66"/>
                             <subviews>
                                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Lid-6Q-zHR" userLabel="Main Action Button" customClass="SPAuthenticationButton">
                                     <rect key="frame" x="0.0" y="0.0" width="320" height="40"/>
@@ -134,7 +136,7 @@
                             </constraints>
                         </customView>
                         <button wantsLayer="YES" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="y1M-Np-v9m" userLabel="Secondary Action Button">
-                            <rect key="frame" x="0.0" y="108" width="320" height="20"/>
+                            <rect key="frame" x="0.0" y="160" width="320" height="20"/>
                             <buttonCell key="cell" type="bevel" title="[Secondary Action]" bezelStyle="rounded" alignment="center" imageScaling="proportionallyDown" inset="2" id="zjo-dD-vux" userLabel="[Secondary Action]">
                                 <behavior key="behavior" lightByContents="YES"/>
                                 <font key="font" metaFont="systemMedium" size="13"/>
@@ -144,7 +146,7 @@
                             </constraints>
                         </button>
                         <customView appearanceType="darkAqua" translatesAutoresizingMaskIntoConstraints="NO" id="WI9-SH-Yrp" userLabel="Actions Separator View">
-                            <rect key="frame" x="0.0" y="52" width="320" height="44"/>
+                            <rect key="frame" x="0.0" y="104" width="320" height="44"/>
                             <subviews>
                                 <customView translatesAutoresizingMaskIntoConstraints="NO" id="4nP-3I-NOF" userLabel="Leading Line">
                                     <rect key="frame" x="0.0" y="22" width="145" height="1"/>
@@ -180,7 +182,7 @@
                             </constraints>
                         </customView>
                         <customView wantsLayer="YES" translatesAutoresizingMaskIntoConstraints="NO" id="3tE-Zi-edS" userLabel="Tertiary Button View">
-                            <rect key="frame" x="0.0" y="0.0" width="320" height="40"/>
+                            <rect key="frame" x="0.0" y="52" width="320" height="40"/>
                             <subviews>
                                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="sc9-DH-ug9" userLabel="Tertiary Button">
                                     <rect key="frame" x="0.0" y="0.0" width="320" height="40"/>
@@ -201,6 +203,28 @@
                                 <constraint firstItem="sc9-DH-ug9" firstAttribute="top" secondItem="3tE-Zi-edS" secondAttribute="top" priority="999" id="k9B-l0-1OW"/>
                             </constraints>
                         </customView>
+                        <customView wantsLayer="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Aiw-Qy-Zcs" userLabel="Quartenary Button View">
+                            <rect key="frame" x="0.0" y="0.0" width="320" height="40"/>
+                            <subviews>
+                                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="PF9-wA-mIg" userLabel="Quarternary Button">
+                                    <rect key="frame" x="0.0" y="0.0" width="320" height="40"/>
+                                    <buttonCell key="cell" type="bevel" title="Quarternary" bezelStyle="rounded" imagePosition="left" alignment="center" imageScaling="proportionallyDown" inset="2" id="eEj-p1-LWQ" userLabel="Quarternary">
+                                        <behavior key="behavior" lightByContents="YES"/>
+                                        <font key="font" metaFont="system" size="16"/>
+                                    </buttonCell>
+                                    <constraints>
+                                        <constraint firstAttribute="height" priority="999" constant="40" id="XZN-6k-gIC"/>
+                                    </constraints>
+                                </button>
+                            </subviews>
+                            <constraints>
+                                <constraint firstAttribute="trailing" secondItem="PF9-wA-mIg" secondAttribute="trailing" id="Hfu-10-dUj"/>
+                                <constraint firstAttribute="bottom" secondItem="PF9-wA-mIg" secondAttribute="bottom" id="Hkz-Fv-C90"/>
+                                <constraint firstAttribute="height" constant="40" id="Mxu-QC-FOY"/>
+                                <constraint firstItem="PF9-wA-mIg" firstAttribute="leading" secondItem="Aiw-Qy-Zcs" secondAttribute="leading" id="TFC-PM-uEN"/>
+                                <constraint firstItem="PF9-wA-mIg" firstAttribute="top" secondItem="Aiw-Qy-Zcs" secondAttribute="top" priority="999" id="iEG-06-TqS"/>
+                            </constraints>
+                        </customView>
                     </subviews>
                     <constraints>
                         <constraint firstAttribute="trailing" secondItem="lwM-mh-i3o" secondAttribute="trailing" id="2mH-bL-ey0"/>
@@ -210,10 +234,12 @@
                         <constraint firstItem="2bk-bk-VfG" firstAttribute="leading" secondItem="PWa-EY-51O" secondAttribute="leading" id="GPa-uH-nyA"/>
                         <constraint firstItem="y1M-Np-v9m" firstAttribute="leading" secondItem="PWa-EY-51O" secondAttribute="leading" id="GWL-9k-A81"/>
                         <constraint firstAttribute="width" constant="320" id="Ifa-qD-b3e"/>
+                        <constraint firstAttribute="trailing" secondItem="Aiw-Qy-Zcs" secondAttribute="trailing" id="UKd-8G-vNO"/>
                         <constraint firstAttribute="trailing" secondItem="y1M-Np-v9m" secondAttribute="trailing" id="Zys-3I-SBQ"/>
                         <constraint firstAttribute="trailing" secondItem="Epn-oY-sfo" secondAttribute="trailing" id="eWd-kZ-fSY"/>
                         <constraint firstAttribute="trailing" secondItem="Fco-3r-2Ys" secondAttribute="trailing" id="gTV-rG-Rz6"/>
                         <constraint firstItem="Fco-3r-2Ys" firstAttribute="leading" secondItem="PWa-EY-51O" secondAttribute="leading" id="lFa-dR-M3o"/>
+                        <constraint firstItem="Aiw-Qy-Zcs" firstAttribute="leading" secondItem="PWa-EY-51O" secondAttribute="leading" id="nms-7H-Ibk"/>
                         <constraint firstAttribute="trailing" secondItem="3tE-Zi-edS" secondAttribute="trailing" id="oW8-45-PLX"/>
                         <constraint firstItem="lwM-mh-i3o" firstAttribute="leading" secondItem="PWa-EY-51O" secondAttribute="leading" id="pMz-cI-3Ed"/>
                         <constraint firstAttribute="trailing" secondItem="WI9-SH-Yrp" secondAttribute="trailing" id="sUi-JY-GKT"/>
@@ -232,8 +258,10 @@
                         <integer value="1000"/>
                         <integer value="1000"/>
                         <integer value="1000"/>
+                        <integer value="1000"/>
                     </visibilityPriorities>
                     <customSpacing>
+                        <real value="3.4028234663852886e+38"/>
                         <real value="3.4028234663852886e+38"/>
                         <real value="3.4028234663852886e+38"/>
                         <real value="3.4028234663852886e+38"/>

--- a/Simplenote/AuthViewController.xib
+++ b/Simplenote/AuthViewController.xib
@@ -11,6 +11,7 @@
                 <outlet property="actionButton" destination="Lid-6Q-zHR" id="k1R-7A-0Fc"/>
                 <outlet property="actionProgress" destination="GMB-3v-AEQ" id="Qv3-0X-3xO"/>
                 <outlet property="actionsSeparatorView" destination="WI9-SH-Yrp" id="SJl-TQ-htb"/>
+                <outlet property="codeTextField" destination="y3O-LQ-R2F" id="DFz-hT-edA"/>
                 <outlet property="errorField" destination="lwM-mh-i3o" id="hCf-XY-GKI"/>
                 <outlet property="headerLabel" destination="xA2-cU-2CM" id="fvc-Az-Hc1"/>
                 <outlet property="leadingSeparatorView" destination="4nP-3I-NOF" id="mKf-M6-kx7"/>
@@ -34,13 +35,13 @@
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <view wantsLayer="YES" appearanceType="aqua" translatesAutoresizingMaskIntoConstraints="NO" id="kU7-kg-wG3" customClass="SPAuthenticationView">
-            <rect key="frame" x="0.0" y="0.0" width="380" height="645"/>
+            <rect key="frame" x="0.0" y="0.0" width="380" height="697"/>
             <subviews>
                 <stackView distribution="fill" orientation="vertical" alignment="centerX" spacing="12" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="PWa-EY-51O">
-                    <rect key="frame" x="30" y="45" width="320" height="555"/>
+                    <rect key="frame" x="30" y="45" width="320" height="607"/>
                     <subviews>
                         <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="W9h-HS-WbG">
-                            <rect key="frame" x="112" y="459" width="96" height="96"/>
+                            <rect key="frame" x="112" y="511" width="96" height="96"/>
                             <constraints>
                                 <constraint firstAttribute="width" constant="96" id="Sys-NN-iWa"/>
                                 <constraint firstAttribute="height" constant="96" id="mq9-yP-8Tc"/>
@@ -48,7 +49,7 @@
                             <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="icon_simplenote_login" id="2Fh-2C-hTH"/>
                         </imageView>
                         <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="QdZ-0O-kg0" userLabel="simplenoteTitleLabel">
-                            <rect key="frame" x="129" y="409" width="62" height="38"/>
+                            <rect key="frame" x="129" y="461" width="62" height="38"/>
                             <textFieldCell key="cell" lineBreakMode="clipping" alignment="center" title="title" id="qpG-DI-lUy">
                                 <font key="font" metaFont="systemMedium" size="32"/>
                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -56,7 +57,7 @@
                             </textFieldCell>
                         </textField>
                         <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="OWk-yc-eau" userLabel="simplenoteSubTitleLabel">
-                            <rect key="frame" x="129" y="378" width="62" height="19"/>
+                            <rect key="frame" x="129" y="430" width="62" height="19"/>
                             <textFieldCell key="cell" lineBreakMode="clipping" alignment="center" title="subtitle" id="biC-yR-Nb8">
                                 <font key="font" metaFont="system" size="16"/>
                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -64,7 +65,7 @@
                             </textFieldCell>
                         </textField>
                         <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="xA2-cU-2CM" userLabel="headerLabel">
-                            <rect key="frame" x="134" y="350" width="53" height="16"/>
+                            <rect key="frame" x="134" y="402" width="53" height="16"/>
                             <textFieldCell key="cell" lineBreakMode="clipping" alignment="center" title="Header" id="pyn-HV-JBL">
                                 <font key="font" metaFont="system"/>
                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -72,7 +73,7 @@
                             </textFieldCell>
                         </textField>
                         <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="lwM-mh-i3o">
-                            <rect key="frame" x="-2" y="322" width="324" height="16"/>
+                            <rect key="frame" x="-2" y="374" width="324" height="16"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="16" id="Pcu-pb-Ma8"/>
                             </constraints>
@@ -83,15 +84,24 @@
                             </textFieldCell>
                         </textField>
                         <customView translatesAutoresizingMaskIntoConstraints="NO" id="Fco-3r-2Ys" userLabel="Username TextField" customClass="SPAuthenticationTextField">
-                            <rect key="frame" x="0.0" y="270" width="320" height="40"/>
+                            <rect key="frame" x="0.0" y="322" width="320" height="40"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="40" id="ZyF-TN-zXQ"/>
                             </constraints>
                         </customView>
                         <customView wantsLayer="YES" translatesAutoresizingMaskIntoConstraints="NO" id="2bk-bk-VfG" userLabel="Password TextField" customClass="SPAuthenticationTextField">
-                            <rect key="frame" x="0.0" y="218" width="320" height="40"/>
+                            <rect key="frame" x="0.0" y="270" width="320" height="40"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="40" id="Cah-V8-aCS"/>
+                            </constraints>
+                            <userDefinedRuntimeAttributes>
+                                <userDefinedRuntimeAttribute type="boolean" keyPath="secure" value="YES"/>
+                            </userDefinedRuntimeAttributes>
+                        </customView>
+                        <customView wantsLayer="YES" translatesAutoresizingMaskIntoConstraints="NO" id="y3O-LQ-R2F" userLabel="CodeTextField" customClass="SPAuthenticationTextField">
+                            <rect key="frame" x="0.0" y="218" width="320" height="40"/>
+                            <constraints>
+                                <constraint firstAttribute="height" constant="40" id="hpG-uZ-e1S"/>
                             </constraints>
                             <userDefinedRuntimeAttributes>
                                 <userDefinedRuntimeAttribute type="boolean" keyPath="secure" value="YES"/>
@@ -221,8 +231,10 @@
                         <integer value="1000"/>
                         <integer value="1000"/>
                         <integer value="1000"/>
+                        <integer value="1000"/>
                     </visibilityPriorities>
                     <customSpacing>
+                        <real value="3.4028234663852886e+38"/>
                         <real value="3.4028234663852886e+38"/>
                         <real value="3.4028234663852886e+38"/>
                         <real value="3.4028234663852886e+38"/>

--- a/Simplenote/AuthenticationMode.swift
+++ b/Simplenote/AuthenticationMode.swift
@@ -113,7 +113,7 @@ extension AuthenticationMode {
     static func loginWithPassword(header: String? = nil) -> AuthenticationMode {
         AuthenticationMode(title: NSLocalizedString("Log In with Password", comment: "LogIn Interface Title"),
                            header: header,
-                           inputElements: [.username, .password],
+                           inputElements: [.password],
                            actions: [
                             AuthenticationActionDescriptor(name: .primary,
                                                            selector: #selector(AuthViewController.pressedLogInWithPassword),
@@ -137,9 +137,6 @@ extension AuthenticationMode {
                             AuthenticationActionDescriptor(name: .primary, 
                                                            selector: #selector(AuthViewController.pressedLoginWithMagicLink),
                                                            text: MagicLinkStrings.primaryAction),
-                            AuthenticationActionDescriptor(name: .secondary,
-                                                           selector: #selector(AuthViewController.switchToPasswordAuth),
-                                                           text: MagicLinkStrings.secondaryAction),
                             AuthenticationActionDescriptor(name: .tertiary,
                                                            selector: #selector(AuthViewController.wordpressSSOAction), text: LoginStrings.wordpressAction)
                            ],

--- a/Simplenote/AuthenticationMode.swift
+++ b/Simplenote/AuthenticationMode.swift
@@ -1,5 +1,14 @@
 import Foundation
 
+// MARK: - State
+//
+@objcMembers
+class AuthenticationState: NSObject {
+    var username = String()
+    var password = String()
+    var code = String()
+}
+
 // MARK: - Authentication Elements
 //
 struct AuthenticationInputElements: OptionSet, Hashable {
@@ -152,6 +161,25 @@ extension AuthenticationMode {
                            primaryActionAnimationText: SignupStrings.primaryAnimationText,
                            isPasswordVisible: false)
     }
+
+    /// Login with Code: Submit Code + Authenticate the user
+    ///
+    static var loginWithCode: AuthenticationMode {
+        AuthenticationMode(title: NSLocalizedString("Enter Code", comment: "LogIn Interface Title"),
+                           header: NSLocalizedString("We've sent a code to {{EMAIL}}. The code will be valid for a few minutes.", comment: "Header for the Login with Code UI. Please preserve the {{EMAIL}} string as is!"),
+                           inputElements: [.code, .actionSeparator],
+                           actions: [
+                            AuthenticationActionDescriptor(name: .primary,
+                                                           selector: #selector(AuthViewController.performLogInWithCode),
+                                                           text: NSLocalizedString("Log In", comment: "LogIn Interface Title")),
+                            AuthenticationActionDescriptor(name: .quaternary,
+                                                           selector: #selector(AuthViewController.pushPasswordView),
+                                                           text: NSLocalizedString("Enter password", comment: "Enter Password fallback Action")),
+                           ],
+                           primaryActionAnimationText: "",
+                           isPasswordVisible: false)
+    }
+
 }
 
 

--- a/Simplenote/AuthenticationMode.swift
+++ b/Simplenote/AuthenticationMode.swift
@@ -52,8 +52,7 @@ class AuthenticationMode: NSObject {
     let actions: [AuthenticationActionDescriptor]
 
     let primaryActionAnimationText: String
-    
-    let isPasswordVisible: Bool
+
     let isIntroView: Bool
 
     init(title: String,
@@ -61,31 +60,15 @@ class AuthenticationMode: NSObject {
          inputElements: AuthenticationInputElements,
          actions: [AuthenticationActionDescriptor],
          primaryActionAnimationText: String,
-         isPasswordVisible: Bool,
          isIntroView: Bool = false) {
         self.title = title
         self.header = header
         self.inputElements = inputElements
         self.actions = actions
         self.primaryActionAnimationText =  primaryActionAnimationText
-        self.isPasswordVisible = isPasswordVisible
         self.isIntroView = isIntroView
     }
 }
-
-// MARK: - Dynamic Properties
-//
-extension AuthenticationMode {
-    
-    var passwordFieldHeight: CGFloat {
-        isPasswordVisible ? CGFloat(40) : .zero
-    }
-
-    var passwordFieldAlpha: CGFloat {
-        isPasswordVisible ? AppKitConstants.alpha1_0 : AppKitConstants.alpha0_0
-    }
-}
-
 
 // MARK: - Static Properties
 //
@@ -104,7 +87,6 @@ extension AuthenticationMode {
                                                                    text: LoginStrings.primaryAction.uppercased())
                                   ],
                                   primaryActionAnimationText: SignupStrings.primaryAnimationText,
-                                  isPasswordVisible: false,
                                   isIntroView: true)
     }
 
@@ -122,8 +104,7 @@ extension AuthenticationMode {
                                                            selector: #selector(AuthViewController.openForgotPasswordURL),
                                                            text: LoginStrings.secondaryAction)
                            ],
-                           primaryActionAnimationText: LoginStrings.primaryAnimationText,
-                           isPasswordVisible: true)
+                           primaryActionAnimationText: LoginStrings.primaryAnimationText)
     }
 
     /// Auth Mode: Login is handled via Magic Links!
@@ -140,8 +121,7 @@ extension AuthenticationMode {
                             AuthenticationActionDescriptor(name: .tertiary,
                                                            selector: #selector(AuthViewController.wordpressSSOAction), text: LoginStrings.wordpressAction)
                            ],
-                           primaryActionAnimationText: MagicLinkStrings.primaryAnimationText,
-                           isPasswordVisible: false)
+                           primaryActionAnimationText: MagicLinkStrings.primaryAnimationText)
     }
 
     /// Auth Mode: SignUp
@@ -155,8 +135,7 @@ extension AuthenticationMode {
                                                            selector: #selector(AuthViewController.pressedSignUp),
                                                            text: SignupStrings.primaryAction)
                            ],
-                           primaryActionAnimationText: SignupStrings.primaryAnimationText,
-                           isPasswordVisible: false)
+                           primaryActionAnimationText: SignupStrings.primaryAnimationText)
     }
 
     /// Login with Code: Submit Code + Authenticate the user
@@ -173,8 +152,7 @@ extension AuthenticationMode {
                                                            selector: #selector(AuthViewController.pushPasswordView),
                                                            text: NSLocalizedString("Enter password", comment: "Enter Password fallback Action")),
                            ],
-                           primaryActionAnimationText: "",
-                           isPasswordVisible: false)
+                           primaryActionAnimationText: "")
     }
 
 }

--- a/Simplenote/AuthenticationMode.swift
+++ b/Simplenote/AuthenticationMode.swift
@@ -78,6 +78,26 @@ extension AuthenticationMode {
     }
 }
 
+// MARK: - Public Properties
+//
+extension AuthenticationMode {
+
+    func buildHeaderText(email: String) -> NSAttributedString? {
+        guard let header = header?.replacingOccurrences(of: "{{EMAIL}}", with: email) else {
+            return nil
+        }
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.alignment = .center
+
+        return NSMutableAttributedString(string: header, attributes: [
+            .font: NSFont.systemFont(ofSize: 16, weight: .regular),
+            .paragraphStyle: paragraphStyle
+        ], highlighting: email, highlightAttributes: [
+            .font: NSFont.systemFont(ofSize: 16, weight: .bold)
+        ])
+    }
+}
+
 // MARK: - Static Properties
 //
 extension AuthenticationMode {

--- a/Simplenote/AuthenticationMode.swift
+++ b/Simplenote/AuthenticationMode.swift
@@ -70,6 +70,14 @@ class AuthenticationMode: NSObject {
     }
 }
 
+// MARK: - Convenience Properties
+//
+extension AuthenticationMode {
+    func action(withName name: AuthenticationActionName) -> AuthenticationActionDescriptor? {
+        actions.first(where: { $0.name == name })
+    }
+}
+
 // MARK: - Static Properties
 //
 extension AuthenticationMode {
@@ -152,7 +160,7 @@ extension AuthenticationMode {
                                                            selector: #selector(AuthViewController.pushPasswordView),
                                                            text: NSLocalizedString("Enter password", comment: "Enter Password fallback Action")),
                            ],
-                           primaryActionAnimationText: "")
+                           primaryActionAnimationText: LoginStrings.primaryAnimationText)
     }
 
 }

--- a/Simplenote/NSProgressIndicator+Simplenote.swift
+++ b/Simplenote/NSProgressIndicator+Simplenote.swift
@@ -17,4 +17,24 @@ extension NSProgressIndicator {
         progressIndicator.startAnimation(view)
         return progressIndicator
     }
+
+    func set(tintColor: NSColor) {
+        guard let adjustedTintColor = NSColor.white.usingColorSpace(.deviceRGB) else {
+            return
+        }
+
+        let tintColorRedComponent = adjustedTintColor.redComponent
+        let tintColorGreenComponent = adjustedTintColor.greenComponent
+        let tintColorBlueComponent = adjustedTintColor.blueComponent
+
+        let tintColorMinComponentsVector = CIVector(x: tintColorRedComponent, y: tintColorGreenComponent, z: tintColorBlueComponent, w: 0.0)
+        let tintColorMaxComponentsVector = CIVector(x: tintColorRedComponent, y: tintColorGreenComponent, z: tintColorBlueComponent, w: 1.0)
+
+        let colorClampFilter = CIFilter(name: "CIColorClamp")!
+        colorClampFilter.setDefaults()
+        colorClampFilter.setValue(tintColorMinComponentsVector, forKey: "inputMinComponents")
+        colorClampFilter.setValue(tintColorMaxComponentsVector, forKey: "inputMaxComponents")
+
+        contentFilters = [colorClampFilter]
+    }
 }

--- a/Simplenote/SignupVerificationViewController.swift
+++ b/Simplenote/SignupVerificationViewController.swift
@@ -126,8 +126,9 @@ private extension SignupVerificationViewController {
 
     func presentAuthenticationInteface() {
         let authViewController = AuthViewController()
+        let navigationController = SPNavigationController(initialViewController: authViewController)
         authViewController.authenticator = authenticator
-        view.window?.transition(to: authViewController)
+        view.window?.transition(to: navigationController)
     }
 }
 


### PR DESCRIPTION
### Fix
Rounding third base on this one, so what we have here is I have finished splitting up the different auth views so that on each view you have one option.  So all the changes listed out here:

- Added auth with code view
- added auth with password view
- dropped access to password view in earlier views
- fixed issue with the button titles during animation
- added persistent state from one view to the next
- added authentication with a code
- Added header text to the different views

### Test
1. Launch simplenote and tap on Sign in.  Enter an invalid email and tap sign up.  Confirm that you see an error saying the email is invalid
2. Go back, tap on login. On the login with email screen, confirm that you can't use an invalid email without getting an error.  Attempt to enter a valid email address.  Confirm there is an animation and that you are pushed to the code view
3. Tap on the login with password button.  On the password view, confirm an invalid password shows an error and a successful password logs you in
4. Back on the code view confirm an invalid code fails to login and a valid one authenticates (note that we don't have handling for invalid codes yet or error handling for the code auth)

### Review
***(Required)*** Add instructions for reviewers.  For example:
> Only one developer is required to review these changes, but anyone can perform the review.

### Release
***(Required)*** Add a concise statement to `RELEASE-NOTES.txt` if the changes should be included in release notes. Include details about updating the notes in this section. For example:
> These changes do not require release notes.
