### PR TITLE
Magic links: Tweaks and updates

### DIFF
--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -338,6 +338,7 @@
 		BACA687C2C0A764C005409C1 /* KeychainPasswordItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = BACA687A2C0A7634005409C1 /* KeychainPasswordItem.swift */; };
 		BAD4ECC026E6FC0A00881CC4 /* markdown-light.css in Resources */ = {isa = PBXBuildFile; fileRef = BAF8D5DB26AE3BE800CA9383 /* markdown-light.css */; };
 		BAE66CAA26AF647500398FF3 /* Remote.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA938CEB26ACFF4A00BE5A1D /* Remote.swift */; };
+		BAEBDD4A2C52C14500335700 /* SPAuthenticationTextField+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAEBDD492C52C14500335700 /* SPAuthenticationTextField+Simplenote.swift */; };
 		BAF1B0C32BC9B1C500B55F73 /* NoteWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAF1B0C12BC9B1C500B55F73 /* NoteWindow.swift */; };
 		BAF1B0C92BCEDFD400B55F73 /* NoteWindowControllersManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAF1B0C72BCDDA9600B55F73 /* NoteWindowControllersManager.swift */; };
 		BAF4E5DE2C49C08A009B891F /* SPNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAF4E5DD2C49C08A009B891F /* SPNavigationController.swift */; };
@@ -807,6 +808,7 @@
 		BACA68752C0A72F3005409C1 /* NSString+Intents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSString+Intents.swift"; sourceTree = "<group>"; };
 		BACA68772C0A7537005409C1 /* KeychainManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainManager.swift; sourceTree = "<group>"; };
 		BACA687A2C0A7634005409C1 /* KeychainPasswordItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainPasswordItem.swift; sourceTree = "<group>"; };
+		BAEBDD492C52C14500335700 /* SPAuthenticationTextField+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SPAuthenticationTextField+Simplenote.swift"; sourceTree = "<group>"; };
 		BAF1B0C12BC9B1C500B55F73 /* NoteWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteWindow.swift; sourceTree = "<group>"; };
 		BAF1B0C72BCDDA9600B55F73 /* NoteWindowControllersManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteWindowControllersManager.swift; sourceTree = "<group>"; };
 		BAF4E5DD2C49C08A009B891F /* SPNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPNavigationController.swift; sourceTree = "<group>"; };
@@ -1244,6 +1246,7 @@
 				BA2C65CA26FE996100FA84E1 /* NSButton+Extensions.swift */,
 				BA52005C2BC88397003F1B75 /* NSManagedObjectContext+Simplenote.swift */,
 				BAF4E5DF2C49C17A009B891F /* NSViewController+Simplenote.swift */,
+				BAEBDD492C52C14500335700 /* SPAuthenticationTextField+Simplenote.swift */,
 			);
 			name = Extensions;
 			sourceTree = "<group>";
@@ -2243,6 +2246,7 @@
 				B5ACE42F24785D8C00AB02C7 /* BackgroundView.swift in Sources */,
 				B5F5415525F0137100CAF52C /* MagicLinkAuthenticator.swift in Sources */,
 				B58A71BF258422CC00601641 /* NSBezierPath+Simplenote.swift in Sources */,
+				BAEBDD4A2C52C14500335700 /* SPAuthenticationTextField+Simplenote.swift in Sources */,
 				B587D7EE2C2217B1006645CF /* LoginRemoteProtocol.swift in Sources */,
 				BAF4E5DE2C49C08A009B891F /* SPNavigationController.swift in Sources */,
 				B5DD0F922476309000C8DD41 /* NoteTableCellView.swift in Sources */,

--- a/Simplenote/AuthViewController+Swift.swift
+++ b/Simplenote/AuthViewController+Swift.swift
@@ -280,9 +280,9 @@ extension AuthViewController {
 
 
         do {
-//            let email = usernameText
-//            let remote = LoginRemote()
-//            try await remote.requestLoginEmail(email: email)
+            let email = usernameText
+            let remote = LoginRemote()
+            try await remote.requestLoginEmail(email: email)
 
             pushCodeLoginView()
         } catch {

--- a/Simplenote/AuthViewController+Swift.swift
+++ b/Simplenote/AuthViewController+Swift.swift
@@ -6,10 +6,6 @@ extension AuthViewController {
 
     @objc
     func setupInterface() {
-        if state == nil {
-            state = AuthenticationState()
-        }
-
         simplenoteTitleView.stringValue = "Simplenote"
         simplenoteSubTitleView.textColor = .simplenoteGray50Color
         simplenoteSubTitleView.stringValue = NSLocalizedString("The simplest way to keep notes.", comment: "Simplenote subtitle")
@@ -203,32 +199,32 @@ extension AuthViewController {
         ensureFirstTextFieldIsFirstResponder()
     }
 
-    private func authViewController(with mode: AuthenticationMode, state: AuthenticationState) -> AuthViewController {
-        let vc = AuthViewController()
-        vc.authenticator = authenticator
-        vc.state = state
-        vc.mode = mode
+    private func pushNewAuthViewController(with mode: AuthenticationMode, state: AuthenticationState) {
+        guard let authVC = AuthViewController(mode: mode, state: state) else {
+            return
+        }
+        authVC.authenticator = authenticator
 
-        return vc
+        containingNavigationController?.push(authVC)
     }
 
     @objc
     func pushEmailLoginView() {
-        containingNavigationController?.push(authViewController(with: .requestLoginCode, state: state))
+        pushNewAuthViewController(with: .requestLoginCode, state: state)
     }
 
     @objc
     func pushSignupView() {
-        containingNavigationController?.push(authViewController(with: .signup, state: state))
+        pushNewAuthViewController(with: .signup, state: state)
     }
 
     @objc
     func pushPasswordView() {
-        containingNavigationController?.push(authViewController(with: .loginWithPassword(), state: state))
+        pushNewAuthViewController(with: .loginWithPassword(), state: state)
     }
 
     func pushCodeLoginView() {
-        containingNavigationController?.push(authViewController(with: .loginWithCode, state: state))
+        pushNewAuthViewController(with: .loginWithCode, state: state)
     }
 }
 

--- a/Simplenote/AuthViewController+Swift.swift
+++ b/Simplenote/AuthViewController+Swift.swift
@@ -180,7 +180,7 @@ extension AuthViewController {
     ///
     @objc
     func ensureFirstTextFieldIsFirstResponder() {
-        firstVisibleTextField?.textField.becomeFirstResponder()
+        firstVisibleTextField?.becomeFirstResponder()
         view.needsDisplay = true
     }
 }
@@ -280,9 +280,9 @@ extension AuthViewController {
 
 
         do {
-            let email = usernameText
-            let remote = LoginRemote()
-            try await remote.requestLoginEmail(email: email)
+//            let email = usernameText
+//            let remote = LoginRemote()
+//            try await remote.requestLoginEmail(email: email)
 
             pushCodeLoginView()
         } catch {

--- a/Simplenote/AuthViewController+Swift.swift
+++ b/Simplenote/AuthViewController+Swift.swift
@@ -220,7 +220,7 @@ extension AuthViewController {
 
     @objc
     func pushPasswordView() {
-        pushNewAuthViewController(with: .loginWithPassword(), state: state)
+        pushNewAuthViewController(with: .loginWithPassword, state: state)
     }
 
     func pushCodeLoginView() {
@@ -235,7 +235,7 @@ extension AuthViewController {
 
     @IBAction
     func switchToPasswordAuth(_ sender: Any) {
-        mode = AuthenticationMode.loginWithPassword(header: nil)
+        mode = AuthenticationMode.loginWithPassword
     }
     
     @objc

--- a/Simplenote/AuthViewController.h
+++ b/Simplenote/AuthViewController.h
@@ -40,6 +40,7 @@
 @property (nonatomic, strong) AuthenticationMode                    *mode;
 @property (nonatomic, strong) AuthenticationState                   *state;
 
+- (instancetype)initWithMode:(AuthenticationMode*)mode state:(AuthenticationState*)state;
 - (void)pressedLogInWithPassword;
 - (void)pressedLoginWithMagicLink;
 - (void)pressedSignUp;

--- a/Simplenote/AuthViewController.m
+++ b/Simplenote/AuthViewController.m
@@ -23,11 +23,23 @@
     [[NSNotificationCenter defaultCenter] removeObserver: self];
 }
 
+- (instancetype)initWithMode:(AuthenticationMode*)mode state:(AuthenticationState*)state;
+{
+    if (self = [super init]) {
+        self.validator = [SPAuthenticationValidator new];
+        self.mode = mode;
+        self.state = state;
+    }
+
+    return self;
+}
+
 - (instancetype)init
 {
     if (self = [super init]) {
         self.validator = [SPAuthenticationValidator new];
         self.mode = [AuthenticationMode onboarding];
+        self.state = [AuthenticationState new];
     }
 
     return self;

--- a/Simplenote/AuthViewController.xib
+++ b/Simplenote/AuthViewController.xib
@@ -106,7 +106,7 @@
                                 <constraint firstAttribute="height" constant="40" id="hpG-uZ-e1S"/>
                             </constraints>
                             <userDefinedRuntimeAttributes>
-                                <userDefinedRuntimeAttribute type="boolean" keyPath="secure" value="YES"/>
+                                <userDefinedRuntimeAttribute type="boolean" keyPath="secure" value="NO"/>
                             </userDefinedRuntimeAttributes>
                         </customView>
                         <customView translatesAutoresizingMaskIntoConstraints="NO" id="Epn-oY-sfo" userLabel="Action View">

--- a/Simplenote/AuthWindowController.swift
+++ b/Simplenote/AuthWindowController.swift
@@ -78,8 +78,9 @@ extension AuthWindowController {
         }
         
         let authViewController = AuthViewController()
+        let navigationController = SPNavigationController(initialViewController: authViewController)
         authViewController.authenticator = authenticator
-        window.transition(to: authViewController)
+        window.transition(to: navigationController)
     }
     
     func switchToMagicLinkRequestedUI(email: String) {

--- a/Simplenote/AuthWindowController.swift
+++ b/Simplenote/AuthWindowController.swift
@@ -26,7 +26,7 @@ class AuthWindowController: NSWindowController, SPAuthenticationInterface {
     }
 
     init() {
-        self.authViewController = AuthViewController()
+        self.authViewController = AuthViewController(mode: .onboarding, state: AuthenticationState())
         let navigationController = SPNavigationController(initialViewController: authViewController)
         let window = NSWindow(contentViewController: navigationController)
         window.styleMask = [.borderless, .closable, .titled, .fullSizeContentView]

--- a/Simplenote/AuthenticationMode.swift
+++ b/Simplenote/AuthenticationMode.swift
@@ -199,7 +199,7 @@ private enum LoginStrings {
 }
 
 private enum MagicLinkStrings {
-    static let primaryAction        = NSLocalizedString("Instantly Log In with Email", comment: "Title of button for logging in")
+    static let primaryAction        = NSLocalizedString("Log in with email", comment: "Title of button for logging in")
     static let primaryAnimationText = NSLocalizedString("Requesting Email...", comment: "Title of button for logging in")
     static let secondaryAction      = NSLocalizedString("Continue with Password", comment: "Continue with Password Action")
     static let switchAction         = NSLocalizedString("Sign Up", comment: "Title of button for signing up")

--- a/Simplenote/AuthenticationMode.swift
+++ b/Simplenote/AuthenticationMode.swift
@@ -120,9 +120,9 @@ extension AuthenticationMode {
 
     /// Auth Mode: Login with Username + Password
     ///
-    static func loginWithPassword(header: String? = nil) -> AuthenticationMode {
+    static var loginWithPassword: AuthenticationMode {
         AuthenticationMode(title: NSLocalizedString("Log In with Password", comment: "LogIn Interface Title"),
-                           header: header,
+                           header: LoginStrings.loginWithEmailEmailHeader,
                            inputElements: [.password],
                            actions: [
                             AuthenticationActionDescriptor(name: .primary,
@@ -195,6 +195,7 @@ private enum LoginStrings {
     static let switchAction         = NSLocalizedString("Sign Up", comment: "Title of button for signing up")
     static let switchTip            = NSLocalizedString("Need an account?", comment: "Link to create an account")
     static let wordpressAction      = NSLocalizedString("Log in with WordPress.com", comment: "Title to use wordpress login instead of email")
+    static let loginWithEmailEmailHeader = NSLocalizedString("Enter the password for the account {{EMAIL}}", comment: "Header for Login With Password. Please preserve the {{EMAIL}} substring")
 }
 
 private enum MagicLinkStrings {

--- a/Simplenote/SPAuthenticationTextField+Simplenote.swift
+++ b/Simplenote/SPAuthenticationTextField+Simplenote.swift
@@ -1,0 +1,13 @@
+import Simperium_OSX
+
+extension SPAuthenticationTextField {
+    @discardableResult
+    override open func becomeFirstResponder() -> Bool {
+        let responderStatus = textField.becomeFirstResponder()
+
+        let selectedRange = textField.currentEditor()?.selectedRange
+        textField.currentEditor()?.selectedRange = NSMakeRange(selectedRange?.length ?? .zero, .zero)
+
+        return responderStatus
+    }
+}

--- a/Simplenote/SPNavigationController.swift
+++ b/Simplenote/SPNavigationController.swift
@@ -62,6 +62,12 @@ class SPNavigationController: NSViewController {
         backButton = button
         backButton.isHidden = hideBackButton
         button.bezelStyle = .accessoryBarAction
+        button.cell?.isBordered = false
+        button.contentTintColor = .darkGray
+        button.wantsLayer = true
+        button.layer?.cornerRadius = 5
+        let trackingArea = NSTrackingArea(rect: backButton.bounds, options: [.mouseEnteredAndExited, .activeAlways], owner: self)
+        button.addTrackingArea(trackingArea)
 
         view.addSubview(backButton)
         NSLayoutConstraint.activate([
@@ -190,5 +196,17 @@ class SPNavigationController: NSViewController {
         } completionHandler: {
             onCompletion()
         }
+    }
+}
+
+// MARK: - Button Hover Color Animation
+//
+extension SPNavigationController {
+    override func mouseEntered(with event: NSEvent) {
+        backButton.layer?.backgroundColor = NSColor.lightGray.withAlphaComponent(0.1).cgColor
+    }
+
+    override func mouseExited(with event: NSEvent) {
+        backButton.layer?.backgroundColor = .clear
     }
 }


### PR DESCRIPTION
### Fix
Magic link sign in on SNMac is almost there.  After the last few updates we did some testing and have identified a few things that needed to be fixed.  I have fixed many of those things in this PR.  The list of changes fixed here:
-On Invalid Token UI, when you hit the back button the buttons on the onboarding view don't respond
-Enter Code TextField should probably be readable (since it's easy to miss, and it expires quickly, anyways)
-Going Back from the Enter Code UI results in the "Enter Email" UI, with your email highlighted
-Enter password button's textColor doesn't match the border
-Enter Password UI needs a header, too, with the account's email (recently added in iOS).

### Test
####Login Flow####
1. Launch simplenote, click on login, enter a valid simplenote email into the field
2. Confirm that you receive a code in your email.  Type into the code text field and confirm that you can see the code text
3. Confirm that the password button has the correct color (same as it's border)
4. Click on the login with password button.  Confirm there is a header with your email in it
5. Click the back button twice. Confirm that the email is still in the field but the text is not highlighted

####Invalid Code####
1.  In the steps above you never used the login code.  Give that a bit of time to become in valid.  
2. Launch simplenote and then tap on the link.  You should see the invalid code ui
3. Tap on the back button
4. Confirm that on the view that appears you can use the signup and login buttons to get into the auth flow

### Review
***(Required)*** Add instructions for reviewers.  For example:
> Only one developer is required to review these changes, but anyone can perform the review.

### Release
***(Required)*** Add a concise statement to `RELEASE-NOTES.txt` if the changes should be included in release notes. Include details about updating the notes in this section. For example:
> These changes do not require release notes.
