### PR TITLE
Error Handling Upgrades

### DIFF
--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -104,6 +104,7 @@
 		B51AFE6E25D30A1800A196DF /* SearchField.swift in Sources */ = {isa = PBXBuildFile; fileRef = B51AFE6C25D30A1800A196DF /* SearchField.swift */; };
 		B51AFE7725D36CDD00A196DF /* NSFont+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B51AFE7525D36CDD00A196DF /* NSFont+Simplenote.swift */; };
 		B51D44582C52AB2200F296A7 /* SimplenoteEndpoints in Frameworks */ = {isa = PBXBuildFile; productRef = B51D44572C52AB2200F296A7 /* SimplenoteEndpoints */; };
+		B51D44672C52F5AE00F296A7 /* AuthenticationError.swift in Sources */ = {isa = PBXBuildFile; fileRef = B51D44662C52F5AE00F296A7 /* AuthenticationError.swift */; };
 		B51D85F525A8B392005F08CE /* NoteListPrefixFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B51D85F325A8B392005F08CE /* NoteListPrefixFormatter.swift */; };
 		B51E9FE222E615FA004F16B4 /* SPExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B51E9FE022E615FA004F16B4 /* SPExporter.swift */; };
 		B51E9FE622E644A0004F16B4 /* NSObject+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B51E9FE422E644A0004F16B4 /* NSObject+Helpers.swift */; };
@@ -510,6 +511,7 @@
 		B518D37D2507C356006EA7F8 /* StringSimplenoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringSimplenoteTests.swift; sourceTree = "<group>"; };
 		B51AFE6C25D30A1800A196DF /* SearchField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchField.swift; sourceTree = "<group>"; };
 		B51AFE7525D36CDD00A196DF /* NSFont+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSFont+Simplenote.swift"; sourceTree = "<group>"; };
+		B51D44662C52F5AE00F296A7 /* AuthenticationError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthenticationError.swift; sourceTree = "<group>"; };
 		B51D85F325A8B392005F08CE /* NoteListPrefixFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteListPrefixFormatter.swift; sourceTree = "<group>"; };
 		B51E9FE022E615FA004F16B4 /* SPExporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPExporter.swift; sourceTree = "<group>"; };
 		B51E9FE422E644A0004F16B4 /* NSObject+Helpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSObject+Helpers.swift"; sourceTree = "<group>"; };
@@ -1356,6 +1358,7 @@
 			children = (
 				B5F5415325F0137100CAF52C /* MagicLinkAuthenticator.swift */,
 				B587D7E92C221575006645CF /* SimperiumAuthenticatorProtocol.swift */,
+				B51D44662C52F5AE00F296A7 /* AuthenticationError.swift */,
 			);
 			name = Authentication;
 			sourceTree = "<group>";
@@ -2196,6 +2199,7 @@
 				B5DD0F922476309000C8DD41 /* NoteTableCellView.swift in Sources */,
 				B503FF4924848D0B00066059 /* TagAttachmentCell.swift in Sources */,
 				466FFED417CC10A800399652 /* SPTableView.m in Sources */,
+				B51D44672C52F5AE00F296A7 /* AuthenticationError.swift in Sources */,
 				375D293921E033D1007AB25A /* escape.c in Sources */,
 				BA0B43CA26F2FCFC00B44A8C /* PreferencesViewController.swift in Sources */,
 				B53BF19D24ABDE7C00938C34 /* DateFormatter+Simplenote.swift in Sources */,

--- a/Simplenote/AuthViewController+Swift.swift
+++ b/Simplenote/AuthViewController+Swift.swift
@@ -445,8 +445,8 @@ extension AuthViewController {
             showAuthenticationError(message)
 
         case .requestNotFound:
-// TODO
-            break
+            let message = NSLocalizedString("The authentication code you've requested has expired. Please request a new one", comment: "Login Code no longer exists")
+            showAuthenticationError(message)
 
         case .tooManyAttempts:
             let message = NSLocalizedString("Too many log in attempts. Try again later.", comment: "Error for too many login attempts")

--- a/Simplenote/AuthViewController.h
+++ b/Simplenote/AuthViewController.h
@@ -49,6 +49,8 @@
 - (void)setInterfaceEnabled:(BOOL)enabled;
 
 - (void)presentPasswordResetAlert;
+- (void)presentPasswordCompromisedAlert;
+- (void)presentUnverifiedEmailAlert;
 - (void)showAuthenticationErrorForCode:(NSInteger)responseCode responseString:(NSString *)responseString;
 
 @end

--- a/Simplenote/AuthViewController.m
+++ b/Simplenote/AuthViewController.m
@@ -284,49 +284,6 @@
     [self validateCodeInput];
 }
 
-- (void)showAuthenticationError:(NSString *)errorMessage {
-    [self.errorField setStringValue:errorMessage];
-}
-
-- (void)showAuthenticationErrorForCode:(NSInteger)responseCode responseString:(NSString *)responseString {
-    switch (responseCode) {
-        case 409:
-            [self showAuthenticationError:NSLocalizedString(@"That email is already being used", @"Error when address is in use")];
-            [self.view.window makeFirstResponder:self.usernameField];
-            break;
-        case 401:
-            if ([self isPasswordCompromisedResponse:responseString]) {
-                [self presentPasswordCompromisedAlert];
-            } else {
-                [self showAuthenticationError:NSLocalizedString(@"Bad email or password", @"Error for bad email or password")];
-            }
-            break;
-        case 403:
-            if ([self isRequiresVerificationdResponse:responseString]) {
-                [self presentUnverifiedEmailAlert];
-            } else {
-                [self showAuthenticationError:NSLocalizedString(@"Authorization failed", @"Error for authorization failure")];
-            }
-            break;
-        case 429:
-            [self showAuthenticationError:NSLocalizedString(@"Too many log in attempts. Try again later.", @"Error for too many login attempts")];
-            break;
-        default:
-            [self showAuthenticationError:NSLocalizedString(@"We're having problems. Please try again soon.", @"Generic error")];
-            break;
-    }
-}
-
-- (BOOL)isPasswordCompromisedResponse:(NSString *)responseString
-{
-   return ([responseString isEqual:@"compromised password"]);
-}
-
-- (BOOL)isRequiresVerificationdResponse:(NSString *)responseString
-{
-   return ([responseString isEqual:@"verification required"]);
-}
-
 -(void)presentPasswordCompromisedAlert
 {
     __weak typeof(self) weakSelf = self;

--- a/Simplenote/AuthenticationError.swift
+++ b/Simplenote/AuthenticationError.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+
+// MARK: - AuthenticationError
+//
+public enum AuthenticationError: Error {
+    case compromisedPassword
+    case invalidCode
+    case loginBadCredentials
+    case network
+    case requestNotFound
+    case tooManyAttempts
+    case unverifiedEmail
+    case unknown(statusCode: Int, response: String?, error: Error?)
+}
+
+
+// MARK: - Initializers
+//
+extension AuthenticationError {
+
+    /// Returns the AuthenticationError for a given Login statusCode + Response
+    ///
+    public init(statusCode: Int, response: String?, error: Error?) {
+        switch statusCode {
+        case .zero:
+            self = .network
+        case 400 where response == ErrorResponse.requestNotFound:
+            self = .requestNotFound
+        case 400 where response == ErrorResponse.invalidCode:
+            self = .invalidCode
+        case 401 where response == ErrorResponse.compromisedPassword:
+            self = .compromisedPassword
+        case 401:
+            self = .loginBadCredentials
+        case 403 where response == ErrorResponse.requiresVerification:
+            self = .unverifiedEmail
+        case 429:
+            self = .tooManyAttempts
+        default:
+            self = .unknown(statusCode: statusCode, response: response, error: error)
+        }
+    }
+}
+
+
+// MARK: - Error Responses
+//
+private struct ErrorResponse {
+    static let compromisedPassword = "compromised password"
+    static let requiresVerification = "verification required"
+    static let requestNotFound = "request-not-found"
+    static let invalidCode = "invalid-code"
+}

--- a/Simplenote/AuthenticationMode.swift
+++ b/Simplenote/AuthenticationMode.swift
@@ -147,7 +147,8 @@ extension AuthenticationMode {
                                                            selector: #selector(AuthViewController.pressedLoginWithMagicLink),
                                                            text: MagicLinkStrings.primaryAction),
                             AuthenticationActionDescriptor(name: .tertiary,
-                                                           selector: #selector(AuthViewController.wordpressSSOAction), text: LoginStrings.wordpressAction)
+                                                           selector: #selector(AuthViewController.wordpressSSOAction),
+                                                           text: LoginStrings.wordpressAction)
                            ],
                            primaryActionAnimationText: MagicLinkStrings.primaryAnimationText)
     }


### PR DESCRIPTION
### Fix
In this PR we're bringing `AuthenticationError` from iOS, and simplifying, a bit, our Authentication Error Handlers.

### Test
- [x] Verify that attempting to log in with the wrong Code triggers a relevant error
- [x] Verify that attempting to log in with the wrong Password also triggers a relevant error
- [x] Verify that quickly requesting x4 codes gets you rate limited, and the error is relevant
- [x] Verify that attempting to use an expired code, gets you a relevant error too (they expire in 5 min?)

**Important:** We'll improve on the `requestNotFound` error (code expired) flow in a follow up. I'll touch base with Sly, and align both iOS and macOS.

### Release
> These changes do not require release notes.
