### PR TITLE
AuthenticationMode: RateLimiting Fallback

### DIFF
--- a/Simplenote/AuthViewController+Swift.swift
+++ b/Simplenote/AuthViewController+Swift.swift
@@ -428,6 +428,12 @@ extension AuthViewController {
             showLoginCodeExpiredAlert()
 
         case .tooManyAttempts:
+            if let fallbackMode = mode.rateLimitingFallbackMode?() {
+                pushNewAuthViewController(with: fallbackMode, state: state)
+                break
+            }
+
+            /// No fallback =(
             let message = NSLocalizedString("Too many log in attempts. Try again later.", comment: "Error for too many login attempts")
             showAuthenticationError(message)
 


### PR DESCRIPTION
### Fix
In this PR we're building "special" handling whenever the `Request Login Code` endpoint returns 429.

### Test
1. Fresh install Simplenote macOS
2. Click on `Log in`
3. Enter your email and click `Log in with email`
4. Click back, and click on `Log in with email` about 4x times

- [x] Verify that eventually you get rate limited
- [x] Verify that you get sent straight to the `Enter Password` UI, whenever you're rate limited

### Release
> These changes do not require release notes.
