### PR TITLE
Magic Links: Fix window resizing animation + some clean up

### DIFF
--- a/Simplenote/SPNavigationController.swift
+++ b/Simplenote/SPNavigationController.swift
@@ -17,7 +17,7 @@ class SPNavigationController: NSViewController {
     
     private var heightConstraint: NSLayoutConstraint!
     private var totalTopPadding: CGFloat {
-        Constants.buttonViewLeadingPadding + Constants.buttonViewHeight
+        Constants.buttonViewTopPadding + Constants.buttonViewHeight
     }
 
     init(initialViewController: NSViewController) {

--- a/Simplenote/SPNavigationController.swift
+++ b/Simplenote/SPNavigationController.swift
@@ -95,13 +95,6 @@ class SPNavigationController: NSViewController {
         let currentView = topViewController?.view
 
         attach(child: viewController)
-        
-        /// Disable Bottom Constraint
-        /// This allows for the enclosing NSWindow to resize, just enough to fit the `nextViewController.view`
-        ///
-        if let currentView, let bottomConstraint = view.firstContraint(firstView: currentView, firstAttribute: .bottom) {
-            bottomConstraint.isActive = false
-        }
 
         guard let (leadingAnchor, trailingAnchor) = attachView(subview: viewController.view, below: currentView) else {
             return
@@ -162,8 +155,7 @@ class SPNavigationController: NSViewController {
         NSLayoutConstraint.activate([
             leadingAnchor,
             trailingAnchor,
-            subview.topAnchor.constraint(equalTo: backButton.bottomAnchor) //,
-//            subview.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+            subview.topAnchor.constraint(equalTo: backButton.bottomAnchor)
         ])
 
         NSLog("# After Window Height \(view.window?.frame.height.description) - size \(subview.intrinsicContentSize) - \(subview.fittingSize)")
@@ -174,13 +166,6 @@ class SPNavigationController: NSViewController {
     func popViewController() {
         guard viewStack.count > 1, let currentViewController = viewStack.popLast(), let nextViewController = viewStack.last else {
             return
-        }
-        
-        /// Disable Bottom Constraint
-        /// This allows for the enclosing NSWindow to resize, just enough to fit the `nextViewController.view`
-        ///
-        if let currentBottomConstraint = view.firstContraint(firstView: currentViewController.view, firstAttribute: .bottom) {
-            currentBottomConstraint.isActive = false
         }
   
         attachView(subview: nextViewController.view, below: currentViewController.view)

--- a/Simplenote/SPNavigationController.swift
+++ b/Simplenote/SPNavigationController.swift
@@ -99,7 +99,7 @@ class SPNavigationController: NSViewController {
 
         guard animated else {
             currentView?.removeFromSuperview()
-            backButton.animator().isHidden = hideBackButton
+            backButton.isHidden = hideBackButton
             return
         }
 

--- a/Simplenote/SPNavigationController.swift
+++ b/Simplenote/SPNavigationController.swift
@@ -41,7 +41,6 @@ class SPNavigationController: NSViewController {
         view.translatesAutoresizingMaskIntoConstraints = false
         initialView.translatesAutoresizingMaskIntoConstraints = false
 
-        attach(child: initialViewController)
         attachView(subview: initialViewController.view, below: nil, animated: false)
 
         /// "Hint" we wanna occupy as little as possible. This constraint is meant to be broken, but the layout system will
@@ -92,7 +91,7 @@ class SPNavigationController: NSViewController {
 
     // MARK: - Add a View to the stack
     //
-    func push(_ viewController: NSViewController, animated: Bool = true) {
+    func push(_ viewController: NSViewController, animated: Bool = false) {
         let currentView = topViewController?.view
 
         attach(child: viewController)
@@ -102,6 +101,8 @@ class SPNavigationController: NSViewController {
         }
 
         guard animated else {
+            currentView?.removeFromSuperview()
+            backButton.animator().isHidden = hideBackButton
             return
         }
 
@@ -123,9 +124,10 @@ class SPNavigationController: NSViewController {
 
         let padding = Constants.buttonViewLeadingPadding + Constants.buttonViewHeight
         let finalHeight = subview.fittingSize.height + padding
-        
-        if let siblingView {
-            heightConstraint?.constant = siblingView.fittingSize.height + padding
+
+        if let siblingView,
+           animated {
+            heightConstraint?.constant = finalHeight
             view.addSubview(subview, positioned: .below, relativeTo: siblingView)
         } else {
             view.addSubview(subview)
@@ -158,12 +160,18 @@ class SPNavigationController: NSViewController {
     }
 
     // MARK: - Remove view from stack
-    func popViewController(animated: Bool = true) {
+    func popViewController(animated: Bool = false) {
         guard viewStack.count > 1, let currentViewController = viewStack.popLast(), let nextViewController = viewStack.last else {
             return
         }
   
         attachView(subview: nextViewController.view, below: currentViewController.view, animated: animated)
+
+        guard animated else {
+            self.dettach(child: currentViewController)
+            backButton.isHidden = hideBackButton
+            return
+        }
 
         animateTransition(slidingView: currentViewController.view, fadingView: nextViewController.view, direction: .leadingToTrailing) {
             self.dettach(child: currentViewController)

--- a/Simplenote/SPNavigationController.swift
+++ b/Simplenote/SPNavigationController.swift
@@ -16,6 +16,9 @@ class SPNavigationController: NSViewController {
     }
     
     private var heightConstraint: NSLayoutConstraint!
+    private var totalTopPadding: CGFloat {
+        Constants.buttonViewLeadingPadding + Constants.buttonViewHeight
+    }
 
     init(initialViewController: NSViewController) {
         super.init(nibName: nil, bundle: nil)
@@ -41,6 +44,7 @@ class SPNavigationController: NSViewController {
         initialView.translatesAutoresizingMaskIntoConstraints = false
 
         attachView(subview: initialViewController.view, below: nil, animated: false)
+        resizeWindow(to: initialViewController.view, animated: false)
 
         NSLayoutConstraint.activate([
             initialView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
@@ -89,6 +93,7 @@ class SPNavigationController: NSViewController {
 
         attach(child: viewController)
         attachView(subview: viewController.view, below: currentView, animated: animated)
+        resizeWindow(to: viewController.view, animated: animated)
 
         guard animated else {
             currentView?.removeFromSuperview()
@@ -107,25 +112,25 @@ class SPNavigationController: NSViewController {
     }
 
     private func attachView(subview: NSView, below siblingView: NSView?, animated: Bool) {
-
-        let padding = Constants.buttonViewLeadingPadding + Constants.buttonViewHeight
-        let finalHeight = subview.fittingSize.height + padding
+        subview.translatesAutoresizingMaskIntoConstraints = false
 
         if let siblingView,
            animated {
-            heightConstraint.constant = siblingView.fittingSize.height + padding
+            heightConstraint.constant = siblingView.fittingSize.height + totalTopPadding
             view.addSubview(subview, positioned: .below, relativeTo: siblingView)
         } else {
             view.addSubview(subview)
         }
-
-        subview.translatesAutoresizingMaskIntoConstraints = false
 
         NSLayoutConstraint.activate([
             subview.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             subview.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             subview.topAnchor.constraint(equalTo: backButton.bottomAnchor)
         ])
+    }
+
+    private func resizeWindow(to subview: NSView, animated: Bool) {
+        let finalHeight = subview.fittingSize.height + totalTopPadding
 
         guard animated else {
             heightConstraint.constant = finalHeight
@@ -147,6 +152,7 @@ class SPNavigationController: NSViewController {
         }
   
         attachView(subview: nextViewController.view, below: currentViewController.view, animated: animated)
+        resizeWindow(to: nextViewController.view, animated: animated)
 
         guard animated else {
             dettach(child: currentViewController)

--- a/Simplenote/SPNavigationController.swift
+++ b/Simplenote/SPNavigationController.swift
@@ -34,14 +34,16 @@ class SPNavigationController: NSViewController {
 
         view = NSView()
         heightConstraint = view.heightAnchor.constraint(equalToConstant: .zero)
+        heightConstraint?.isActive = true
         let initialView = initialViewController.view
         backButton = insertBackButton()
 
         view.translatesAutoresizingMaskIntoConstraints = false
         initialView.translatesAutoresizingMaskIntoConstraints = false
 
-        view.addSubview(initialView)
-                
+        attach(child: initialViewController)
+        attachView(subview: initialViewController.view, below: nil, animated: false)
+
         /// "Hint" we wanna occupy as little as possible. This constraint is meant to be broken, but the layout system will
         /// attempt to reduce the Height, when possible
         ///
@@ -131,7 +133,6 @@ class SPNavigationController: NSViewController {
 
         subview.translatesAutoresizingMaskIntoConstraints = false
 
-        heightConstraint?.isActive = true
         let leadingAnchor = subview.leadingAnchor.constraint(equalTo: view.leadingAnchor)
         let trailingAnchor = subview.trailingAnchor.constraint(equalTo: view.trailingAnchor)
 

--- a/Simplenote/SPNavigationController.swift
+++ b/Simplenote/SPNavigationController.swift
@@ -15,9 +15,7 @@ class SPNavigationController: NSViewController {
         viewStack.last
     }
     
-    private lazy var heightConstraint: NSLayoutConstraint = {
-        view.heightAnchor.constraint(equalToConstant: 300)
-    }()
+    private var heightConstraint: NSLayoutConstraint? = nil
 
     init(initialViewController: NSViewController) {
         super.init(nibName: nil, bundle: nil)
@@ -35,6 +33,7 @@ class SPNavigationController: NSViewController {
         }
 
         view = NSView()
+        heightConstraint = view.heightAnchor.constraint(equalToConstant: .zero)
         let initialView = initialViewController.view
         backButton = insertBackButton()
 
@@ -124,7 +123,7 @@ class SPNavigationController: NSViewController {
         let finalHeight = subview.fittingSize.height + padding
         
         if let siblingView {
-            heightConstraint.constant = siblingView.fittingSize.height + padding
+            heightConstraint?.constant = siblingView.fittingSize.height + padding
             view.addSubview(subview, positioned: .below, relativeTo: siblingView)
         } else {
             view.addSubview(subview)
@@ -132,7 +131,7 @@ class SPNavigationController: NSViewController {
 
         subview.translatesAutoresizingMaskIntoConstraints = false
 
-        heightConstraint.isActive = true
+        heightConstraint?.isActive = true
         let leadingAnchor = subview.leadingAnchor.constraint(equalTo: view.leadingAnchor)
         let trailingAnchor = subview.trailingAnchor.constraint(equalTo: view.trailingAnchor)
 
@@ -143,7 +142,7 @@ class SPNavigationController: NSViewController {
         ])
 
         guard animated else {
-            heightConstraint.constant = finalHeight
+            heightConstraint?.constant = finalHeight
             return (leading: leadingAnchor, trailing: trailingAnchor)
         }
 
@@ -151,7 +150,7 @@ class SPNavigationController: NSViewController {
             context.duration = 0.4
             context.timingFunction = .init(name: .easeInEaseOut)
 
-            heightConstraint.animator().constant = finalHeight
+            heightConstraint?.animator().constant = finalHeight
         }
 
         return (leading: leadingAnchor, trailing: trailingAnchor)

--- a/Simplenote/SPNavigationController.swift
+++ b/Simplenote/SPNavigationController.swift
@@ -115,7 +115,6 @@ class SPNavigationController: NSViewController {
         subview.translatesAutoresizingMaskIntoConstraints = false
 
         if let siblingView {
-//            heightConstraint.constant = siblingView.fittingSize.height + totalTopPadding
             view.addSubview(subview, positioned: .below, relativeTo: siblingView)
         } else {
             view.addSubview(subview)

--- a/Simplenote/SPNavigationController.swift
+++ b/Simplenote/SPNavigationController.swift
@@ -43,7 +43,7 @@ class SPNavigationController: NSViewController {
         view.translatesAutoresizingMaskIntoConstraints = false
         initialView.translatesAutoresizingMaskIntoConstraints = false
 
-        attachView(subview: initialViewController.view, below: nil, animated: false)
+        attachView(subview: initialViewController.view, below: nil)
         resizeWindow(to: initialViewController.view, animated: false)
 
         NSLayoutConstraint.activate([
@@ -92,7 +92,7 @@ class SPNavigationController: NSViewController {
         let currentView = topViewController?.view
 
         attach(child: viewController)
-        attachView(subview: viewController.view, below: currentView, animated: animated)
+        attachView(subview: viewController.view, below: currentView)
         resizeWindow(to: viewController.view, animated: animated)
 
         guard animated else {
@@ -111,12 +111,11 @@ class SPNavigationController: NSViewController {
         viewStack.append(child)
     }
 
-    private func attachView(subview: NSView, below siblingView: NSView?, animated: Bool) {
+    private func attachView(subview: NSView, below siblingView: NSView?) {
         subview.translatesAutoresizingMaskIntoConstraints = false
 
-        if let siblingView,
-           animated {
-            heightConstraint.constant = siblingView.fittingSize.height + totalTopPadding
+        if let siblingView {
+//            heightConstraint.constant = siblingView.fittingSize.height + totalTopPadding
             view.addSubview(subview, positioned: .below, relativeTo: siblingView)
         } else {
             view.addSubview(subview)
@@ -151,7 +150,7 @@ class SPNavigationController: NSViewController {
             return
         }
   
-        attachView(subview: nextViewController.view, below: currentViewController.view, animated: animated)
+        attachView(subview: nextViewController.view, below: currentViewController.view)
         resizeWindow(to: nextViewController.view, animated: animated)
 
         guard animated else {

--- a/Simplenote/SPNavigationController.swift
+++ b/Simplenote/SPNavigationController.swift
@@ -119,14 +119,9 @@ class SPNavigationController: NSViewController {
 
     @discardableResult
     private func attachView(subview: NSView, below siblingView: NSView?) -> (leading: NSLayoutConstraint, trailing: NSLayoutConstraint)? {
-        
-        NSLog("# Before Window Height \(view.window?.frame.height.description) - size \(subview.intrinsicContentSize) - \(subview.fittingSize)")
-        
-        let padding = (view.window?.frame.height ?? .zero) - backButton.frame.minY
-        NSLog("# Button Origin \(backButton.frame.minY) - \(padding)")
-        
+
+        let padding = Constants.buttonViewLeadingPadding + Constants.buttonViewHeight
         let finalHeight = subview.fittingSize.height + padding
-        NSLog("# Button Origin \(finalHeight)")
         
         if let siblingView {
             heightConstraint.constant = siblingView.fittingSize.height + padding
@@ -158,7 +153,6 @@ class SPNavigationController: NSViewController {
             subview.topAnchor.constraint(equalTo: backButton.bottomAnchor)
         ])
 
-        NSLog("# After Window Height \(view.window?.frame.height.description) - size \(subview.intrinsicContentSize) - \(subview.fittingSize)")
         return (leading: leadingAnchor, trailing: trailingAnchor)
     }
 

--- a/Simplenote/SPNavigationController.swift
+++ b/Simplenote/SPNavigationController.swift
@@ -158,7 +158,7 @@ class SPNavigationController: NSViewController {
         attachView(subview: nextViewController.view, below: currentViewController.view, animated: animated)
 
         guard animated else {
-            self.dettach(child: currentViewController)
+            dettach(child: currentViewController)
             backButton.isHidden = hideBackButton
             return
         }

--- a/Simplenote/SPNavigationController.swift
+++ b/Simplenote/SPNavigationController.swift
@@ -75,10 +75,10 @@ class SPNavigationController: NSViewController {
 
         view.addSubview(backButton)
         NSLayoutConstraint.activate([
-            backButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 10),
-            backButton.topAnchor.constraint(equalTo: view.topAnchor, constant: 30),
-            backButton.widthAnchor.constraint(equalToConstant: 50),
-            backButton.heightAnchor.constraint(equalToConstant: 30)
+            backButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: Constants.buttonViewLeadingPadding),
+            backButton.topAnchor.constraint(equalTo: view.topAnchor, constant: Constants.buttonViewTopPadding),
+            backButton.widthAnchor.constraint(equalToConstant: Constants.buttonViewWidth),
+            backButton.heightAnchor.constraint(equalToConstant: Constants.buttonViewHeight)
         ])
 
         return button
@@ -235,4 +235,11 @@ extension SPNavigationController {
     override func mouseExited(with event: NSEvent) {
         backButton.layer?.backgroundColor = .clear
     }
+}
+
+private struct Constants {
+    static let buttonViewWidth = CGFloat(50)
+    static let buttonViewHeight = CGFloat(30)
+    static let buttonViewTopPadding = CGFloat(30)
+    static let buttonViewLeadingPadding = CGFloat(10)
 }

--- a/Simplenote/SPNavigationController.swift
+++ b/Simplenote/SPNavigationController.swift
@@ -145,8 +145,6 @@ class SPNavigationController: NSViewController {
 
             heightConstraint?.animator().constant = finalHeight
         }
-
-        return
     }
 
     // MARK: - Remove view from stack

--- a/Simplenote/SPNavigationController.swift
+++ b/Simplenote/SPNavigationController.swift
@@ -15,7 +15,7 @@ class SPNavigationController: NSViewController {
         viewStack.last
     }
     
-    private var heightConstraint: NSLayoutConstraint? = nil
+    private var heightConstraint: NSLayoutConstraint!
 
     init(initialViewController: NSViewController) {
         super.init(nibName: nil, bundle: nil)
@@ -34,7 +34,6 @@ class SPNavigationController: NSViewController {
 
         view = NSView()
         heightConstraint = view.heightAnchor.constraint(equalToConstant: .zero)
-        heightConstraint?.isActive = true
         let initialView = initialViewController.view
         backButton = insertBackButton()
 
@@ -43,18 +42,12 @@ class SPNavigationController: NSViewController {
 
         attachView(subview: initialViewController.view, below: nil, animated: false)
 
-        /// "Hint" we wanna occupy as little as possible. This constraint is meant to be broken, but the layout system will
-        /// attempt to reduce the Height, when possible
-        ///
-        let minimumHeightConstraint = view.heightAnchor.constraint(equalToConstant: .zero)
-        minimumHeightConstraint.priority = .init(1)
-
         NSLayoutConstraint.activate([
             initialView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             initialView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             initialView.topAnchor.constraint(equalTo: backButton.bottomAnchor),
             initialView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-            minimumHeightConstraint
+            heightConstraint
         ])
     }
 
@@ -120,7 +113,7 @@ class SPNavigationController: NSViewController {
 
         if let siblingView,
            animated {
-            heightConstraint?.constant = siblingView.fittingSize.height + padding
+            heightConstraint.constant = siblingView.fittingSize.height + padding
             view.addSubview(subview, positioned: .below, relativeTo: siblingView)
         } else {
             view.addSubview(subview)
@@ -135,7 +128,7 @@ class SPNavigationController: NSViewController {
         ])
 
         guard animated else {
-            heightConstraint?.constant = finalHeight
+            heightConstraint.constant = finalHeight
             return
         }
 
@@ -143,7 +136,7 @@ class SPNavigationController: NSViewController {
             context.duration = 0.4
             context.timingFunction = .init(name: .easeInEaseOut)
 
-            heightConstraint?.animator().constant = finalHeight
+            heightConstraint.animator().constant = finalHeight
         }
     }
 


### PR DESCRIPTION
### Fix
We had noticed some wonky animations when pushing and popping from one view to another during the auth login/signup flow.  This was causing the size of the window to jump to meet the new view size.  Didn't look great.  In this PR we have updated the animations so that it will animate smoothly to the new size of the view loaded into the navigation controller.  Huge T/Y to @jleandroperez for the assist on this one.

Also while I was in there I fixed an issue where if you don't animate the navigation controller push/pop the views didn't size and the back button didn't hide correctly (we don't really need this, but if we are gonna build the component might as well make it work correctly)

 and I did a bit of cleanup to make the methods simpler.

relies on #1202 

### Test
***(Required)*** List the steps to test the behavior.  For example:
1. Launch Simplenote Mac to the onboarding/auth screen.  
2. Tap on the sign up button, then the back button, then the login button, then the back button again.

- [ ] Confirm that the views animate smoothly
- [ ] Confirm that the back button appears when you go off the initial view and disappears when you return to it.
- [ ] Confirm the size of the window changes to match the new view that appears.

### Review
***(Required)*** Add instructions for reviewers.  For example:
> Only one developer is required to review these changes, but anyone can perform the review.

### Release
***(Required)*** Add a concise statement to `RELEASE-NOTES.txt` if the changes should be included in release notes. Include details about updating the notes in this section. For example:
> These changes do not require release notes.
