### PR TITLE
Add username/password fallback option for login

### DIFF
--- a/Simplenote/AuthViewController+Swift.swift
+++ b/Simplenote/AuthViewController+Swift.swift
@@ -170,6 +170,7 @@ extension AuthViewController {
         actionsSeparatorView.isHidden   = !inputElements.contains(.actionSeparator)
 
         usernameField.stringValue = state.username
+        usernameField.textField?.nextResponder = passwordField.textField
     }
 
     /// Drops any Errors onscreen

--- a/Simplenote/AuthViewController+Swift.swift
+++ b/Simplenote/AuthViewController+Swift.swift
@@ -150,6 +150,8 @@ extension AuthViewController {
 
             if let title = descriptor.text {
                 actionView.title = title
+            } else if let attributedTitle = descriptor.attributedText {
+                actionView.attributedTitle = attributedTitle
             }
 
             actionView.action = descriptor.selector
@@ -225,6 +227,11 @@ extension AuthViewController {
 
     func pushCodeLoginView() {
         pushNewAuthViewController(with: .loginWithCode, state: state)
+    }
+
+    @objc
+    func pushUsernameAndPasswordView() {
+        pushNewAuthViewController(with: .loginWithUsernameAndPassword, state: state)
     }
 }
 

--- a/Simplenote/AuthViewController+Swift.swift
+++ b/Simplenote/AuthViewController+Swift.swift
@@ -169,6 +169,7 @@ extension AuthViewController {
         codeTextField.isHidden          = !inputElements.contains(.code)
         actionsSeparatorView.isHidden   = !inputElements.contains(.actionSeparator)
 
+        usernameField.stringValue = state.username
     }
 
     /// Drops any Errors onscreen

--- a/Simplenote/AuthViewController.xib
+++ b/Simplenote/AuthViewController.xib
@@ -142,7 +142,7 @@
                                 <font key="font" metaFont="systemMedium" size="13"/>
                             </buttonCell>
                             <constraints>
-                                <constraint firstAttribute="height" constant="20" id="HrL-ss-QSd"/>
+                                <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="20" id="HrL-ss-QSd"/>
                             </constraints>
                         </button>
                         <customView appearanceType="darkAqua" translatesAutoresizingMaskIntoConstraints="NO" id="WI9-SH-Yrp" userLabel="Actions Separator View">

--- a/Simplenote/AuthenticationMode.swift
+++ b/Simplenote/AuthenticationMode.swift
@@ -127,7 +127,7 @@ extension AuthenticationMode {
     }
 
     static var loginWithUsernameAndPassword: AuthenticationMode {
-        buildLoginWithPasswordMode(header: LoginStrings.loginWithEmailEmailHeader, includeUsername: true)
+        buildLoginWithPasswordMode(header: nil, includeUsername: true)
     }
 
     /// Auth Mode: Login with Username + Password + Rate Limiting Header
@@ -138,7 +138,7 @@ extension AuthenticationMode {
 
     /// Builds the loginWithPassword Mode with the specified Header
     ///
-    private static func buildLoginWithPasswordMode(header: String, includeUsername: Bool = false) -> AuthenticationMode {
+    private static func buildLoginWithPasswordMode(header: String?, includeUsername: Bool = false) -> AuthenticationMode {
         let inputElements: AuthenticationInputElements = includeUsername ? [.username, .password] : [.password]
         return AuthenticationMode(title: NSLocalizedString("Log In with Password", comment: "LogIn Interface Title"),
                            header: header,

--- a/Simplenote/AuthenticationMode.swift
+++ b/Simplenote/AuthenticationMode.swift
@@ -125,7 +125,11 @@ extension AuthenticationMode {
     static var loginWithPassword: AuthenticationMode {
         buildLoginWithPasswordMode(header: LoginStrings.loginWithEmailEmailHeader)
     }
-    
+
+    static var loginWithUsernameAndPassword: AuthenticationMode {
+        buildLoginWithPasswordMode(header: LoginStrings.loginWithEmailEmailHeader, includeUsername: true)
+    }
+
     /// Auth Mode: Login with Username + Password + Rate Limiting Header
     ///
     static var loginWithPasswordRateLimited: AuthenticationMode {
@@ -134,10 +138,11 @@ extension AuthenticationMode {
 
     /// Builds the loginWithPassword Mode with the specified Header
     ///
-    private static func buildLoginWithPasswordMode(header: String) -> AuthenticationMode {
-        AuthenticationMode(title: NSLocalizedString("Log In with Password", comment: "LogIn Interface Title"),
+    private static func buildLoginWithPasswordMode(header: String, includeUsername: Bool = false) -> AuthenticationMode {
+        let inputElements: AuthenticationInputElements = includeUsername ? [.username, .password] : [.password]
+        return AuthenticationMode(title: NSLocalizedString("Log In with Password", comment: "LogIn Interface Title"),
                            header: header,
-                           inputElements: [.password],
+                           inputElements: inputElements,
                            actions: [
                             AuthenticationActionDescriptor(name: .primary,
                                                            selector: #selector(AuthViewController.pressedLogInWithPassword),
@@ -160,6 +165,10 @@ extension AuthenticationMode {
                             AuthenticationActionDescriptor(name: .primary,
                                                            selector: #selector(AuthViewController.pressedLoginWithMagicLink),
                                                            text: MagicLinkStrings.primaryAction),
+                            AuthenticationActionDescriptor(name: .secondary,
+                                                           selector: #selector(AuthViewController.pushUsernameAndPasswordView),
+                                                           text: nil,
+                                                           attributedText: LoginStrings.usernameAndPasswordOption),
                             AuthenticationActionDescriptor(name: .tertiary,
                                                            selector: #selector(AuthViewController.wordpressSSOAction),
                                                            text: LoginStrings.wordpressAction)
@@ -213,6 +222,23 @@ private enum LoginStrings {
     static let wordpressAction      = NSLocalizedString("Log in with WordPress.com", comment: "Title to use wordpress login instead of email")
     static let loginWithEmailEmailHeader = NSLocalizedString("Enter the password for the account {{EMAIL}}", comment: "Header for Login With Password. Please preserve the {{EMAIL}} substring")
     static let loginWithEmailLimitHeader = NSLocalizedString("Log in with email failed, please enter the password for {{EMAIL}}", comment: "Header for Enter Password UI, when the user performed too many requests")
+
+    /// Returns a formatted Secondary Action String for Optional Username and password login
+    ///
+    static var usernameAndPasswordOption: NSAttributedString {
+        let output = NSMutableAttributedString(string: String(), attributes: [
+            .font: NSFont.preferredFont(forTextStyle: .subheadline)
+        ])
+
+        let prefix = NSLocalizedString("We'll email you a code to log in, \nor you can", comment: "Option to login with username and password *PREFIX*: printed in dark color")
+        let suffix = NSLocalizedString("log in manually.", comment: "Option to login with username and password *SUFFIX*: Concatenated with a space, after the PREFIX, and printed in blue")
+
+        output.append(string: prefix, foregroundColor: NSColor(studioColor: ColorStudio.gray60))
+        output.append(string: " ")
+        output.append(string: suffix, foregroundColor: NSColor(studioColor: ColorStudio.spBlue60))
+
+        return output
+    }
 
 }
 

--- a/Simplenote/NSMutableAttributedString+Simplenote.swift
+++ b/Simplenote/NSMutableAttributedString+Simplenote.swift
@@ -21,8 +21,13 @@ extension NSMutableAttributedString {
 
     /// Appends the specified String
     ///
-    func append(string: String) {
-        let string = NSAttributedString(string: string)
+    func append(string: String, foregroundColor: NSColor? = nil) {
+        var attributes = [NSAttributedString.Key: Any]()
+        if let foregroundColor = foregroundColor {
+            attributes[.foregroundColor] = foregroundColor
+        }
+
+        let string = NSAttributedString(string: string, attributes: attributes)
         append(string)
     }
 


### PR DESCRIPTION
Fix
We have received some feedback about the new login flow that some people thought we had dropped the login with password option. We have decided to add a button on the login with email page where users can choose to login with email and password instead. This surfaces this option for users who wants it and doesn't require receiving the login email to before you can enter your password. This also helps in circumstances where GAE might be down and login with email isn't possible.

| Login | Username/Password |
|--------|--------|
| <img src="https://cdn-std.droplr.net/files/acc_593859/RkQl1t" /> | <img src="https://cdn-std.droplr.net/files/acc_593859/nL5zXq" /> | 

### Test
1. Clean install Simplenote
2. On the onboarding page, tap on Sign up. Make sure that you see the username field and the terms and conditions info
3. Go back, tap on Log In.
- [x] confirm that you see the option We'll email you a code to log in, or you can log in manually
- [x] Tap on that and confirm you are shown a login page with username and password fields
- [x] confirm that you can login from that page if you enter both pieces of info

Smoke test the magic links flow and make sure it still looks as expected

### Review
***(Required)*** Add instructions for reviewers.  For example:
> Only one developer is required to review these changes, but anyone can perform the review.

### Release
> These changes do not require release notes.
