### PR TITLE
Update: Fix privacy notice for California users

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,6 @@
 2.22
 -----
-
+- Updated link to privacy notice for California users
 
 2.21
 -----

--- a/Simplenote/Resources/AppStoreStrings.pot
+++ b/Simplenote/Resources/AppStoreStrings.pot
@@ -37,7 +37,7 @@ msgid ""
 "\n"
 "Privacy Policy: https://automattic.com/privacy/\n"
 "Terms of Service: https://simplenote.com/terms/\n"
-"California users privacy notice: https://wp.me/Pe4R-d/#california-consumer-privacy-act-ccpa\n"
+"Privacy Notice for California Users: https://automattic.com/privacy/#us-privacy-laws\n"
 msgstr ""
 
 #. translators: Keywords used in the App Store search engine to find the app.

--- a/fastlane/appstoreres/metadata/source/description.txt
+++ b/fastlane/appstoreres/metadata/source/description.txt
@@ -14,4 +14,4 @@ Happy noting!
 
 Privacy Policy: https://automattic.com/privacy/
 Terms of Service: https://simplenote.com/terms/
-California users privacy notice: https://wp.me/Pe4R-d/#california-consumer-privacy-act-ccpa
+Privacy Notice for California Users: https://automattic.com/privacy/#us-privacy-laws


### PR DESCRIPTION
### Fix

The anchor link to the privacy policy for US states has changed, this PR fixes the broken link. Note that the text should still refer specifically to CA, as noted internally (ref: p4H3ND-1El#comment-3586 )

I also changed the wording to "Privacy Notice for California Users" for consistency with our other platforms.

There are a lot of these links within translated files, can someone let me know how to update these translations?

Also, for some reason it was using the shortlink format (wp.me), I changed it to the full automattic.com URL for clarity.

### Release

`RELEASE-NOTES.txt` was updated with:
 
> Updated link to privacy notice for California users
