### PR TITLE
[Tooling] SwiftLint: Use `linter` agent instead of `default` agent

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -11,13 +11,14 @@ steps:
       queue: mac
 
   - label: ":swift: SwiftLint"
-    command: run_swiftlint --strict
-    plugins: [$CI_TOOLKIT_PLUGIN]
+    command: swiftlint
+    env:
+      SWIFTLINT_OPTION_STRICT: true
     notify:
       - github_commit_status:
-          context: "SwiftLint"
+          context: SwiftLint
     agents:
-      queue: default
+      queue: linter
 
   - label: "🛠 Verify App Store Target Builds"
     command: .buildkite/commands/build-and-test-app-store.sh


### PR DESCRIPTION
### Description

This PR updates the SwiftLint CI task to use the `linter` agent for running SwiftLint instead of the `default` agent. 

### Testing Details

This is good to go as long as CI (and especially SwiftLint) is green