### PR TITLE
Update build script to use mobile secrets path.

### DIFF
--- a/Scripts/Build-Phases/copy-secret.sh
+++ b/Scripts/Build-Phases/copy-secret.sh
@@ -49,7 +49,7 @@ function ensure_is_in_input_files_list() {
   fi
 }
 
-SECRETS_ROOT="${HOME}/.configure/simplenote-macos/secrets"
+SECRETS_ROOT="${HOME}/.mobile-secrets/macOS/simplenote"
 SECRETS_FILE="${SECRETS_ROOT}/SPCredentials.swift"
 EXAMPLE_SECRETS_FILE="${SRCROOT}/Simplenote/SPCredentials-demo.swift"
 

--- a/Scripts/Build-Phases/copy-secret.xcfilelist
+++ b/Scripts/Build-Phases/copy-secret.xcfilelist
@@ -1,6 +1,6 @@
 # Inputs for the build phase run script marshalling the secrets for the app,
 # currently running from the SimplenoteSecrets aggregate targets
-${HOME}/.configure/simplenote-macos/secrets/SPCredentials.swift
+${HOME}/.mobile-secrets/macOS/simplenote/SPCredentials.swift
 ${SRCROOT}/Simplenote/SPCredentials-demo.swift
 # Add the script itself as an input, so the build system will know to run it
 # if it changes


### PR DESCRIPTION
### Fix
This PR updates the build script to pull SPCredentials from the mobile secrets folder.

### Test
1. Ensure you have mobile secrets checked out
2. Build and run the app
3. You should be able to sign in to a production Simplenote account.