### PR TITLE
Update App Store Connect Copyright Date

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -368,7 +368,8 @@ lane :update_metadata_on_app_store_connect do |with_screenshots: false|
     overwrite_screenshots: true, # won't have effect if `skip_screenshots` is true
     phased_release: true,
     precheck_include_in_app_purchases: false,
-    api_key: app_store_connect_api_key
+    api_key: app_store_connect_api_key,
+    copyright: "© #{Time.now.year} Automattic, Inc."
   )
 end
 

--- a/fastlane/metadata/copyright.txt
+++ b/fastlane/metadata/copyright.txt
@@ -1,1 +1,0 @@
-2024 Automattic Inc.


### PR DESCRIPTION
## What it does
This updates the copyright uploaded to App Store Connect to be derived so we won't have to manually update it each year.. It'll be updated on App Store Connect during the next release cycle.