### PR TITLE
Minimize note processing for excessively long notes

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,7 @@
+2.23
+-----
+- Stop optional note processing for very long notes
+
 2.22
 -----
 - Updated link to privacy notice for California users

--- a/Simplenote/NSTextView+Simplenote.swift
+++ b/Simplenote/NSTextView+Simplenote.swift
@@ -113,8 +113,11 @@ private extension NSTextView {
 // MARK: - I/O
 //
 extension NSTextView {
-
-    private var linkProcessorCharacterLimit: Int {
+    // On really long notes some processes take too long, we need to limit them to a certain character count
+    // currently 1 million characters is about when we start to see that lag.  So after that we don't process
+    // links or markdown or scroll position
+    @objc
+    static var heavyProcessCharacterLimit: Int {
         1_000_000
     }
 
@@ -160,7 +163,10 @@ extension NSTextView {
     ///         This causes the Editor to update the Note's Modification Date, and may affect the List Sort Order (!)
     ///
     func processLinksInDocument() {
-        guard string.count < linkProcessorCharacterLimit else {
+        // Processing links can take a long time for really long notes
+        // this can cause the app to hang for a while.  By skipping these processes we save a lot of
+        // processing time when updating notes
+        guard string.count < NSTextView.heavyProcessCharacterLimit else {
             return
         }
 

--- a/Simplenote/NSTextView+Simplenote.swift
+++ b/Simplenote/NSTextView+Simplenote.swift
@@ -114,6 +114,10 @@ private extension NSTextView {
 //
 extension NSTextView {
 
+    private var linkProcessorCharacterLimit: Int {
+        1_000_000
+    }
+
     /// Displays the specified Note's Contents
     ///
     ///     -   List Markers will be replaced by Text Attachments
@@ -126,6 +130,7 @@ extension NSTextView {
         string = content
         textStorage?.processChecklists(with: .simplenoteEditorTextColor)
         undoManager?.removeAllActions()
+
         processLinksInDocumentAsynchronously()
     }
 
@@ -155,6 +160,10 @@ extension NSTextView {
     ///         This causes the Editor to update the Note's Modification Date, and may affect the List Sort Order (!)
     ///
     func processLinksInDocument() {
+        guard string.count < linkProcessorCharacterLimit else {
+            return
+        }
+
         /// Disable the Delegate:
         let theDelegate = delegate
         delegate = nil

--- a/Simplenote/NoteEditorViewController.m
+++ b/Simplenote/NoteEditorViewController.m
@@ -212,9 +212,14 @@ static NSString * const SPTextViewPreferencesKey        = @"kTextViewPreferences
         [self displayContent:nil];
     }
 
-    [self.storage refreshStyleWithMarkdownEnabled:self.note.markdown];
+    // Processing markdown and scroll position take a long time for really long notes
+    // this can cause the app to hang for a while.  By skipping these processes we save a lot of
+    // processing time when displaying a note
+    if (self.note.content.length < [NSTextView heavyProcessCharacterLimit]) {
+        [self.storage refreshStyleWithMarkdownEnabled:self.note.markdown];
+        [self restoreScrollPosition];
+    }
 
-    [self restoreScrollPosition];
     [self restoreCursorLocation];
 }
 


### PR DESCRIPTION
### Fix
Some recent changes to MacOS/Text Kit have caused processing on really long notes (over 1 million + characters) to take a very long time.  Some of these processes are triggered by SN, but most of them are happening inside the text kit processing system so we have little control over them, but it makes these long notes very hard to work in.

What we have identified is that some optional processing is causing text rendering cycles and that is where the extra time comes from, so in this PR for notes over 1 million characters we are doing these processes.  Specifically we are not processing:
- inter links
- markdown
- scroll position

This will change the experience for these long notes a little bit, but not greatly and it makes loading the notes much faster.  

fixes #1229
### Test
1. Create a note with more than 1m characters (I have a sample file, ping me if needed)
2. launch SNMac into another note
3. tap on the long note

- [ ] confirm that after a few second hang the note opens and you can edit it

### Review
***(Required)*** Add instructions for reviewers.  For example:
> Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
***(Required)*** Add a concise statement to `RELEASE-NOTES.txt` if the changes should be included in release notes. Include details about updating the notes in this section. For example:
> `RELEASE-NOTES.txt` was updated in 6247e3 with:
> 
> > - Stop optional note processing for very long notes

If the changes should not be included in release notes, add a statement to this section. For example:

> These changes do not require release notes.
