### PR TITLE
Fixed issue where printing from light mode only displayed the first page

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 2.23
 -----
 - Stop optional note processing for very long notes
+- Fixed a bug when printing multiple pages when in light mode
 
 2.22
 -----

--- a/Simplenote/NoteEditorViewController.m
+++ b/Simplenote/NoteEditorViewController.m
@@ -428,7 +428,9 @@ static NSString * const SPTextViewPreferencesKey        = @"kTextViewPreferences
 - (IBAction)printAction:(id)sender
 {
     // Create a copy of the editor view to be used as the print source
-    NSTextView *printView = [[NSTextView alloc] init];
+    // NOTE: forcing the print view into Text Kit 1 because TK2 was not printing multiple pages correctly
+    // ref: https://github.com/Automattic/simplenote-macos/issues/1232
+    NSTextView *printView = [[NSTextView alloc] initUsingTextLayoutManager:NO];
     [printView.textStorage appendAttributedString:self.noteEditor.attributedString];
     [printView setTextColor:[NSColor blackColor]];
 
@@ -437,11 +439,8 @@ static NSString * const SPTextViewPreferencesKey        = @"kTextViewPreferences
     [printInfo setHorizontalPagination:NSPrintingPaginationModeFit];
     [printInfo setVerticallyCentered:NO];
 
-    // Calculate the height needed for all content
-    NSSize contentSize = [printView.layoutManager usedRectForTextContainer:printView.textContainer].size;
-
     // Set the view's frame to the size of the content
-    printView.frame = NSMakeRect(0, 0, printInfo.paperSize.width, MAX(contentSize.height, printInfo.paperSize.height));
+    printView.frame = NSMakeRect(0, 0, printInfo.paperSize.width, printInfo.paperSize.height);
 
     // Print the sucker
     NSPrintOperation *operation = [NSPrintOperation printOperationWithView:printView];

--- a/Simplenote/NoteEditorViewController.m
+++ b/Simplenote/NoteEditorViewController.m
@@ -437,8 +437,11 @@ static NSString * const SPTextViewPreferencesKey        = @"kTextViewPreferences
     [printInfo setHorizontalPagination:NSPrintingPaginationModeFit];
     [printInfo setVerticallyCentered:NO];
 
-    // Set the view's frame to the size of the page
-    printView.frame = CGRectMake(0, 0, printInfo.paperSize.width, printInfo.paperSize.height);
+    // Calculate the height needed for all content
+    NSSize contentSize = [printView.layoutManager usedRectForTextContainer:printView.textContainer].size;
+
+    // Set the view's frame to the size of the content
+    printView.frame = NSMakeRect(0, 0, printInfo.paperSize.width, MAX(contentSize.height, printInfo.paperSize.height));
 
     // Print the sucker
     NSPrintOperation *operation = [NSPrintOperation printOperationWithView:printView];


### PR DESCRIPTION
### Fix
Fixes #1232 

Interesting issue.  So on SNMac if you use light mode (if people still do such things) and you try to print out a multiple page note you will receive the first page and only the first page, but the document will be long enough to house the entire document...  Just after the first page there is no content.  More weirdly this does not happen if your computer is in dark mode.  Very odd.

Turns out the way that we were calculating the size of the print view was based on the print page size and that cut off the size of the view.  It seems that when in dark mode MacOS is doing some helpful translations to the print info which fix the size of the document and so you get all the details.  weird.  

In this PR I have changed the size of the document so that it will work with the size of the content if it is bigger than one page.

### Test
1. Open simplenote Mac, put your computer display into light mode
2. Open a note that would print out to longer than one page.  Attempt to print
3. Confirm in the preview that you see all pages of the text content.  
4. Print the doc to pdf and confirm you see all the pages of the text content
5. Try steps 2-4 again on a short note and confirm the note is still printing the correct size

### Review
***(Required)*** Add instructions for reviewers.  For example:
> Only one developer is required to review these changes, but anyone can perform the review.

### Release
***(Required)*** Add a concise statement to `RELEASE-NOTES.txt` if the changes should be included in release notes. Include details about updating the notes in this section. For example:
> `RELEASE-NOTES.txt` was updated in e8c9bd with:
> 
> > - Fixed a bug when printing multiple pages when in light mode

