### PR TITLE
Updated release notes to reflect correct version

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,11 +1,8 @@
-2.23
------
-- Stop optional note processing for very long notes
-- Fixed a bug when printing multiple pages when in light mode
-
 2.22
 -----
 - Updated link to privacy notice for California users
+- Stop optional note processing for very long notes
+- Fixed a bug when printing multiple pages when in light mode
 
 2.21
 -----


### PR DESCRIPTION
The release notes on Simplenote Mac were pointing ahead to the wrong milestone.  This PR corrects the release notes.