### PR TITLE
Update release notes source for version 2.22

### DIFF
--- a/Simplenote/Resources/AppStoreStrings.pot
+++ b/Simplenote/Resources/AppStoreStrings.pot
@@ -46,9 +46,10 @@ msgctxt "app_store_keywords"
 msgid "simplenote,note,notes,sync,syncing,list,todo,simple,markdown,ideas"
 msgstr ""
 
-msgctxt "v2.21-whats-new"
+msgctxt "v2.22-whats-new"
 msgid ""
-"- Added shortcuts to Simplenote Mac!!\n"
-"- New Magic Link Authentication support\n"
+"- Updated link to privacy notice for California users\n"
+"- Stop optional note processing for very long notes\n"
+"- Fixed a bug when printing multiple pages when in light mode\n"
 msgstr ""
 

--- a/Simplenote/Resources/release_notes.txt
+++ b/Simplenote/Resources/release_notes.txt
@@ -1,2 +1,3 @@
-- Added shortcuts to Simplenote Mac!!
-- New Magic Link Authentication support
+- Updated link to privacy notice for California users
+- Stop optional note processing for very long notes
+- Fixed a bug when printing multiple pages when in light mode


### PR DESCRIPTION
We'll merge this into `release/2.22`, then `release/2.22` into `trunk` to send the release notes for localization.