### PR TITLE
Remove xcpretty-travis-formatter dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,5 @@ gem 'fastlane', '~> 2.232'
 gem 'fastlane-plugin-sentry', '~> 1.14'
 gem 'fastlane-plugin-wpmreleasetoolkit', '~> 9.2'
 gem 'rake', '~> 12.3'
-gem 'xcpretty-travis-formatter', '~> 1.0'
-
 plugins_path = File.join(File.dirname(__FILE__), 'fastlane', 'Pluginfile')
 eval_gemfile(plugins_path) if File.exist?(plugins_path)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -368,7 +368,6 @@ DEPENDENCIES
   fastlane-plugin-sentry (~> 1.14)
   fastlane-plugin-wpmreleasetoolkit (~> 9.2)
   rake (~> 12.3)
-  xcpretty-travis-formatter (~> 1.0)
 
 BUNDLED WITH
    2.4.14

--- a/Rakefile
+++ b/Rakefile
@@ -184,7 +184,7 @@ def xcodebuild(*build_cmds)
   cmd += " -configuration #{xcode_configuration}"
   cmd += ' '
   cmd += build_cmds.map(&:to_s).join(' ')
-  cmd += ' | bundle exec xcpretty -f `bundle exec xcpretty-travis-formatter` && exit ${PIPESTATUS[0]}' unless ENV['verbose']
+  cmd += ' | bundle exec xcpretty && exit ${PIPESTATUS[0]}' unless ENV['verbose']
   sh(cmd)
 end
 


### PR DESCRIPTION
## Summary

- Remove unused `xcpretty-travis-formatter` gem from `Gemfile`
- Update `Rakefile` to use plain `xcpretty` instead of the Travis CI formatter

The Travis CI formatter is unnecessary — CI runs on Buildkite, not Travis.

See https://github.com/woocommerce/woocommerce-ios/pull/16707#discussion_r2845925808

_Gio here_: We'll followup removing the `Rakefile` logic that was using the Travis formatter and now uses only `xcpretty`. It's unused legacy logic that we already removed from the WooCommerce implementation and can remove from here, too. I didn't realize the logic was there when I prompted for this work. But that's okay, let's move in small incremental steps.

## Test plan

- [ ] CI passes with the updated Rakefile
- [ ] `bundle install` succeeds without the explicit gem dependency

*Posted by Claude Code (Opus 4.6) on behalf of @mokagio with approval.*

🤖 Generated with [Claude Code](https://claude.ai/code)