### PR TITLE
Update activesupport to fix security vulnerabilities

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ GEM
   specs:
     CFPropertyList (3.0.8)
     abbrev (0.1.2)
-    activesupport (7.2.2.1)
+    activesupport (7.2.3.1)
       base64
       benchmark (>= 0.3)
       bigdecimal
@@ -12,7 +12,7 @@ GEM
       drb
       i18n (>= 1.6, < 2)
       logger (>= 1.4.2)
-      minitest (>= 5.1)
+      minitest (>= 5.1, < 6)
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
     addressable (2.8.8)
@@ -41,7 +41,7 @@ GEM
       aws-eventstream (~> 1, >= 1.0.2)
     babosa (1.0.4)
     base64 (0.2.0)
-    benchmark (0.4.0)
+    benchmark (0.4.1)
     bigdecimal (4.0.1)
     buildkit (1.6.1)
       sawyer (>= 0.6)
@@ -55,8 +55,8 @@ GEM
     colored2 (3.1.2)
     commander (4.6.0)
       highline (~> 2.0.0)
-    concurrent-ruby (1.3.5)
-    connection_pool (2.5.0)
+    concurrent-ruby (1.3.6)
+    connection_pool (2.5.5)
     cork (0.3.0)
       colored2 (~> 3.1)
     csv (3.3.5)
@@ -90,7 +90,7 @@ GEM
       rake (>= 12.0.0, < 14.0.0)
     domain_name (0.6.20240107)
     dotenv (2.8.1)
-    drb (2.2.1)
+    drb (2.2.3)
     emoji_regex (3.2.3)
     excon (0.112.0)
     faraday (1.10.4)
@@ -242,7 +242,7 @@ GEM
       domain_name (~> 0.5)
     httpclient (2.9.0)
       mutex_m
-    i18n (1.14.7)
+    i18n (1.14.8)
       concurrent-ruby (~> 1.0)
     java-properties (0.3.0)
     jmespath (1.6.2)


### PR DESCRIPTION
## Summary
- Updates `activesupport` gem to fix three security vulnerabilities published on 2026-03-23
- **GHSA-cg4j-q9v8-6v38**: ReDoS vulnerability in `number_to_delimited` (`NumberToDelimitedConverter` used a regex with `gsub!` causing quadratic time complexity)
- **GHSA-89vf-4333-qx8v**: XSS vulnerability in `SafeBuffer#%`
- **GHSA-2j26-frm8-cmj9**: DoS vulnerability in number helpers

## Test plan
- [ ] Verify CI passes
- [ ] Confirm `activesupport` version in `Gemfile.lock` is patched (>= 8.1.2.1 for 8.1.x, >= 8.0.4.1 for 8.0.x, >= 7.2.3.1 for 7.x)

🤖 Generated with [Claude Code](https://claude.com/claude-code)