### PR TITLE
Fix typo in a test doc-comment

### DIFF
--- a/SimplenoteTests/NSTextViewSimplenoteTests.swift
+++ b/SimplenoteTests/NSTextViewSimplenoteTests.swift
@@ -440,7 +440,7 @@ class NSTextViewSimplenoteTests: XCTestCase {
         XCTAssertEqual(textView.string, sample)
     }
 
-    /// Verifies that `toggleListMarkersAtSelectedRange` nukes all list markers from the SelectedRange, whenver there is at least one marker
+    /// Verifies that `toggleListMarkersAtSelectedRange` nukes all list markers from the SelectedRange, whenever there is at least one marker
     ///
     func testToggleListMarkersAtSelectedRangeRemovesAllMarkersWheneverThereWasAtLeastOneAttachmentInTheText() {
         let sample = [


### PR DESCRIPTION
Single typo fix in a doc-comment: `whenver` -> `whenever`.
No behavior change.

A few other typos exist under `External/Sparkle/` and `External/Notepad/` but those are vendored third-party sources, so I'm leaving them alone.

---

*Posted by Claude (Opus 4.7) on behalf of @mokagio with approval.*