### PR TITLE
Decrypt secrets outside of the repo

### DIFF
--- a/.buildkite/commands/build-and-test.sh
+++ b/.buildkite/commands/build-and-test.sh
@@ -3,5 +3,12 @@
 echo "--- :rubygems: Setting up Gems"
 install_gems
 
+echo "--- :closed_lock_with_key: Decrypting Secrets"
+# TODO: Drop once a8c-secrets is adopted — its CLI is light enough for the
+# `Copy Secret` build phase to decrypt on its own, the way Gravatar-SDK-iOS
+# does. `bundle` is not readily available to a build phase, so `configure_apply`
+# cannot move there.
+bundle exec fastlane run configure_apply
+
 echo "--- :hammer_and_wrench: Build and Test"
 bundle exec fastlane test

--- a/.buildkite/commands/build-and-test.sh
+++ b/.buildkite/commands/build-and-test.sh
@@ -3,12 +3,11 @@
 echo "--- :rubygems: Setting up Gems"
 install_gems
 
-echo "--- :closed_lock_with_key: Decrypting Secrets"
-# TODO: Drop once a8c-secrets is adopted — its CLI is light enough for the
-# `Copy Secret` build phase to decrypt on its own, the way Gravatar-SDK-iOS
-# does. `bundle` is not readily available to a build phase, so `configure_apply`
-# cannot move there.
-bundle exec fastlane run configure_apply
+echo "--- :key: Providing Credentials"
+# The unit tests do not need real credentials, so take the same path the readme
+# gives external contributors. That keeps this job out of the secret store and
+# makes it a regression test for the contributor flow.
+cp Simplenote/SPCredentials.template.swift Simplenote/SPCredentials.external-contributors.swift
 
 echo "--- :hammer_and_wrench: Build and Test"
 bundle exec fastlane test

--- a/.buildkite/commands/build-and-test.sh
+++ b/.buildkite/commands/build-and-test.sh
@@ -3,10 +3,8 @@
 echo "--- :rubygems: Setting up Gems"
 install_gems
 
+# Unit tests don't need real credentials
 echo "--- :key: Providing Credentials"
-# The unit tests do not need real credentials, so take the same path the readme
-# gives external contributors. That keeps this job out of the secret store and
-# makes it a regression test for the contributor flow.
 cp Simplenote/SPCredentials.template.swift Simplenote/SPCredentials.external-contributors.swift
 
 echo "--- :hammer_and_wrench: Build and Test"

--- a/.gitignore
+++ b/.gitignore
@@ -31,9 +31,6 @@ Simplenote/DerivedSources/*
 # Settings
 Simplenote/config.plist
 
-# Stale copies of the decrypted credentials, from before they moved to DerivedSources
-Simplenote/Credentials/
-
 # Bundler
 /vendor/
 /vendor/bundle/

--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,8 @@ build/
 .configure-files/*
 !.configure-files/*.enc
 
+Simplenote/SPCredentials.external-contributors.swift
+
 # Swift Package Manager
 .build
 

--- a/.gitignore
+++ b/.gitignore
@@ -25,10 +25,13 @@ DerivedData
 .idea/
 *.hmap
 *.xcscmblueprint
-Simplenote/DerivedSources/
+Simplenote/DerivedSources/*
+!Simplenote/DerivedSources/README.md
 
 # Settings
 Simplenote/config.plist
+
+# Stale copies of the decrypted credentials, from before they moved to DerivedSources
 Simplenote/Credentials/
 
 # Bundler

--- a/Scripts/Build-Phases/copy-secret.sh
+++ b/Scripts/Build-Phases/copy-secret.sh
@@ -43,7 +43,7 @@ function ensure_is_in_input_files_list() {
     exit 1
   fi
 
-  if [ "$SCRIPT_INPUT_FILE_LIST_COUNT" -eq 0 ]; then
+  if [ "${SCRIPT_INPUT_FILE_LIST_COUNT:-0}" -eq 0 ]; then
     echo "error: No input file list given (.xcfilelist). Cannot continue."
     exit 1
   fi

--- a/Scripts/Build-Phases/copy-secret.sh
+++ b/Scripts/Build-Phases/copy-secret.sh
@@ -24,7 +24,7 @@ function ensure_is_in_input_files_list() {
   fi
   file_to_find=$1
 
-  if [ $SCRIPT_INPUT_FILE_LIST_COUNT -eq 0 ]; then
+  if [ "$SCRIPT_INPUT_FILE_LIST_COUNT" -eq 0 ]; then
     echo "error: No input file list given (.xcfilelist). Cannot continue."
     exit 1
   fi
@@ -55,8 +55,8 @@ SECRETS_ROOT="${HOME}/.configure/simplenote-macos/secrets"
 SECRETS_FILE="${SECRETS_ROOT}/SPCredentials.swift"
 EXAMPLE_SECRETS_FILE="${SRCROOT}/Simplenote/SPCredentials-demo.swift"
 
-ensure_is_in_input_files_list $SECRETS_FILE
-ensure_is_in_input_files_list $EXAMPLE_SECRETS_FILE
+ensure_is_in_input_files_list "$SECRETS_FILE"
+ensure_is_in_input_files_list "$EXAMPLE_SECRETS_FILE"
 
 # The destination comes from the build phase's `outputPaths`, which Xcode
 # exposes as SCRIPT_OUTPUT_FILE_N. Each consumer target writes into its own
@@ -67,9 +67,9 @@ if [ "${SCRIPT_OUTPUT_FILE_COUNT:-0}" -lt 1 ]; then
 fi
 
 SECRETS_DESTINATION_FILE="${SCRIPT_OUTPUT_FILE_0}"
-mkdir -p $(dirname "$SECRETS_DESTINATION_FILE")
+mkdir -p "$(dirname "$SECRETS_DESTINATION_FILE")"
 
-if cmp --silent -- ${SECRETS_FILE} ${SECRETS_DESTINATION_FILE}; then
+if cmp --silent -- "$SECRETS_FILE" "$SECRETS_DESTINATION_FILE"; then
     echo "☑️ Credentials were not modified. Skipping..."
     exit 0
 fi
@@ -86,7 +86,7 @@ fi
 COULD_NOT_FIND_SECRET_MSG="Could not find secrets file at ${SECRETS_FILE}"
 INTERNAL_CONTRIBUTOR_MSG="If you are an internal contributor, run \`bundle exec fastlane run configure_apply\` to update your secrets"
 
-case $CONFIGURATION in
+case "$CONFIGURATION" in
   Release)
     echo "error: $COULD_NOT_FIND_SECRET_MSG. Cannot continue Release build. $INTERNAL_CONTRIBUTOR_MSG and try again. External contributors should not need to perform a Release build."
     exit 1

--- a/Scripts/Build-Phases/copy-secret.sh
+++ b/Scripts/Build-Phases/copy-secret.sh
@@ -2,6 +2,22 @@
 
 set -euo pipefail
 
+# Materialize secrets into the target's DERIVED_FILE_DIR so the decrypted
+# credentials never land in the repo checkout.
+#
+# The compiled file comes from one of two sources, in order:
+#
+#   1. ${SECRETS_ROOT}, for internal contributors. `bundle exec fastlane run
+#      configure_apply` decrypts it there, outside the repo; this phase only
+#      reads it.
+#   2. Simplenote/SPCredentials-demo.swift, committed, so external contributors
+#      can build without any secrets. Under Release the missing secrets are an
+#      error instead.
+
+SECRETS_ROOT="${HOME}/.configure/simplenote-macos/secrets"
+SECRETS_FILE="${SECRETS_ROOT}/SPCredentials.swift"
+EXAMPLE_SECRETS_FILE="${SRCROOT}/Simplenote/SPCredentials-demo.swift"
+
 # To help the Xcode build system optimize the build, we want to ensure each of
 # the secrets we want to copy is defined as an input file for the run script
 # build phase.
@@ -22,12 +38,13 @@ function ensure_is_in_input_files_list() {
     echo "error: Input file list verification needs a path to verify!"
     exit 1
   fi
-  file_to_find=$1
 
   if [ "$SCRIPT_INPUT_FILE_LIST_COUNT" -eq 0 ]; then
     echo "error: No input file list given (.xcfilelist). Cannot continue."
     exit 1
   fi
+
+  file_to_find=$1
 
   i=0
   found=false
@@ -37,23 +54,20 @@ function ensure_is_in_input_files_list() {
     file_list_resolved_var_name=SCRIPT_INPUT_FILE_LIST_${i}
     # The following reads the processed xcfilelist line by line looking for
     # the given file
-    while read input_file; do
+    while read -r input_file; do
       if [ "$file_to_find" == "$input_file" ]; then
         found=true
         break
       fi
     done <"${!file_list_resolved_var_name}"
-    let i=i+1
+    (( i=i+1 ))
   done
+
   if [ "$found" = false ]; then
     echo "error: Could not find $file_to_find as an input to the build phase. Add $file_to_find to the input files list using the .xcfilelist."
     exit 1
   fi
 }
-
-SECRETS_ROOT="${HOME}/.configure/simplenote-macos/secrets"
-SECRETS_FILE="${SECRETS_ROOT}/SPCredentials.swift"
-EXAMPLE_SECRETS_FILE="${SRCROOT}/Simplenote/SPCredentials-demo.swift"
 
 ensure_is_in_input_files_list "$SECRETS_FILE"
 ensure_is_in_input_files_list "$EXAMPLE_SECRETS_FILE"
@@ -69,17 +83,17 @@ fi
 SECRETS_DESTINATION_FILE="${SCRIPT_OUTPUT_FILE_0}"
 mkdir -p "$(dirname "$SECRETS_DESTINATION_FILE")"
 
+if cmp --silent -- "$SECRETS_FILE" "$SECRETS_DESTINATION_FILE"; then
+    echo "☑️ Credentials were not modified. Skipping..."
+    exit 0
+fi
+
 apply() {
     echo "Applying secrets from ${1}"
     # `cp -v` names the destination, which differs per consumer target.
     cp -v "$1" "$SECRETS_DESTINATION_FILE"
     exit 0
 }
-
-if cmp --silent -- "$SECRETS_FILE" "$SECRETS_DESTINATION_FILE"; then
-    echo "☑️ Credentials were not modified. Skipping..."
-    exit 0
-fi
 
 if [ -f "$SECRETS_FILE" ]; then
     apply "$SECRETS_FILE"

--- a/Scripts/Build-Phases/copy-secret.sh
+++ b/Scripts/Build-Phases/copy-secret.sh
@@ -1,4 +1,6 @@
-#!/bin/bash -euo pipefail
+#!/usr/bin/env bash
+
+set -euo pipefail
 
 # To help the Xcode build system optimize the build, we want to ensure each of
 # the secrets we want to copy is defined as an input file for the run script

--- a/Scripts/Build-Phases/copy-secret.sh
+++ b/Scripts/Build-Phases/copy-secret.sh
@@ -88,11 +88,6 @@ SECRETS_DESTINATION_FILE="${SCRIPT_OUTPUT_FILE_0}"
 mkdir -p "$(dirname "$SECRETS_DESTINATION_FILE")"
 
 apply() {
-    if cmp --silent -- "$1" "$SECRETS_DESTINATION_FILE"; then
-        echo "☑️ Credentials were not modified. Skipping..."
-        exit 0
-    fi
-
     echo "Applying secrets from ${1}"
     # `cp -v` names the destination, which differs per consumer target.
     cp -v "$1" "$SECRETS_DESTINATION_FILE"

--- a/Scripts/Build-Phases/copy-secret.sh
+++ b/Scripts/Build-Phases/copy-secret.sh
@@ -69,9 +69,9 @@ fi
 SECRETS_DESTINATION_FILE="${SCRIPT_OUTPUT_FILE_0}"
 mkdir -p "$(dirname "$SECRETS_DESTINATION_FILE")"
 
-# `cp -v` names the destination, which differs per consumer target.
 apply() {
     echo "Applying secrets from ${1}"
+    # `cp -v` names the destination, which differs per consumer target.
     cp -v "$1" "$SECRETS_DESTINATION_FILE"
     exit 0
 }

--- a/Scripts/Build-Phases/copy-secret.sh
+++ b/Scripts/Build-Phases/copy-secret.sh
@@ -69,15 +69,20 @@ fi
 SECRETS_DESTINATION_FILE="${SCRIPT_OUTPUT_FILE_0}"
 mkdir -p "$(dirname "$SECRETS_DESTINATION_FILE")"
 
+# `cp -v` names the destination, which differs per consumer target.
+apply() {
+    echo "Applying secrets from ${1}"
+    cp -v "$1" "$SECRETS_DESTINATION_FILE"
+    exit 0
+}
+
 if cmp --silent -- "$SECRETS_FILE" "$SECRETS_DESTINATION_FILE"; then
     echo "☑️ Credentials were not modified. Skipping..."
     exit 0
 fi
 
 if [ -f "$SECRETS_FILE" ]; then
-    echo "Applying Production Secrets"
-    cp -v "$SECRETS_FILE" "${SECRETS_DESTINATION_FILE}"
-    exit 0
+    apply "$SECRETS_FILE"
 fi
 
 # No secrets file found. Use the example secrets file as a last resort, unless
@@ -93,7 +98,6 @@ case "$CONFIGURATION" in
     ;;
   *)
     echo "warning: $COULD_NOT_FIND_SECRET_MSG. Falling back to $EXAMPLE_SECRETS_FILE. In a Release build, this would be an error. $INTERNAL_CONTRIBUTOR_MSG and try again. If you are an external contributor, you can ignore this warning."
-    echo "Applying Example Secrets"
-    cp -v "$EXAMPLE_SECRETS_FILE" "$SECRETS_DESTINATION_FILE"
+    apply "$EXAMPLE_SECRETS_FILE"
     ;;
 esac

--- a/Scripts/Build-Phases/copy-secret.sh
+++ b/Scripts/Build-Phases/copy-secret.sh
@@ -56,7 +56,15 @@ EXAMPLE_SECRETS_FILE="${SRCROOT}/Simplenote/SPCredentials-demo.swift"
 ensure_is_in_input_files_list $SECRETS_FILE
 ensure_is_in_input_files_list $EXAMPLE_SECRETS_FILE
 
-SECRETS_DESTINATION_FILE="${SRCROOT}/Simplenote/Credentials/SPCredentials.swift"
+# The destination comes from the build phase's `outputPaths`, which Xcode
+# exposes as SCRIPT_OUTPUT_FILE_N. Each consumer target writes into its own
+# $(DERIVED_FILE_DIR), keeping the decrypted secret out of the checkout.
+if [ "${SCRIPT_OUTPUT_FILE_COUNT:-0}" -lt 1 ]; then
+  echo "error: No output file given. Declare the destination in the build phase's output files list."
+  exit 1
+fi
+
+SECRETS_DESTINATION_FILE="${SCRIPT_OUTPUT_FILE_0}"
 mkdir -p $(dirname "$SECRETS_DESTINATION_FILE")
 
 if cmp --silent -- ${SECRETS_FILE} ${SECRETS_DESTINATION_FILE}; then
@@ -73,7 +81,7 @@ fi
 # No secrets file found. Use the example secrets file as a last resort, unless
 # building for Release.
 
-COULD_NOT_FIND_SECRET_MSG="Could not find secrets file at ${SECRETS_DESTINATION_FILE}. This is likely due to the source secrets being missing from ${SECRETS_ROOT}"
+COULD_NOT_FIND_SECRET_MSG="Could not find secrets file at ${SECRETS_FILE}"
 INTERNAL_CONTRIBUTOR_MSG="If you are an internal contributor, run \`bundle exec fastlane run configure_apply\` to update your secrets"
 
 case $CONFIGURATION in

--- a/Scripts/Build-Phases/copy-secret.sh
+++ b/Scripts/Build-Phases/copy-secret.sh
@@ -10,13 +10,17 @@ set -euo pipefail
 #   1. ${SECRETS_ROOT}, for internal contributors. `bundle exec fastlane run
 #      configure_apply` decrypts it there, outside the repo; this phase only
 #      reads it.
-#   2. Simplenote/SPCredentials-demo.swift, committed, so external contributors
-#      can build without any secrets. Under Release the missing secrets are an
-#      error instead.
+#   2. Simplenote/SPCredentials.external-contributors.swift — gitignored, so
+#      external contributors can keep their own Simperium credentials with
+#      little-to-no risk of committing them, starting from a copy of the
+#      committed template.
+#
+# If neither is present, the build will fail.
 
 SECRETS_ROOT="${HOME}/.configure/simplenote-macos/secrets"
 SECRETS_FILE="${SECRETS_ROOT}/SPCredentials.swift"
-EXAMPLE_SECRETS_FILE="${SRCROOT}/Simplenote/SPCredentials-demo.swift"
+TEMPLATE_SECRETS_FILE="${SRCROOT}/Simplenote/SPCredentials.template.swift"
+EXTERNAL_SECRETS_FILE="${SRCROOT}/Simplenote/SPCredentials.external-contributors.swift"
 
 # To help the Xcode build system optimize the build, we want to ensure each of
 # the secrets we want to copy is defined as an input file for the run script
@@ -70,7 +74,7 @@ function ensure_is_in_input_files_list() {
 }
 
 ensure_is_in_input_files_list "$SECRETS_FILE"
-ensure_is_in_input_files_list "$EXAMPLE_SECRETS_FILE"
+ensure_is_in_input_files_list "$EXTERNAL_SECRETS_FILE"
 
 # The destination comes from the build phase's `outputPaths`, which Xcode
 # exposes as SCRIPT_OUTPUT_FILE_N. Each consumer target writes into its own
@@ -83,12 +87,12 @@ fi
 SECRETS_DESTINATION_FILE="${SCRIPT_OUTPUT_FILE_0}"
 mkdir -p "$(dirname "$SECRETS_DESTINATION_FILE")"
 
-if cmp --silent -- "$SECRETS_FILE" "$SECRETS_DESTINATION_FILE"; then
-    echo "☑️ Credentials were not modified. Skipping..."
-    exit 0
-fi
-
 apply() {
+    if cmp --silent -- "$1" "$SECRETS_DESTINATION_FILE"; then
+        echo "☑️ Credentials were not modified. Skipping..."
+        exit 0
+    fi
+
     echo "Applying secrets from ${1}"
     # `cp -v` names the destination, which differs per consumer target.
     cp -v "$1" "$SECRETS_DESTINATION_FILE"
@@ -99,19 +103,9 @@ if [ -f "$SECRETS_FILE" ]; then
     apply "$SECRETS_FILE"
 fi
 
-# No secrets file found. Use the example secrets file as a last resort, unless
-# building for Release.
+if [ -f "$EXTERNAL_SECRETS_FILE" ]; then
+    apply "$EXTERNAL_SECRETS_FILE"
+fi
 
-COULD_NOT_FIND_SECRET_MSG="Could not find secrets file at ${SECRETS_FILE}"
-INTERNAL_CONTRIBUTOR_MSG="If you are an internal contributor, run \`bundle exec fastlane run configure_apply\` to update your secrets"
-
-case "$CONFIGURATION" in
-  Release)
-    echo "error: $COULD_NOT_FIND_SECRET_MSG. Cannot continue Release build. $INTERNAL_CONTRIBUTOR_MSG and try again. External contributors should not need to perform a Release build."
-    exit 1
-    ;;
-  *)
-    echo "warning: $COULD_NOT_FIND_SECRET_MSG. Falling back to $EXAMPLE_SECRETS_FILE. In a Release build, this would be an error. $INTERNAL_CONTRIBUTOR_MSG and try again. If you are an external contributor, you can ignore this warning."
-    apply "$EXAMPLE_SECRETS_FILE"
-    ;;
-esac
+echo "error: No secrets found! Internal contributors: run \`bundle exec fastlane run configure_apply\`. External contributors: copy '${TEMPLATE_SECRETS_FILE}' to '${EXTERNAL_SECRETS_FILE}', fill in your own Simperium credentials, and build again."
+exit 1

--- a/Scripts/Build-Phases/copy-secret.xcfilelist
+++ b/Scripts/Build-Phases/copy-secret.xcfilelist
@@ -3,7 +3,7 @@
 # IntentsExtension targets — each phase writes its own SPCredentials.swift into
 # $(DERIVED_FILE_DIR).
 ${HOME}/.configure/simplenote-macos/secrets/SPCredentials.swift
-${SRCROOT}/Simplenote/SPCredentials-demo.swift
+${SRCROOT}/Simplenote/SPCredentials.external-contributors.swift
 # Add the script itself as an input, so the build system will know to run it
 # if it changes
 ${SRCROOT}/Scripts/Build-Phases/copy-secret.sh

--- a/Scripts/Build-Phases/copy-secret.xcfilelist
+++ b/Scripts/Build-Phases/copy-secret.xcfilelist
@@ -1,5 +1,7 @@
-# Inputs for the build phase run script marshalling the secrets for the app,
-# currently running from the SimplenoteSecrets aggregate targets
+# Inputs for the build phase run script marshalling the secrets for the app.
+# Shared between the per-target "Copy Secret" build phases on the Simplenote and
+# IntentsExtension targets — each phase writes its own SPCredentials.swift into
+# $(DERIVED_FILE_DIR).
 ${HOME}/.configure/simplenote-macos/secrets/SPCredentials.swift
 ${SRCROOT}/Simplenote/SPCredentials-demo.swift
 # Add the script itself as an input, so the build system will know to run it

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -6,20 +6,6 @@
 	objectVersion = 54;
 	objects = {
 
-/* Begin PBXAggregateTarget section */
-		B52D0EC5230DCAD7003F799D /* SimplenoteSecrets */ = {
-			isa = PBXAggregateTarget;
-			buildConfigurationList = B52D0EC8230DCAD7003F799D /* Build configuration list for PBXAggregateTarget "SimplenoteSecrets" */;
-			buildPhases = (
-				B52D0EC9230DCB15003F799D /* ShellScript */,
-			);
-			dependencies = (
-			);
-			name = SimplenoteSecrets;
-			productName = GenerateCredentials;
-		};
-/* End PBXAggregateTarget section */
-
 /* Begin PBXBuildFile section */
 		3700E97721C1E390004771C9 /* SPTextAttachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3700E97521C1E390004771C9 /* SPTextAttachment.swift */; };
 		3712FC831FE1ACAA008544AC /* Storage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3712FC701FE1ACA9008544AC /* Storage.swift */; };
@@ -233,7 +219,7 @@
 		B5E086362448EA3C00DEF476 /* TagTableCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E086342448EA3C00DEF476 /* TagTableCellView.swift */; };
 		B5E086392448EE9D00DEF476 /* NSTableView+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E086372448EE9D00DEF476 /* NSTableView+Simplenote.swift */; };
 		B5E0863C2449012700DEF476 /* NSImage+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E0863A2449012700DEF476 /* NSImage+Simplenote.swift */; };
-		B5E196C2230F5F5300F5658A /* SPCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E196C0230F5F5300F5658A /* SPCredentials.swift */; };
+		B5E196C2230F5F5300F5658A /* SPCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8C27310000000000000A003 /* SPCredentials.swift */; };
 		B5E8E41224575C990098892B /* ToolbarState.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E8E41024575C990098892B /* ToolbarState.swift */; };
 		B5E96B671BDE732500D707F5 /* AuthViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = B5E96B651BDE732500D707F5 /* AuthViewController.m */; };
 		B5EB3AD22458B9940089858D /* NSNotification+Simplenote.m in Sources */ = {isa = PBXBuildFile; fileRef = B5EB3AD02458B9940089858D /* NSNotification+Simplenote.m */; };
@@ -264,7 +250,7 @@
 		BA2BF3402C07C75500A7C894 /* FindNoteIntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA2BF33F2C07C75500A7C894 /* FindNoteIntentHandler.swift */; };
 		BA2C65CF26FE996A00FA84E1 /* NSButton+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA2C65CA26FE996100FA84E1 /* NSButton+Extensions.swift */; };
 		BA4C6D18264CAAF800B723A7 /* URLRequest+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA4C6D17264CAAF800B723A7 /* URLRequest+Simplenote.swift */; };
-		BA4F223E2C1255A500144EDA /* SPCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E196C0230F5F5300F5658A /* SPCredentials.swift */; };
+		BA4F223E2C1255A500144EDA /* SPCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8C27310000000000000A004 /* SPCredentials.swift */; };
 		BA54F2462C0E63C700DBCE9D /* AppendNoteIntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA54F2452C0E63C700DBCE9D /* AppendNoteIntentHandler.swift */; };
 		BA54F2482C0E6A6900DBCE9D /* CreateNewNoteIntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA54F2472C0E6A6900DBCE9D /* CreateNewNoteIntentHandler.swift */; };
 		BA553F0927065E20007737E9 /* FontSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA553F0727065E20007737E9 /* FontSettings.swift */; };
@@ -340,13 +326,6 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		B52D0ECE230DCEAC003F799D /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 26F72A7F14032D2900A7935E /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = B52D0EC5230DCAD7003F799D;
-			remoteInfo = GenerateCredentials;
-		};
 		BAB261692BFFD0AF009A98D7 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 26F72A7F14032D2900A7935E /* Project object */;
@@ -679,7 +658,9 @@
 		B5E086342448EA3C00DEF476 /* TagTableCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagTableCellView.swift; sourceTree = "<group>"; };
 		B5E086372448EE9D00DEF476 /* NSTableView+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSTableView+Simplenote.swift"; sourceTree = "<group>"; };
 		B5E0863A2449012700DEF476 /* NSImage+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSImage+Simplenote.swift"; sourceTree = "<group>"; };
-		B5E196C0230F5F5300F5658A /* SPCredentials.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SPCredentials.swift; sourceTree = "<group>"; };
+		A8C27310000000000000A003 /* SPCredentials.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPCredentials.swift; sourceTree = DERIVED_FILE_DIR; };
+		A8C27310000000000000A004 /* SPCredentials.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPCredentials.swift; sourceTree = DERIVED_FILE_DIR; };
+		A8C27310000000000000A008 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		B5E8E41024575C990098892B /* ToolbarState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolbarState.swift; sourceTree = "<group>"; };
 		B5E96B641BDE732500D707F5 /* AuthViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AuthViewController.h; sourceTree = "<group>"; };
 		B5E96B651BDE732500D707F5 /* AuthViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AuthViewController.m; sourceTree = "<group>"; };
@@ -897,7 +878,7 @@
 				B53BF1A224AC388F00938C34 /* Controllers */,
 				B5CBB05A241971240003C271 /* Converters */,
 				B557A0E825BB0DC700E5313E /* Coordinators */,
-				B52D0ECA230DCE22003F799D /* Credentials */,
+				A8C27310000000000000A005 /* DerivedSources */,
 				B51E9FE322E64473004F16B4 /* Extensions */,
 				B574CA71242D539400F8D02F /* Handlers */,
 				463774DB171F111600E2E333 /* Models */,
@@ -1190,12 +1171,30 @@
 			name = Extensions;
 			sourceTree = "<group>";
 		};
-		B52D0ECA230DCE22003F799D /* Credentials */ = {
+		A8C27310000000000000A005 /* DerivedSources */ = {
 			isa = PBXGroup;
 			children = (
-				B5E196C0230F5F5300F5658A /* SPCredentials.swift */,
+				A8C27310000000000000A006 /* Simplenote */,
+				A8C27310000000000000A007 /* IntentsExtension */,
+				A8C27310000000000000A008 /* README.md */,
 			);
-			path = Credentials;
+			path = DerivedSources;
+			sourceTree = "<group>";
+		};
+		A8C27310000000000000A006 /* Simplenote */ = {
+			isa = PBXGroup;
+			children = (
+				A8C27310000000000000A003 /* SPCredentials.swift */,
+			);
+			name = Simplenote;
+			sourceTree = "<group>";
+		};
+		A8C27310000000000000A007 /* IntentsExtension */ = {
+			isa = PBXGroup;
+			children = (
+				A8C27310000000000000A004 /* SPCredentials.swift */,
+			);
+			name = IntentsExtension;
 			sourceTree = "<group>";
 		};
 		B52EE32C25927D5D00347F2B /* Notes */ = {
@@ -1697,6 +1696,7 @@
 			buildConfigurationList = 466FFF2C17CC10A800399652 /* Build configuration list for PBXNativeTarget "Simplenote" */;
 			buildPhases = (
 				BAAA71F42C07B8BB00244C01 /* Swiftlint */,
+				A8C27310000000000000A001 /* Copy Secret */,
 				466FFEA717CC10A800399652 /* Sources */,
 				466FFEDC17CC10A800399652 /* Frameworks */,
 				466FFEE517CC10A800399652 /* Resources */,
@@ -1706,7 +1706,6 @@
 			buildRules = (
 			);
 			dependencies = (
-				B52D0ECF230DCEAC003F799D /* PBXTargetDependency */,
 				BAB2616A2BFFD0AF009A98D7 /* PBXTargetDependency */,
 			);
 			name = Simplenote;
@@ -1743,6 +1742,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = BAB2616F2BFFD0AF009A98D7 /* Build configuration list for PBXNativeTarget "IntentsExtension" */;
 			buildPhases = (
+				A8C27310000000000000A002 /* Copy Secret */,
 				BAB2615E2BFFD0AF009A98D7 /* Sources */,
 				BAB2615F2BFFD0AF009A98D7 /* Frameworks */,
 				BAB261602BFFD0AF009A98D7 /* Resources */,
@@ -1773,10 +1773,6 @@
 				TargetAttributes = {
 					466FFEA617CC10A800399652 = {
 						LastSwiftMigration = 0920;
-						ProvisioningStyle = Manual;
-					};
-					B52D0EC5230DCAD7003F799D = {
-						CreatedOnToolsVersion = 11.0;
 						ProvisioningStyle = Manual;
 					};
 					B5CBB068241976230003C271 = {
@@ -1830,7 +1826,6 @@
 			projectRoot = "";
 			targets = (
 				466FFEA617CC10A800399652 /* Simplenote */,
-				B52D0EC5230DCAD7003F799D /* SimplenoteSecrets */,
 				B5CBB068241976230003C271 /* SimplenoteTests */,
 				BAB261612BFFD0AF009A98D7 /* IntentsExtension */,
 			);
@@ -1884,9 +1879,8 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		B52D0EC9230DCB15003F799D /* ShellScript */ = {
+		A8C27310000000000000A001 /* Copy Secret */ = {
 			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -1895,10 +1889,31 @@
 			);
 			inputPaths = (
 			);
+			name = "Copy Secret";
 			outputFileListPaths = (
 			);
 			outputPaths = (
-				"$(SRCROOT)/Simplenote/Credentials/SPCredentials.swift",
+				"$(DERIVED_FILE_DIR)/SPCredentials.swift",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "${SRCROOT}/Scripts/Build-Phases/copy-secret.sh\n";
+		};
+		A8C27310000000000000A002 /* Copy Secret */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${SRCROOT}/Scripts/Build-Phases/copy-secret.xcfilelist",
+			);
+			inputPaths = (
+			);
+			name = "Copy Secret";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/SPCredentials.swift",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -2228,11 +2243,6 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		B52D0ECF230DCEAC003F799D /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = B52D0EC5230DCAD7003F799D /* SimplenoteSecrets */;
-			targetProxy = B52D0ECE230DCEAC003F799D /* PBXContainerItemProxy */;
-		};
 		BAB2616A2BFFD0AF009A98D7 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = BAB261612BFFD0AF009A98D7 /* IntentsExtension */;
@@ -2546,24 +2556,6 @@
 			};
 			name = Release;
 		};
-		B52D0EC6230DCAD7003F799D /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				DEAD_CODE_STRIPPING = YES;
-				MACOSX_DEPLOYMENT_TARGET = "$(RECOMMENDED_MACOSX_DEPLOYMENT_TARGET)";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-			};
-			name = Debug;
-		};
-		B52D0EC7230DCAD7003F799D /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				DEAD_CODE_STRIPPING = YES;
-				MACOSX_DEPLOYMENT_TARGET = "$(RECOMMENDED_MACOSX_DEPLOYMENT_TARGET)";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-			};
-			name = Release;
-		};
 		B5CBB071241976230003C271 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -2755,15 +2747,6 @@
 			buildConfigurations = (
 				466FFF2D17CC10A800399652 /* Debug */,
 				466FFF2E17CC10A800399652 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		B52D0EC8230DCAD7003F799D /* Build configuration list for PBXAggregateTarget "SimplenoteSecrets" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				B52D0EC6230DCAD7003F799D /* Debug */,
-				B52D0EC7230DCAD7003F799D /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Simplenote/DerivedSources/README.md
+++ b/Simplenote/DerivedSources/README.md
@@ -1,35 +1,9 @@
 # DerivedSources
 
-Xcode shows two `SPCredentials.swift` entries in the project navigator under
-`DerivedSources/Simplenote/` and `DerivedSources/IntentsExtension/`.
-Both appear in **red** with an empty **Full Path** in the File Inspector.
-This is **expected** and **harmless**.
+The two `SPCredentials.swift` entries here — one per consumer target, under `Simplenote/` and `IntentsExtension/` — are shown in red in Xcode and `Open Quickly` cannot find them.
+That is expected: they do not exist in the repository.
 
-## Why they are red and "not accessible"
+The `Copy Secret` build phase writes each into its own target's `$(DERIVED_FILE_DIR)`, from the decrypted credentials under `~/.configure/simplenote-macos/secrets/`, or, missing those and outside a Release build, from the committed `SPCredentials-demo.swift`.
+See `Scripts/Build-Phases/copy-secret.sh`.
 
-Both file references use `sourceTree = DERIVED_FILE_DIR`.
-`DERIVED_FILE_DIR` is a *per-target, per-configuration* build setting that only has a value while a specific target is actively being built.
-The project navigator is populated at project-parse time, before any build and with no target or configuration context, so Xcode has no single absolute path to resolve.
-The File Inspector still shows **Location: Relative to DERIVED_FILE_DIR**, confirming the declaration is understood — there just isn't one path to display, because it differs between the `Simplenote` and `IntentsExtension` targets, and per configuration.
-
-At **build time** Xcode resolves `DERIVED_FILE_DIR` per target, a `Copy Secret` script build phase on each consumer target writes `SPCredentials.swift` into that target's own derived sources directory under Derived Data, and the Swift compiler reads it back from that same location.
-The actual paths look like:
-
-```
-~/Library/Developer/Xcode/DerivedData/Simplenote-<hash>/
-  Build/Intermediates.noindex/Simplenote.build/<config>/
-    Simplenote.build/DerivedSources/SPCredentials.swift        # Simplenote target
-    IntentsExtension.build/DerivedSources/SPCredentials.swift  # IntentsExtension target
-```
-
-Search a build log for `Applying Production Secrets` or `Applying Example Secrets` to see the exact path for the current build.
-
-## How to actually view a generated file
-
-1. Build the target at least once.
-2. Right-click the red `SPCredentials.swift` entry in the navigator and pick **Show in Finder** — Xcode opens the per-target derived sources folder for the most recent build of that target.
-
-## The generation pipeline itself
-
-Lives in `Scripts/Build-Phases/copy-secret.sh` and its `copy-secret.xcfilelist`.
-The script copies the decrypted credentials from outside the checkout, falling back to `Simplenote/SPCredentials-demo.swift` for non-Release builds so the app compiles without secrets.
+Do not delete the red references. The app will not compile without them!

--- a/Simplenote/DerivedSources/README.md
+++ b/Simplenote/DerivedSources/README.md
@@ -1,0 +1,35 @@
+# DerivedSources
+
+Xcode shows two `SPCredentials.swift` entries in the project navigator under
+`DerivedSources/Simplenote/` and `DerivedSources/IntentsExtension/`.
+Both appear in **red** with an empty **Full Path** in the File Inspector.
+This is **expected** and **harmless**.
+
+## Why they are red and "not accessible"
+
+Both file references use `sourceTree = DERIVED_FILE_DIR`.
+`DERIVED_FILE_DIR` is a *per-target, per-configuration* build setting that only has a value while a specific target is actively being built.
+The project navigator is populated at project-parse time, before any build and with no target or configuration context, so Xcode has no single absolute path to resolve.
+The File Inspector still shows **Location: Relative to DERIVED_FILE_DIR**, confirming the declaration is understood — there just isn't one path to display, because it differs between the `Simplenote` and `IntentsExtension` targets, and per configuration.
+
+At **build time** Xcode resolves `DERIVED_FILE_DIR` per target, a `Copy Secret` script build phase on each consumer target writes `SPCredentials.swift` into that target's own derived sources directory under Derived Data, and the Swift compiler reads it back from that same location.
+The actual paths look like:
+
+```
+~/Library/Developer/Xcode/DerivedData/Simplenote-<hash>/
+  Build/Intermediates.noindex/Simplenote.build/<config>/
+    Simplenote.build/DerivedSources/SPCredentials.swift        # Simplenote target
+    IntentsExtension.build/DerivedSources/SPCredentials.swift  # IntentsExtension target
+```
+
+Search a build log for `Applying Production Secrets` or `Applying Example Secrets` to see the exact path for the current build.
+
+## How to actually view a generated file
+
+1. Build the target at least once.
+2. Right-click the red `SPCredentials.swift` entry in the navigator and pick **Show in Finder** — Xcode opens the per-target derived sources folder for the most recent build of that target.
+
+## The generation pipeline itself
+
+Lives in `Scripts/Build-Phases/copy-secret.sh` and its `copy-secret.xcfilelist`.
+The script copies the decrypted credentials from outside the checkout, falling back to `Simplenote/SPCredentials-demo.swift` for non-Release builds so the app compiles without secrets.

--- a/Simplenote/DerivedSources/README.md
+++ b/Simplenote/DerivedSources/README.md
@@ -3,7 +3,8 @@
 The two `SPCredentials.swift` entries here — one per consumer target, under `Simplenote/` and `IntentsExtension/` — are shown in red in Xcode and `Open Quickly` cannot find them.
 That is expected: they do not exist in the repository.
 
-The `Copy Secret` build phase writes each into its own target's `$(DERIVED_FILE_DIR)`, from the decrypted credentials under `~/.configure/simplenote-macos/secrets/`, or, missing those and outside a Release build, from the committed `SPCredentials-demo.swift`.
+The `Copy Secret` build phase writes each into its own target's `$(DERIVED_FILE_DIR)`, from the decrypted credentials under `~/.configure/simplenote-macos/secrets/`, or, missing those, from `SPCredentials.external-contributors.swift`.
+Missing both fails the build.
 See `Scripts/Build-Phases/copy-secret.sh`.
 
 Do not delete the red references. The app will not compile without them!

--- a/Simplenote/SPCredentials.template.swift
+++ b/Simplenote/SPCredentials.template.swift
@@ -1,4 +1,7 @@
-/// Simplenote API Demo Credentials
+/// Simplenote API Credentials Template
+///
+/// Copy to `SPCredentials.external-contributors.swift` and fill in your own
+/// credentials. That path is gitignored.
 ///
 
 import Foundation

--- a/readme.md
+++ b/readme.md
@@ -52,14 +52,8 @@ Simplenote is powered by the [Simperium Sync'ing protocol](https://www.simperium
 
 **⚠️ Please note → We're not accepting any new Simperium accounts at this time.**
 
-
-Please copy the **testing Simperium credentials** as follows:
-
-```
-mkdir -p Simplenote/Credentials && cp Simplenote/SPCredentials-demo.swift Simplenote/Credentials/SPCredentials.swift
-```
-
-This will allow you to compile and run the app on a device or a simulator.
+Refer to the `simperium*` properties in `SPCredentials`.
+The type is generated at build time from internal secrets when available, falling back to `Simplenote/SPCredentials-demo.swift` otherwise.
 
 _Note: Simplenote API features such as sharing and publishing will not work with development builds._
 

--- a/readme.md
+++ b/readme.md
@@ -48,7 +48,7 @@ You can also open the project by double clicking on `Simplenote.xcworkspace` fil
 
 ## Setup Credentials
 
-Simplenote is powered by the [Simperium Sync'ing protocol](https://www.simperium.com). We distribute **testing credentials** that help us authenticate your application, and verify that the API calls being made are valid.
+Simplenote is powered by the [Simperium Sync'ing protocol](https://www.simperium.com), which requires credentials to authenticate the application and verify that the API calls being made are valid.
 
 **⚠️ Please note → We're not accepting any new Simperium accounts at this time.**
 

--- a/readme.md
+++ b/readme.md
@@ -52,8 +52,8 @@ Simplenote is powered by the [Simperium Sync'ing protocol](https://www.simperium
 
 **⚠️ Please note → We're not accepting any new Simperium accounts at this time.**
 
-Refer to the `simperium*` properties in `SPCredentials`.
-The type is generated at build time from internal secrets when available, falling back to `Simplenote/SPCredentials-demo.swift` otherwise.
+Credentials live in the `simperium*` properties of the `SPCredentials` type, which is generated at build time from production credentials kept outside the checkout, falling back to user-specified ones.
+When it finds neither, the build fails with instructions on how to provide them.
 
 _Note: Simplenote API features such as sharing and publishing will not work with development builds._
 


### PR DESCRIPTION
Prep step to then adopt [`a8c-secrets`](https://github.com/Automattic/a8c-secrets), which requires secrets outside of the repo. See https://linear.app/a8c/issue/AINFRA-2731. 

I modelled the script changes on the recent Gravatar SDK implementation, which benefitted from the back and forth with @AliSoftware.

**Same** 

- Precedence: internal store first, gitignored external file second
- Hard failure with a two-audience hint
- `Secrets.template.swift` → `*.external-contributors.swift` pair, writing to `SCRIPT_OUTPUT_FILE_0` under `DERIVED_FILE_DIR`
- `README` explaining sources generation and why they are red

**Different**, aside for the differences due to the repo not using `a8c-secrets` yet

- Unlike Gravatar, the script in Simplenote has two target consumers:`Simplenote` and `IntentsExtension`. The `SCRIPT_OUTPUT_FILE_0` indirection is "load-bearing" here, because so one script and one `.xcfilelist` back two identical phases, each writing into _its own target's derived dir_
- **Input-list guard.** I kept the pre-existing `ensure_is_in_input_files_list` check (errors if a source isn't declared in the `.xcfilelist`). Gravatar hasn't one, but I think it's useful and we should eventually adopt it there, too (especially if the endgame is for the script to be generic enough that it can run from `a8c-secrets`, i.e. without the source being in the repo and therefore the only knobs we can turn being input and ouput paths/lists)

<details>
<summary>AI-generated Details</summary>

### Fix

The decrypted `SPCredentials.swift` no longer lands in the checkout.
Each target that compiles it — `Simplenote` and `IntentsExtension` — carries a `Copy Secret` build phase writing into that target's own `$(DERIVED_FILE_DIR)`, replacing the `SimplenoteSecrets` aggregate target that wrote into `Simplenote/Credentials/`.
Internal contributors no longer copy anything into place by hand.

The shared demo credentials are gone with it.
`SPCredentials-demo.swift` becomes `SPCredentials.template.swift`, which external contributors copy to the gitignored `SPCredentials.external-contributors.swift` and fill in with their own Simperium credentials.
With neither that file nor the decrypted secrets present, the build fails in every configuration rather than silently compiling against demo values.

Part of [AINFRA-2731](https://linear.app/a8c/issue/AINFRA-2731), applying the pattern [Gravatar-SDK-iOS settled on](https://github.com/Automattic/Gravatar-SDK-iOS/blob/trunk/Scripts/build-phases/generate-secrets.sh).
The commit messages carry the per-step rationale.

### Test

```
bundle exec fastlane test
```

Both consumer targets should compile, each phase writing to its own `…/<Target>.build/DerivedSources/SPCredentials.swift`.
CI exercises both sources: `build-and-test` copies the template, so it runs the flow the readme gives external contributors, while `verify-app-store-target-builds` decrypts and builds against the real secrets.

</details>

### Review

One developer is enough.

The two `SPCredentials.swift` entries show in **red** in Xcode with no resolvable path.
That is expected — `DERIVED_FILE_DIR` only resolves while a specific target is building — and `Simplenote/DerivedSources/README.md` exists so the next reader does not "fix" it.
