### PR TITLE
Upgrade to the Sentry 2.x fastlane plugin

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,6 @@ source 'https://rubygems.org'
 
 gem 'danger-dangermattic', '~> 1.4'
 gem 'fastlane', '~> 2.232'
-gem 'fastlane-plugin-sentry', '~> 1.14'
+gem 'fastlane-plugin-sentry', '~> 2.6'
 gem 'fastlane-plugin-wpmreleasetoolkit', '~> 12.5'
 gem 'rake', '~> 13.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -177,7 +177,7 @@ GEM
       xcodeproj (>= 1.13.0, < 2.0.0)
       xcpretty (~> 0.4.1)
       xcpretty-travis-formatter (>= 0.0.3, < 2.0.0)
-    fastlane-plugin-sentry (1.29.0)
+    fastlane-plugin-sentry (2.6.1)
       os (~> 1.1, >= 1.1.4)
     fastlane-plugin-wpmreleasetoolkit (12.5.0)
       activesupport (>= 6.1.7.1)
@@ -367,7 +367,7 @@ PLATFORMS
 DEPENDENCIES
   danger-dangermattic (~> 1.4)
   fastlane (~> 2.232)
-  fastlane-plugin-sentry (~> 1.14)
+  fastlane-plugin-sentry (~> 2.6)
   fastlane-plugin-wpmreleasetoolkit (~> 12.5)
   rake (~> 13.4)
 

--- a/Scripts/update-translations.rb
+++ b/Scripts/update-translations.rb
@@ -77,7 +77,7 @@ def copy_comment(file, trans_strings, value)
 end
 
 langs = {}
-if ARGV.count.positive?
+if ARGV.any?
   ARGV.each do |key|
     unless (locale = ALL_LANGS[key])
       puts "Unknown language #{key}"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -15,7 +15,6 @@ INTERNAL_SCHEME = 'Simplenote'
 APP_STORE_SCHEME = 'Simplenote'
 BUILD_FOLDER = File.join(PROJECT_FOLDER, 'build')
 APP_NAME = APP_STORE_SCHEME
-DSYM_ZIP_PATH = File.join(BUILD_FOLDER, "#{APP_NAME}.app.dSYM.zip").freeze
 APP_STORE_BUNDLE_IDENTIFIER = 'com.automattic.SimplenoteMac'
 APP_STORE_BUNDLE_IDENTIFIER_INTENTS = "#{APP_STORE_BUNDLE_IDENTIFIER}.IntentsExtension".freeze
 VERSION_FILE_PATH = File.join(PROJECT_FOLDER, 'config', 'Version.Public.xcconfig')
@@ -343,7 +342,7 @@ lane :build_internal_beta do |skip_dsym_upload: true|
 
   next if skip_dsym_upload || !UI.confirm('Do you want to upload the dSYM to Sentry?')
 
-  upload_dsym_to_sentry
+  upload_dsym_to_sentry(archive_path: lane_context[SharedValues::XCODEBUILD_ARCHIVE])
 end
 
 # Upload the localized metadata (from `fastlane/metadata/`) to App Store Connect
@@ -399,7 +398,7 @@ lane :build_and_upload_app_store do |options|
     archive_path: archive_path
   )
 
-  upload_dsym_to_sentry
+  upload_dsym_to_sentry(archive_path: archive_path)
 
   # Do not create the GitHub release unless explicitly requested
   if options[:create_github_release]
@@ -588,13 +587,24 @@ def generate_gitkeep_for_empty_locale_folders
   gitkeeps
 end
 
-def upload_dsym_to_sentry
-  UI.user_error!("Could not find dSYM at expected location '#{DSYM_ZIP_PATH}'.") unless File.exist?(DSYM_ZIP_PATH)
+# Upload the dSYMs from a build archive to Sentry.
+#
+# Reads them out of the archive rather than the zip `gym` writes alongside it:
+# `sentry-cli` searches a path recursively, so pointing it at the archive's
+# `dSYMs/` avoids having to predict that zip's filename. Aim at `dSYMs/` and not
+# the archive root, or the search settles on the stripped binary in `Products/`.
+#
+# @param archive_path [String] Path to the `.xcarchive` the build produced.
+#
+def upload_dsym_to_sentry(archive_path:)
+  dsyms_path = File.join(archive_path, 'dSYMs')
+  UI.user_error!("Could not find dSYMs at '#{dsyms_path}'.") unless File.directory?(dsyms_path)
 
   sentry_debug_files_upload(
     auth_token: get_required_env('SENTRY_AUTH_TOKEN'),
     org_slug: 'a8c',
     project_slug: 'simplenote-macos',
-    path: [DSYM_ZIP_PATH]
+    path: [dsyms_path],
+    type: 'dsym'
   )
 end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -14,6 +14,10 @@ PROJECT = 'Simplenote.xcodeproj'
 INTERNAL_SCHEME = 'Simplenote'
 APP_STORE_SCHEME = 'Simplenote'
 BUILD_FOLDER = File.join(PROJECT_FOLDER, 'build')
+# Passed to the build actions as `output_name` so the artifact names are ours to
+# state rather than gym's to derive from the app name.
+APP_NAME = 'Simplenote'
+DSYM_ZIP_PATH = File.join(BUILD_FOLDER, "#{APP_NAME}.app.dSYM.zip").freeze
 APP_STORE_BUNDLE_IDENTIFIER = 'com.automattic.SimplenoteMac'
 APP_STORE_BUNDLE_IDENTIFIER_INTENTS = "#{APP_STORE_BUNDLE_IDENTIFIER}.IntentsExtension".freeze
 VERSION_FILE_PATH = File.join(PROJECT_FOLDER, 'config', 'Version.Public.xcconfig')
@@ -112,6 +116,7 @@ def build_simplenote(codesign:, archive_path: nil)
     scheme: APP_STORE_SCHEME,
     clean: true,
     output_directory: BUILD_FOLDER,
+    output_name: APP_NAME,
     archive_path: archive_path,
     skip_archive: skip_archive,
     export_team_id: APPLE_TEAM_ID,
@@ -323,6 +328,7 @@ lane :build_internal_beta do |skip_dsym_upload: true|
     scheme: INTERNAL_SCHEME,
     clean: true,
     output_directory: BUILD_FOLDER,
+    output_name: APP_NAME,
     export_method: 'developer-id',
     export_options: {
       provisioningProfiles: {
@@ -335,9 +341,7 @@ lane :build_internal_beta do |skip_dsym_upload: true|
 
   # Show release notes and the path to the binary
   sh('ruby', '../Scripts/extract_release_notes.rb', '-k')
-  UI.success("DeveloperID-signed binary is at: #{File.join(BUILD_FOLDER, 'Simplenote.app')}")
-
-  dsym_path = File.join(BUILD_FOLDER, 'Simplenote.app.dSYM.zip')
+  UI.success("DeveloperID-signed binary is at: #{File.join(BUILD_FOLDER, "#{APP_NAME}.app")}")
 
   next if skip_dsym_upload || !UI.confirm('Do you want to upload the dSYM to Sentry?')
 
@@ -345,7 +349,7 @@ lane :build_internal_beta do |skip_dsym_upload: true|
     auth_token: get_required_env('SENTRY_AUTH_TOKEN'),
     org_slug: 'a8c',
     project_slug: 'simplenote-macos',
-    path: [dsym_path]
+    path: [DSYM_ZIP_PATH]
   )
 end
 
@@ -406,7 +410,7 @@ lane :build_and_upload_app_store do |options|
     auth_token: get_required_env('SENTRY_AUTH_TOKEN'),
     org_slug: 'a8c',
     project_slug: 'simplenotemacos',
-    path: [File.join(BUILD_FOLDER, 'Simplenote.app.dSYM.zip')]
+    path: [DSYM_ZIP_PATH]
   )
 
   # Do not create the GitHub release unless explicitly requested

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -23,6 +23,9 @@ DEFAULT_BRANCH = 'trunk'
 GITHUB_REPO = 'Automattic/simplenote-macos'
 APPLE_TEAM_ID = 'PZYM8XX95Q'
 
+SENTRY_ORG = 'a8c'
+SENTRY_PROJECT = 'simplenote-macos'
+
 APP_RESOURCES_DIR = File.join(PROJECT_ROOT_FOLDER, 'Simplenote', 'Resources')
 RELEASE_NOTES_SOURCE_PATH = File.join(APP_RESOURCES_DIR, 'release_notes.txt')
 STORE_METADATA_FOLDER = File.join(PROJECT_ROOT_FOLDER, 'fastlane', 'metadata')
@@ -345,8 +348,8 @@ lane :build_internal_beta do |skip_dsym_upload: true|
 
   sentry_debug_files_upload(
     auth_token: get_required_env('SENTRY_AUTH_TOKEN'),
-    org_slug: 'a8c',
-    project_slug: 'simplenote-macos',
+    org_slug: SENTRY_ORG,
+    project_slug: SENTRY_PROJECT,
     path: [DSYM_ZIP_PATH]
   )
 end
@@ -406,8 +409,8 @@ lane :build_and_upload_app_store do |options|
 
   sentry_debug_files_upload(
     auth_token: get_required_env('SENTRY_AUTH_TOKEN'),
-    org_slug: 'a8c',
-    project_slug: 'simplenotemacos',
+    org_slug: SENTRY_ORG,
+    project_slug: SENTRY_PROJECT,
     path: [DSYM_ZIP_PATH]
   )
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -597,6 +597,8 @@ end
 # @param archive_path [String] Path to the `.xcarchive` the build produced.
 #
 def upload_dsym_to_sentry(archive_path:)
+  UI.user_error!('The given archive path value '#{archive_path} is missing. Did the build produced an .xcarchive?') if archive_path.to_s.empty?
+  
   dsyms_path = File.join(archive_path, 'dSYMs')
   UI.user_error!("Could not find dSYMs at '#{dsyms_path}'.") unless File.directory?(dsyms_path)
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -597,7 +597,7 @@ end
 # @param archive_path [String] Path to the `.xcarchive` the build produced.
 #
 def upload_dsym_to_sentry(archive_path:)
-  UI.user_error!('The given archive path value '#{archive_path} is missing. Did the build produced an .xcarchive?') if archive_path.to_s.empty?
+  UI.user_error!("The given archive path value '#{archive_path}' is missing. Did the build produced an .xcarchive?") if archive_path.to_s.empty?
   
   dsyms_path = File.join(archive_path, 'dSYMs')
   UI.user_error!("Could not find dSYMs at '#{dsyms_path}'.") unless File.directory?(dsyms_path)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -23,9 +23,6 @@ DEFAULT_BRANCH = 'trunk'
 GITHUB_REPO = 'Automattic/simplenote-macos'
 APPLE_TEAM_ID = 'PZYM8XX95Q'
 
-SENTRY_ORG = 'a8c'
-SENTRY_PROJECT = 'simplenote-macos'
-
 APP_RESOURCES_DIR = File.join(PROJECT_ROOT_FOLDER, 'Simplenote', 'Resources')
 RELEASE_NOTES_SOURCE_PATH = File.join(APP_RESOURCES_DIR, 'release_notes.txt')
 STORE_METADATA_FOLDER = File.join(PROJECT_ROOT_FOLDER, 'fastlane', 'metadata')
@@ -346,12 +343,7 @@ lane :build_internal_beta do |skip_dsym_upload: true|
 
   next if skip_dsym_upload || !UI.confirm('Do you want to upload the dSYM to Sentry?')
 
-  sentry_debug_files_upload(
-    auth_token: get_required_env('SENTRY_AUTH_TOKEN'),
-    org_slug: SENTRY_ORG,
-    project_slug: SENTRY_PROJECT,
-    path: [DSYM_ZIP_PATH]
-  )
+  upload_dsym_to_sentry
 end
 
 # Upload the localized metadata (from `fastlane/metadata/`) to App Store Connect
@@ -407,12 +399,7 @@ lane :build_and_upload_app_store do |options|
     archive_path: archive_path
   )
 
-  sentry_debug_files_upload(
-    auth_token: get_required_env('SENTRY_AUTH_TOKEN'),
-    org_slug: SENTRY_ORG,
-    project_slug: SENTRY_PROJECT,
-    path: [DSYM_ZIP_PATH]
-  )
+  upload_dsym_to_sentry
 
   # Do not create the GitHub release unless explicitly requested
   if options[:create_github_release]
@@ -599,4 +586,15 @@ def generate_gitkeep_for_empty_locale_folders
   end
 
   gitkeeps
+end
+
+def upload_dsym_to_sentry
+  UI.user_error!("Could not find dSYM at expected location '#{DSYM_ZIP_PATH}'.") unless File.exist?(DSYM_ZIP_PATH)
+
+  sentry_debug_files_upload(
+    auth_token: get_required_env('SENTRY_AUTH_TOKEN'),
+    org_slug: 'a8c',
+    project_slug: 'simplenote-macos',
+    path: [DSYM_ZIP_PATH]
+  )
 end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -598,7 +598,6 @@ end
 #
 def upload_dsym_to_sentry(archive_path:)
   UI.user_error!("The given archive path value '#{archive_path}' is missing. Did the build produced an .xcarchive?") if archive_path.to_s.empty?
-  
   dsyms_path = File.join(archive_path, 'dSYMs')
   UI.user_error!("Could not find dSYMs at '#{dsyms_path}'.") unless File.directory?(dsyms_path)
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -406,10 +406,7 @@ lane :build_and_upload_app_store do |options|
     auth_token: get_required_env('SENTRY_AUTH_TOKEN'),
     org_slug: 'a8c',
     project_slug: 'simplenotemacos',
-    # At the time of writing, there's no way to explicitly configure the
-    # dSYM path, but build_mac_app sets it in the environment if successful.
-    # See `bundle exec fastlane action build_mac_app`.
-    path: [ENV.fetch('DSYM_OUTPUT_PATH', nil)].compact
+    path: [File.join(BUILD_FOLDER, 'Simplenote.app.dSYM.zip')]
   )
 
   # Do not create the GitHub release unless explicitly requested

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -14,9 +14,7 @@ PROJECT = 'Simplenote.xcodeproj'
 INTERNAL_SCHEME = 'Simplenote'
 APP_STORE_SCHEME = 'Simplenote'
 BUILD_FOLDER = File.join(PROJECT_FOLDER, 'build')
-# Passed to the build actions as `output_name` so the artifact names are ours to
-# state rather than gym's to derive from the app name.
-APP_NAME = 'Simplenote'
+APP_NAME = APP_STORE_SCHEME
 DSYM_ZIP_PATH = File.join(BUILD_FOLDER, "#{APP_NAME}.app.dSYM.zip").freeze
 APP_STORE_BUNDLE_IDENTIFIER = 'com.automattic.SimplenoteMac'
 APP_STORE_BUNDLE_IDENTIFIER_INTENTS = "#{APP_STORE_BUNDLE_IDENTIFIER}.IntentsExtension".freeze

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -341,11 +341,11 @@ lane :build_internal_beta do |skip_dsym_upload: true|
 
   next if skip_dsym_upload || !UI.confirm('Do you want to upload the dSYM to Sentry?')
 
-  sentry_upload_dsym(
+  sentry_debug_files_upload(
     auth_token: get_required_env('SENTRY_AUTH_TOKEN'),
     org_slug: 'a8c',
     project_slug: 'simplenote-macos',
-    dsym_path: dsym_path
+    path: [dsym_path]
   )
 end
 
@@ -402,14 +402,14 @@ lane :build_and_upload_app_store do |options|
     archive_path: archive_path
   )
 
-  sentry_upload_dsym(
+  sentry_debug_files_upload(
     auth_token: get_required_env('SENTRY_AUTH_TOKEN'),
     org_slug: 'a8c',
     project_slug: 'simplenotemacos',
     # At the time of writing, there's no way to explicitly configure the
     # dSYM path, but build_mac_app sets it in the environment if successful.
     # See `bundle exec fastlane action build_mac_app`.
-    dsym_path: ENV.fetch('DSYM_OUTPUT_PATH', nil)
+    path: [ENV.fetch('DSYM_OUTPUT_PATH', nil)].compact
   )
 
   # Do not create the GitHub release unless explicitly requested


### PR DESCRIPTION
Even though the app is on dev hiatus, the upgrade will prevent further non-actionable PRs from Dependabot, such as #1273.

See [AINFRA-2742](https://linear.app/a8c/issue/AINFRA-2742).

Verified by running builds with Sentry upload in CI via https://github.com/Automattic/simplenote-macos/pull/1275

<img width="3088" height="574" alt="image" src="https://github.com/user-attachments/assets/d5b90baf-8d4a-442b-8a1c-62a7754c13c7" />
<img width="3054" height="870" alt="image" src="https://github.com/user-attachments/assets/eda2aa9f-93ba-489e-a149-b41bc7d1f097" />

<details>
<summary>AI-generated details</summary>

### Fix

Upgrades `fastlane-plugin-sentry` from 1.x to 2.x, per [AINFRA-2742](https://linear.app/a8c/issue/AINFRA-2742), so Dependabot stops opening bumps we can't merge (e.g. #1273).

The plugin's 2.0.0 release removed the `sentry_upload_dsym` action outright, so the Gemfile bump and the call-site migration to `sentry_debug_files_upload` have to land in the same change. The replacement takes `path:` as an array instead of a single `dsym_path:` string; auth keys are unchanged. Same migration already shipped in [woocommerce-ios#17506](https://github.com/woocommerce/woocommerce-ios/pull/17506).

Two things ride along, each in its own commit:

- **A pre-existing RuboCop offense.** The `danger-dangermattic` 1.2.2 → 1.4.0 bump in 6097ca82 pulled in a RuboCop with the `Style/CollectionQuerying` cop, and the `Dangerfile` lints every file rather than just the diff. That leaves trunk red on every open PR — #1271 is still blocked on it.
- **How the upload finds the dSYMs.** `build_and_upload_app_store` read `ENV['DSYM_OUTPUT_PATH']`, which was always nil: `build_app` only exports it when the export produced a `.ipa`/`.pkg` *and* the derived path exists, and on macOS it derives `<name>.dSYM.zip` while gym writes `<name>.app.dSYM.zip`. Both lanes now read the dSYMs out of the build archive instead. Unlike `DSYM_OUTPUT_PATH`, `XCODEBUILD_ARCHIVE` is exported unconditionally — and `build_and_upload_app_store` already computes `archive_path` itself, so nothing has to predict a filename.

### Test

The upload only runs on a real signed release build, so CI can't exercise it. Verified locally:

1. A probe build confirmed `DSYM_OUTPUT_PATH` is nil (both env and lane context) while `Simplenote.app.dSYM.zip` sits in the build folder — the bug above, observed rather than inferred.
2. `sentry-cli debug-files find` against a real archive: `dSYMs/` resolves to the DWARF inside the dSYM bundle; the archive *root* resolves to the stripped binary in `Products/`. Hence the helper targets `dSYMs/`.
3. `bundle exec fastlane lanes` and `bundle exec rubocop` — clean.

`verify-app-store-target-builds` runs `build_simplenote`, so CI does cover the `output_name` addition through a real gym invocation.

### Review

Worth knowing: `sentry_debug_files_upload` searches a path recursively, which is what lets us hand it a directory and stop guessing filenames. The one remaining assumption is Xcode's `<archive>/dSYMs/` layout — public and stable, unlike gym's naming, which lives in a private method.

Not verified end-to-end: no CI job produces a signed release build, so the first real confirmation is the next release.

### Release

These changes do not require release notes.


</details>