### PR TITLE
Verify Sentry dSYM upload on CI (temporary)

### DIFF
--- a/.buildkite/commands/test-sentry-dsym-upload-app-store.sh
+++ b/.buildkite/commands/test-sentry-dsym-upload-app-store.sh
@@ -1,0 +1,7 @@
+#! /bin/bash -eu
+
+echo "--- :rubygems: Setting up Gems"
+install_gems
+
+echo "--- :hammer_and_wrench: Build and upload dSYM to Sentry"
+bundle exec fastlane test_sentry_dsym_upload_app_store

--- a/.buildkite/commands/test-sentry-dsym-upload-internal.sh
+++ b/.buildkite/commands/test-sentry-dsym-upload-internal.sh
@@ -1,0 +1,7 @@
+#! /bin/bash -eu
+
+echo "--- :rubygems: Setting up Gems"
+install_gems
+
+echo "--- :hammer_and_wrench: Build and upload dSYM to Sentry"
+bundle exec fastlane test_sentry_dsym_upload_internal

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -25,3 +25,17 @@ steps:
     plugins: [$CI_TOOLKIT_PLUGIN]
     agents:
       queue: mac
+
+  # TEMPORARY (AINFRA-2742): exercise the Sentry dSYM upload on real signed
+  # archives for both signing paths. Remove once the 2.x upload is confirmed.
+  - label: "🐛 Sentry dSYM Upload — Internal"
+    command: .buildkite/commands/test-sentry-dsym-upload-internal.sh
+    plugins: [$CI_TOOLKIT_PLUGIN]
+    agents:
+      queue: mac
+
+  - label: "🐛 Sentry dSYM Upload — App Store"
+    command: .buildkite/commands/test-sentry-dsym-upload-app-store.sh
+    plugins: [$CI_TOOLKIT_PLUGIN]
+    agents:
+      queue: mac

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -99,6 +99,26 @@ end
 
 # Builds the app with a Developer ID certificate, producing a signed archive.
 def build_simplenote_developer_id
+  # `config/Project.Release.xcconfig` pins signing to App Store. Point the app
+  # and its extension at the Developer ID profiles instead. Scoping this to the
+  # two app targets — rather than a global `xcargs` override — leaves the SPM
+  # dependency targets signing to run locally, as they do in the App Store
+  # build; a global override forces a signing team onto them and fails.
+  {
+    APP_STORE_BUNDLE_IDENTIFIER => 'Simplenote',
+    APP_STORE_BUNDLE_IDENTIFIER_INTENTS => 'IntentsExtension'
+  }.each do |bundle_id, target|
+    update_code_signing_settings(
+      path: File.join(PROJECT_FOLDER, PROJECT),
+      use_automatic_signing: false,
+      team_id: APPLE_TEAM_ID,
+      targets: [target],
+      build_configurations: ['Release'],
+      code_sign_identity: 'Developer ID Application',
+      profile_name: "match Direct #{bundle_id} macos"
+    )
+  end
+
   build_app(
     project: PROJECT,
     scheme: INTERNAL_SCHEME,
@@ -106,13 +126,6 @@ def build_simplenote_developer_id
     output_directory: BUILD_FOLDER,
     output_name: APP_NAME,
     export_method: 'developer-id',
-    # `config/Project.Release.xcconfig` pins the archive to App Store signing,
-    # so override it here to sign for Developer ID. The specifier resolves
-    # per target via `$(PRODUCT_BUNDLE_IDENTIFIER)`.
-    xcargs: {
-      PROVISIONING_PROFILE_SPECIFIER: 'match Direct $(PRODUCT_BUNDLE_IDENTIFIER) macos',
-      CODE_SIGN_IDENTITY: 'Developer ID Application'
-    },
     export_options: {
       provisioningProfiles: {
         "#{APP_STORE_BUNDLE_IDENTIFIER}": "match Direct #{APP_STORE_BUNDLE_IDENTIFIER} macos",

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -592,6 +592,31 @@ def generate_gitkeep_for_empty_locale_folders
   gitkeeps
 end
 
+########################################################################
+# TEMPORARY (AINFRA-2742): Sentry dSYM upload verification
+#
+# These lanes exist only to exercise `upload_dsym_to_sentry` against real
+# signed archives from both signing paths after the fastlane-plugin-sentry
+# 2.x migration. Remove them, and their Buildkite steps, once the upload is
+# confirmed working.
+########################################################################
+desc 'TEMPORARY: build a Developer ID archive and upload its dSYMs to Sentry'
+lane :test_sentry_dsym_upload_internal do
+  configure_apply
+  configure_code_signing_developer_id
+  build_simplenote_developer_id
+  upload_dsym_to_sentry(archive_path: lane_context[SharedValues::XCODEBUILD_ARCHIVE])
+end
+
+desc 'TEMPORARY: build an App Store archive and upload its dSYMs to Sentry'
+lane :test_sentry_dsym_upload_app_store do
+  configure_apply
+  configure_code_signing_app_store
+  archive_path = File.join(BUILD_FOLDER, 'Simplenote-Mac.xcarchive')
+  build_simplenote(codesign: true, archive_path: archive_path)
+  upload_dsym_to_sentry(archive_path: archive_path)
+end
+
 # Upload the dSYMs from a build archive to Sentry.
 #
 # Reads them out of the archive rather than the zip `gym` writes alongside it:

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -106,6 +106,13 @@ def build_simplenote_developer_id
     output_directory: BUILD_FOLDER,
     output_name: APP_NAME,
     export_method: 'developer-id',
+    # `config/Project.Release.xcconfig` pins the archive to App Store signing,
+    # so override it here to sign for Developer ID. The specifier resolves
+    # per target via `$(PRODUCT_BUNDLE_IDENTIFIER)`.
+    xcargs: {
+      PROVISIONING_PROFILE_SPECIFIER: 'match Direct $(PRODUCT_BUNDLE_IDENTIFIER) macos',
+      CODE_SIGN_IDENTITY: 'Developer ID Application'
+    },
     export_options: {
       provisioningProfiles: {
         "#{APP_STORE_BUNDLE_IDENTIFIER}": "match Direct #{APP_STORE_BUNDLE_IDENTIFIER} macos",

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -124,7 +124,7 @@ def build_simplenote_developer_id
 end
 
 # Helper function to DRY the code to build the app
-def build_simplenote(codesign:, archive_path: nil)
+def build_simplenote(codesign:, archive_path: nil, skip_package_pkg: false)
   if codesign
     skip_archive = false
     xcargs = []
@@ -142,6 +142,7 @@ def build_simplenote(codesign:, archive_path: nil)
     output_name: APP_NAME,
     archive_path: archive_path,
     skip_archive: skip_archive,
+    skip_package_pkg: skip_package_pkg,
     export_team_id: APPLE_TEAM_ID,
     xcargs: xcargs,
     export_options: {
@@ -620,7 +621,9 @@ lane :test_sentry_dsym_upload_app_store do
   configure_apply
   configure_code_signing_app_store
   archive_path = File.join(BUILD_FOLDER, 'Simplenote-Mac.xcarchive')
-  build_simplenote(codesign: true, archive_path: archive_path)
+  # Skip the `.pkg` export: it needs a Mac Installer Distribution cert we don't
+  # sync, and the dSYMs are already in the archive from the archive step.
+  build_simplenote(codesign: true, archive_path: archive_path, skip_package_pkg: true)
   upload_dsym_to_sentry(archive_path: archive_path)
 end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -97,6 +97,25 @@ before_all do
   setup_ci # Fixes weird Keychain bugs on CI
 end
 
+# Builds the app with a Developer ID certificate, producing a signed archive.
+def build_simplenote_developer_id
+  build_app(
+    project: PROJECT,
+    scheme: INTERNAL_SCHEME,
+    clean: true,
+    output_directory: BUILD_FOLDER,
+    output_name: APP_NAME,
+    export_method: 'developer-id',
+    export_options: {
+      provisioningProfiles: {
+        "#{APP_STORE_BUNDLE_IDENTIFIER}": "match Direct #{APP_STORE_BUNDLE_IDENTIFIER} macos",
+        "#{APP_STORE_BUNDLE_IDENTIFIER_INTENTS}": "match Direct #{APP_STORE_BUNDLE_IDENTIFIER_INTENTS} macos"
+      },
+      signingSytle: 'manual'
+    }
+  )
+end
+
 # Helper function to DRY the code to build the app
 def build_simplenote(codesign:, archive_path: nil)
   if codesign
@@ -320,21 +339,7 @@ lane :build_internal_beta do |skip_dsym_upload: true|
   configure_apply
   configure_code_signing_developer_id
 
-  build_app(
-    project: PROJECT,
-    scheme: INTERNAL_SCHEME,
-    clean: true,
-    output_directory: BUILD_FOLDER,
-    output_name: APP_NAME,
-    export_method: 'developer-id',
-    export_options: {
-      provisioningProfiles: {
-        "#{APP_STORE_BUNDLE_IDENTIFIER}": "match Direct #{APP_STORE_BUNDLE_IDENTIFIER} macos",
-        "#{APP_STORE_BUNDLE_IDENTIFIER_INTENTS}": "match Direct #{APP_STORE_BUNDLE_IDENTIFIER_INTENTS} macos"
-      },
-      signingSytle: 'manual'
-    }
-  )
+  build_simplenote_developer_id
 
   # Show release notes and the path to the binary
   sh('ruby', '../Scripts/extract_release_notes.rb', '-k')


### PR DESCRIPTION
Stacked on #1274.

## Why

#1274 migrates to `fastlane-plugin-sentry` 2.x and reworks how `upload_dsym_to_sentry` locates dSYMs. The upload only runs with `SENTRY_AUTH_TOKEN`, which lives on CI, so nothing in #1274 actually exercises the new call. This PR does, against real signed archives from **both** signing paths (Developer ID and App Store), since the two produce archives differently.

## What

Two throwaway lanes — `test_sentry_dsym_upload_internal` and `test_sentry_dsym_upload_app_store` — each build a signed archive and upload its dSYMs, wired to two Buildkite steps on the `mac` queue so they run on this PR. Both are clearly marked temporary; revert this PR once the upload is confirmed.

## How to test

Watch the **🐛 Sentry dSYM Upload — Internal** and **— App Store** steps on this PR's Buildkite build, and confirm the dSYMs land in the `a8c/simplenote-macos` Sentry project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)