### PR TITLE
Set up `a8c-secrets` identities

### DIFF
--- a/.a8c-secrets/keys.pub
+++ b/.a8c-secrets/keys.pub
@@ -1,0 +1,4 @@
+# dev
+age125uwqkgr2tuct49zk56y6r5gg8c9k8w2ev329eah5ztfyx57pa8smklsrg
+# ci
+age182h46nrwvgnvuff0clzll0867c2z74cpwr2tmrmg24k382jwq5cqgfpx2s

--- a/.a8c-secrets/repo-id
+++ b/.a8c-secrets/repo-id
@@ -1,0 +1,1 @@
+simplenote-macos@github.com@automattic


### PR DESCRIPTION
Just getting ahead on the adoption work while I wait for some builds to finish.

Closes https://linear.app/a8c/issue/AINFRA-2976
